### PR TITLE
Add gitignore for CMake build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# CMake build artifacts
+build/
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+Makefile
+install_manifest.txt
+Testing/
+CTestTestfile.cmake
+
+# Compilation database
+compile_commands.json


### PR DESCRIPTION
## Summary
- add a repository-level .gitignore
- ignore common CMake build artifacts and generated compilation databases

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925b9de0ad88325b73a6b8104d5d563)