### PR TITLE
Respect error policy in log interpolation

### DIFF
--- a/WeakLibReader/src/LogInterpolate.hpp
+++ b/WeakLibReader/src/LogInterpolate.hpp
@@ -42,7 +42,6 @@ double LogInterpolatedValueDirect(const double* data,
   // Fixed-size arrays: compiler can optimize/unroll the loop below
   int indices[ND];
   double fractions[ND];
-  bool outOfRange = false;
 
   // Index lookup for each dimension
   // Note: Loop used intentionally (not explicit unrolling) because:
@@ -53,7 +52,9 @@ double LogInterpolatedValueDirect(const double* data,
   for (int d = 0; d < ND; ++d) {
     bool out = IndexAndDelta(axes[d], coords[d], indices[d], fractions[d]);
     if (out) {
-      outOfRange = true;
+      if (cfg.outOfRange == OutOfRangePolicy::Error) {
+        return std::numeric_limits<double>::quiet_NaN();
+      }
       // Early exit for FillNaN policy
       if (cfg.outOfRange == OutOfRangePolicy::FillNaN) {
         return std::numeric_limits<double>::quiet_NaN();

--- a/test/test_log_interpolate.cpp
+++ b/test/test_log_interpolate.cpp
@@ -86,6 +86,30 @@ TEST_CASE("Out-of-range clamp FillNaN policy returns NaN", "[loginterp][2d][nan]
   CHECK(std::isnan(value));
 }
 
+TEST_CASE("Out-of-range error policy returns NaN", "[loginterp][2d][nan][error]")
+{
+  using namespace WeakLibReader;
+
+  const std::array<double, 2> gridX{1.0, 2.0};
+  const std::array<double, 2> gridY{1.0, 3.0};
+  const std::array<double, 4> table{
+      std::log10(2.0),
+      std::log10(3.0),
+      std::log10(4.0),
+      std::log10(5.0)};
+
+  InterpConfig cfg;
+  cfg.outOfRange = OutOfRangePolicy::Error;
+
+  const double value = LogInterpolateSingleVariable2DCustomPoint(
+      0.5, 2.0,
+      gridX.data(), 2,
+      gridY.data(), 2,
+      table.data(), 0.0, cfg);
+
+  CHECK(std::isnan(value));
+}
+
 TEST_CASE("Batch 2D log interpolation matches point wrapper", "[loginterp][2d][batch]")
 {
   using namespace WeakLibReader;


### PR DESCRIPTION
## Summary
- honor `OutOfRangePolicy::Error` in the compile-time log interpolation helper so out-of-range queries return NaN instead of clamping
- add a regression test covering the error policy for 2D custom log interpolation

## Testing
- cmake -S . -B build *(fails: missing HDF5 in the environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fb0002aa88325800ed467d9b2b52d)