### PR TITLE
Find and fix easiest repository issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
 
 project(WeakLibReader
   VERSION 0.1.0
@@ -64,7 +64,7 @@ target_include_directories(WeakLibReader INTERFACE
   $<INSTALL_INTERFACE:WeakLibReader/src>)
 target_link_libraries(WeakLibReader INTERFACE
   OpenMP::OpenMP_CXX
-  HDF5::HDF5
+  HDF5::C
   ${AMREX_TARGET})
 
 enable_testing()

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GPU-friendly C++ reimplementation of WeakLib's equation-of-state and opacity int
 
 ## Requirements
 
-- CMake ≥ 3.18
+- CMake ≥ 3.19
 - C++17-capable compiler
 - AMReX headers (point `AMREX_ROOT` to your installation)
 - OpenMP runtime if AMReX was built with OpenMP (e.g. `libomp` on macOS)


### PR DESCRIPTION
- Bump minimum CMake version from 3.18 to 3.19
- Use HDF5::C instead of HDF5::HDF5 for better specificity
- Update README.md to reflect new CMake requirement

The HDF5::HDF5 and component-specific targets like HDF5::C were only introduced in CMake 3.19, but the project was requiring CMake 3.18. This could cause build failures on systems with CMake 3.18. Using HDF5::C is also more semantically correct since we only request the C component in find_package.