### PR TITLE
Fix dataspace error status

### DIFF
--- a/WeakLibReader/src/Hdf5Loader.hpp
+++ b/WeakLibReader/src/Hdf5Loader.hpp
@@ -349,7 +349,7 @@ inline Hdf5LoadStatus LoadHdf5Table(const std::string& filePath,
 
   detail::ScopedHandle dataspace(H5Dget_space(dataset.Get()), H5Sclose);
   if (!dataspace.Valid()) {
-    return Hdf5LoadStatus::DatasetOpenFailed;
+    return Hdf5LoadStatus::DatasetReadFailed;
   }
 
   const int rank = H5Sget_simple_extent_ndims(dataspace.Get());


### PR DESCRIPTION
## Summary
- correct the HDF5 loader to report dataspace retrieval failures as dataset read errors

## Testing
- not run (HDF5 development libraries unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931f4fcd9388325a24a660fbdc84d85)