### PR TITLE
Guard layout creation against invalid dimensions

### DIFF
--- a/WeakLibReader/src/Layout.hpp
+++ b/WeakLibReader/src/Layout.hpp
@@ -61,6 +61,10 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 Layout MakeLayout(const int* extents, int nd) noexcept
 {
   Layout layout{};
+  if (extents == nullptr || nd < 1 || nd > 5) {
+    return layout;
+  }
+
   layout.nd = nd;
   std::size_t stride = 1;
   for (int dim = 0; dim < nd; ++dim) {


### PR DESCRIPTION
## Summary
- validate MakeLayout inputs to avoid undefined behavior when extents are null or dimensions fall outside the supported 1..5 range

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931f4fcd9388325a24a660fbdc84d85)