### PR TITLE
Add examples/amrex placeholder directory

### DIFF
--- a/examples/amrex/CMakeLists.txt
+++ b/examples/amrex/CMakeLists.txt
@@ -1,0 +1,28 @@
+# AMReX CUDA Demo Example
+# This is a placeholder build configuration for the CUDA demo scaffold
+
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+
+project(WeakLibReaderExamples
+  VERSION 0.1.0
+  LANGUAGES CXX)
+
+# NOTE: This example requires CUDA support in AMReX
+# Uncomment when ready to build
+
+# find_package(AMReX REQUIRED)
+#
+# add_executable(amrex_interp_demo
+#   interp_demo.cpp)
+#
+# target_link_libraries(amrex_interp_demo
+#   PRIVATE
+#     WeakLibReader
+#     AMReX::amrex)
+#
+# if(AMReX_GPU_BACKEND STREQUAL "CUDA")
+#   set_target_properties(amrex_interp_demo PROPERTIES
+#     CUDA_SEPARABLE_COMPILATION ON)
+# endif()
+
+message(STATUS "AMReX examples are currently placeholders (see examples/amrex/README.md)")

--- a/examples/amrex/README.md
+++ b/examples/amrex/README.md
@@ -1,0 +1,45 @@
+# AMReX CUDA Demo (Placeholder)
+
+This directory contains a placeholder for the AMReX CUDA demonstration.
+
+## Status
+
+This is a minimal scaffold demonstrating the basic usage pattern. Full CUDA kernel integration will be completed in Phase 3 of development (see `AGENTS.md`).
+
+## Planned Features
+
+- GPU kernel example using `InterpLinearND` with AMReX `MultiFab`
+- Device memory management with `TableDevice`
+- Parallel interpolation across grid cells
+- Performance benchmarking utilities
+
+## Building
+
+The example is not yet integrated into the main build system. Once complete, it will be built with:
+
+```bash
+cmake -S . -B build -DAMREX_ROOT=/path/to/amrex -DBUILD_EXAMPLES=ON
+cmake --build build --target amrex_interp_demo
+```
+
+## Usage Example (Conceptual)
+
+```cpp
+// Load HDF5 table on host
+WeakLibReader::Hdf5Table hostTable;
+LoadHdf5Table("eos_table.h5", hostTable);
+
+// Copy to device
+auto deviceTable = WeakLibReader::MakeDeviceCopy(hostTable);
+
+// Use in AMReX kernel
+amrex::ParallelFor(mf, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+    double coords[3] = {rho[i], temp[j], ye[k]};
+    auto view = deviceTable.View();
+    double value = WeakLibReader::InterpLinearND(
+        view.data, view.layout, view.axes, coords,
+        WeakLibReader::InterpConfig{}, view.nd
+    );
+    mf(i, j, k) = value;
+});
+```

--- a/examples/amrex/interp_demo.cpp
+++ b/examples/amrex/interp_demo.cpp
@@ -1,0 +1,99 @@
+// Placeholder: AMReX CUDA interpolation demo
+//
+// This file provides a template for using WeakLibReader with AMReX GPU kernels.
+// Full implementation will be completed in Phase 3 (see AGENTS.md).
+
+#include <WeakLibReader.hpp>
+#include <Hdf5Loader.hpp>
+
+#include <AMReX.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_PlotFileUtil.H>
+
+#include <iostream>
+#include <string>
+
+// TODO: Implement full CUDA kernel example
+// This is a conceptual outline showing the usage pattern
+
+namespace {
+
+void RunInterpolationDemo(const std::string& hdf5Path)
+{
+  using namespace WeakLibReader;
+
+  // Step 1: Load HDF5 table on host
+  Hdf5Table hostTable;
+  const auto status = LoadHdf5Table(hdf5Path, hostTable);
+  if (status != Hdf5LoadStatus::Success) {
+    std::cerr << "Failed to load HDF5 table" << std::endl;
+    return;
+  }
+
+  std::cout << "Loaded " << hostTable.nd << "D table with extents: ";
+  for (int dim = 0; dim < hostTable.nd; ++dim) {
+    std::cout << hostTable.extents[dim];
+    if (dim < hostTable.nd - 1) {
+      std::cout << " x ";
+    }
+  }
+  std::cout << std::endl;
+
+  // Step 2: Copy to device memory
+  auto deviceTable = MakeDeviceCopy(hostTable);
+
+  // Step 3: Example AMReX MultiFab interpolation (conceptual)
+  // Uncomment and adapt when implementing:
+  //
+  // amrex::Box domain(amrex::IntVect(0), amrex::IntVect(63));
+  // amrex::BoxArray ba(domain);
+  // ba.maxSize(32);
+  // amrex::DistributionMapping dm(ba);
+  // amrex::MultiFab mf(ba, dm, 1, 0);
+  //
+  // auto view = deviceTable.View();
+  //
+  // for (amrex::MFIter mfi(mf); mfi.isValid(); ++mfi) {
+  //   const amrex::Box& box = mfi.validbox();
+  //   amrex::Array4<amrex::Real> const& fab = mf.array(mfi);
+  //
+  //   amrex::ParallelFor(box,
+  //   [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+  //     // Map (i,j,k) to physical coordinates
+  //     double coords[5] = {
+  //       /* map i to axis 0 coordinate */,
+  //       /* map j to axis 1 coordinate */,
+  //       /* map k to axis 2 coordinate */,
+  //       0.0, 0.0
+  //     };
+  //
+  //     InterpConfig cfg;
+  //     const double value = InterpLinearND(
+  //       view.data, view.layout, view.axes, coords, cfg, view.nd
+  //     );
+  //
+  //     fab(i, j, k) = value;
+  //   });
+  // }
+
+  std::cout << "Demo complete (placeholder - see interp_demo.cpp for TODO items)" << std::endl;
+}
+
+} // anonymous namespace
+
+int main(int argc, char* argv[])
+{
+  amrex::Initialize(argc, argv);
+
+  {
+    if (argc < 2) {
+      std::cout << "Usage: " << argv[0] << " <path-to-hdf5-table>" << std::endl;
+      std::cout << "Note: This is a placeholder demo (see examples/amrex/README.md)" << std::endl;
+    } else {
+      RunInterpolationDemo(argv[1]);
+    }
+  }
+
+  amrex::Finalize();
+  return 0;
+}


### PR DESCRIPTION
Create the missing examples/amrex directory referenced in AGENTS.md and README.md. This directory provides a placeholder scaffold for the CUDA demo that will be completed in Phase 3.

Includes:
- README.md explaining the placeholder status and planned features
- CMakeLists.txt build configuration template
- interp_demo.cpp showing conceptual usage with AMReX MultiFab

This addresses the documentation-code mismatch where examples/amrex was referenced but did not exist in the repository.