### PR TITLE
Add option to disable HDF5 dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+option(WEAKLIBREADER_ENABLE_HDF5 "Build HDF5 loader and related tests" ON)
+
 set(AMREX_ROOT "" CACHE PATH "Root directory of the AMReX installation")
 if (NOT AMREX_ROOT AND DEFINED ENV{AMREX_ROOT})
   set(AMREX_ROOT "$ENV{AMREX_ROOT}")
@@ -24,7 +26,10 @@ find_package(AMReX QUIET CONFIG
     ${AMREX_ROOT}/lib64/cmake)
 
 find_package(OpenMP REQUIRED)
-find_package(HDF5 REQUIRED COMPONENTS C)
+
+if (WEAKLIBREADER_ENABLE_HDF5)
+  find_package(HDF5 REQUIRED COMPONENTS C)
+endif()
 
 if (AMReX_FOUND)
   set(AMREX_TARGET AMReX::amrex)
@@ -64,8 +69,11 @@ target_include_directories(WeakLibReader INTERFACE
   $<INSTALL_INTERFACE:WeakLibReader/src>)
 target_link_libraries(WeakLibReader INTERFACE
   OpenMP::OpenMP_CXX
-  HDF5::HDF5
   ${AMREX_TARGET})
+
+if (WEAKLIBREADER_ENABLE_HDF5 AND TARGET HDF5::HDF5)
+  target_link_libraries(WeakLibReader INTERFACE HDF5::HDF5)
+endif()
 
 enable_testing()
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ GPU-friendly C++ reimplementation of WeakLib's equation-of-state and opacity int
 - C++17-capable compiler
 - AMReX headers (point `AMREX_ROOT` to your installation)
 - OpenMP runtime if AMReX was built with OpenMP (e.g. `libomp` on macOS)
-- HDF5 C library (for table loader + unit tests)
+- HDF5 C library (for table loader + unit tests; optional via
+  `-DWEAKLIBREADER_ENABLE_HDF5=OFF`)
 
 ## Configure & Build
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,11 @@
-add_executable(WeakLibReaderTests
-  test_log_interpolate.cpp
-  test_hdf5_loader.cpp)
+set(TEST_SOURCES
+  test_log_interpolate.cpp)
+
+if (WEAKLIBREADER_ENABLE_HDF5 AND TARGET HDF5::HDF5)
+  list(APPEND TEST_SOURCES test_hdf5_loader.cpp)
+endif()
+
+add_executable(WeakLibReaderTests ${TEST_SOURCES})
 
 target_include_directories(WeakLibReaderTests
   PRIVATE


### PR DESCRIPTION
## Summary
- add a CMake option to disable the HDF5 dependency when it is not available
- conditionally include the HDF5 loader test sources only when HDF5 is enabled
- document the new toggle in the requirements section

## Testing
- cmake -S . -B build -DWEAKLIBREADER_ENABLE_HDF5=OFF


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fb0002aa88325800ed467d9b2b52d)