### PR TITLE
Streamline CLAUDE.md and enhance README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,153 +1,84 @@
-# AGENTS Instructions
+# CLAUDE.md
 
 ## Project Goal
 
-Translate WeakLib’s EOS & opacity **interpolators** from Fortran into **GPU‑friendly C++** that integrates cleanly with **AMReX**. Achieve tight numerical agreement with the Fortran reference at interior points and boundaries, with predictable performance on **CUDA** first (HIP later).
+Translate WeakLib's EOS & opacity **interpolators** from Fortran into **GPU-friendly C++** that integrates with **AMReX**. Target: numerical parity with Fortran (≤1e-12 relative error), CUDA first (HIP later).
 
 ## Repository Structure
 
 ```
 WeakLibReader/
   src/                        # Core headers (public API + device helpers)
-    AxisTypes.hpp             # Core types: Axis, InterpConfig, AxisScale, OutOfRangePolicy
+    AxisTypes.hpp             # Axis, InterpConfig, AxisScale, OutOfRangePolicy
     IndexDelta.hpp            # Linear/log10 indexing helpers
-    InterpBasis.hpp           # Linear/bi-/tri-/tetra-/penta-linear basis routines
+    InterpBasis.hpp           # Linear through penta-linear basis routines
     InterpLogTable.hpp        # Log-space point kernels and aligned slices
-    Hdf5Loader.hpp            # Host-side HDF5 reader via amrex::TableData
-    LogInterpolate.hpp        # Log wrappers, derivatives, weighted sums
+    LogInterpolate.hpp        # High-level API: interpolation, derivatives, sweeps
     Layout.hpp                # Row-major stride helpers
-    Math.hpp                  # Minimal math utilities (log10, pow10, etc.)
+    Math.hpp                  # GPU math utilities (Log10, Pow10)
+    Hdf5Loader.hpp            # HDF5 reader via amrex::TableData
 ref/weaklib/                  # Fortran reference implementation
 test/
-  include/catch2/             # Minimal Catch2-compatible shim
-  test_log_interpolate.cpp    # Regression tests (aligned planes, derivatives, etc.)
-  test_hdf5_loader.cpp        # HDF5 loader round-trip coverage
+  test_log_interpolate.cpp    # 28 interpolation tests (1D-5D, derivatives, policies)
+  test_hdf5_loader.cpp        # 11 HDF5 loader tests
 ```
 
-## Code Style & Conventions
+## Naming Conventions
 
-### Naming (Strictly Enforced)
 - **Namespace:** `WeakLibReader`
-- **Types/Structs/Enums/Classes:** `PascalCase` (e.g., `Axis`, `Layout`, `InterpConfig`, `AxisScale`, `OutOfRangePolicy`).
-- **Functions:** `PascalCase` (e.g., `IndexAndDeltaLin`, `LogInterpolateSingleVariable3DCustomPoint`)
-- **Variables/Parameters/Data members:** `lowerCamelCase` (e.g., `outOfRange`, `rowStride`)
-- **Constants/Enumerators:** `PascalCase` (e.g., `Clamp`, `Linear`, `Log10`)
-- **Standard:** C++17+ required
+- **Types/Functions:** `PascalCase` (e.g., `Axis`, `IndexAndDeltaLin`)
+- **Variables:** `lowerCamelCase` (e.g., `outOfRange`, `rowStride`)
+- **Standard:** C++17+
 
-### Key Design Principles
+## Key Design Principles
+
 1. **Row-major layout** with precomputed strides
-2. **No STL containers** in device code
+2. **No STL containers** in device code; no dynamic allocations in kernels
 3. **Pass by value** for small structs (`Axis`, `Layout`, `InterpConfig`)
 4. **Out-of-range handling** via policy (default: `Clamp`)
 5. **Strict monotonicity** for axis grids (validated at load time)
-6. **Numerical parity** with Fortran reference (≤1e-12 relative error)
+6. **Device functions** must be `noexcept`, inline, `AMREX_GPU_HOST_DEVICE`
 
-## Development Workflows
+## Build & Test
 
-### Building
 ```bash
-# Configure (set AMREX_ROOT to your AMReX installation)
-cmake -S . -B build \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DAMREX_ROOT=/path/to/amrex
-
-# Build
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DAMREX_ROOT=/path/to/amrex
 cmake --build build -j
-
-# Run tests
 ctest --test-dir build --output-on-failure
 ```
 
-### Testing Strategy
-- **Unit tests:** `test/test_log_interpolate.cpp` (interpolation kernels, policies, derivatives)
-- **Integration tests:** `test/test_hdf5_loader.cpp` (HDF5 → TableData round-trip)
-- **Coverage areas:**
-  - 2D/3D/4D log interpolation vs. analytical expectations
-  - Out-of-range policies (Clamp, FillNaN, Error)
-  - Symmetric plane helpers and weighted sums
-  - Derivative wrappers (`LogInterpolateDifferentiateSingleVariable*`)
-  - HDF5 axis metadata validation (monotonicity, scale attributes)
+## HDF5 Table Format
 
-### Git Practices
-- **Main branch:** Protected; requires PR + CI pass
-- **Commit messages:** Concise, imperative mood (e.g., "Add 4D log interpolation")
-- **CI:** All PRs must pass `ci.yml` (builds + tests on Ubuntu + AMReX development branch)
+```
+/values              # N-D array (row-major)
+/axis0, /axis1, ...  # 1D arrays with "scale" attribute ("linear" or "log10")
+```
 
-### When Modifying Code
-1. **Read before writing:** Always inspect existing files before proposing changes
-2. **Test coverage:** Add tests for new features; update existing tests for changes
-3. **Fortran parity:** If touching interpolation logic, verify against `ref/weaklib/` behavior
-4. **Device safety:** Ensure new functions are `noexcept`, inline, and use `AMREX_GPU_HOST_DEVICE`
-5. **Documentation:** Update `AGENTS.md` if changing scope/design; update `README.md` for user-facing changes
+Validation: monotonic ascending, positive values for Log10 axes.
 
-## Integration Points
+## Fortran Reference
 
-### AMReX
-- Headers include `AMReX_GpuQualifiers.H`, `AMReX_Extension.H`
-- Tables stored as `amrex::TableData<double,4>`
-- 5D datasets: last two axes flattened into TableData, but full 5D layout preserved for interpolation
-- Use `LoadHdf5TableParallel` for MPI runs (rank 0 reads, broadcasts)
+Located in `ref/weaklib/`. Key modules: `wlInterpolationModule.F90`, `wlInterpolationUtilitiesModule.F90`. Always consult before implementing new interpolation logic.
 
-### HDF5
-- Loader reads datasets + axis metadata from HDF5 files
-- Required HDF5 structure:
-  - Axis datasets: `/axis1`, `/axis2`, ... (1D arrays)
-  - Value dataset: `/values` (N-D array matching axis dimensions)
-  - Scale attributes: `"linear"` or `"log10"` per axis
-- Validation: monotonic ascending, positive values for Log10 axes
+## Architectural Decisions (Locked)
 
-### Fortran Reference
-- Located in `ref/weaklib/`
-- Key modules:
-  - `wlKindModule.f90`: Precision definitions
-  - `wlInterpolationModule.F90`: Main interpolation routines
-  - `wlInterpolationUtilitiesModule.F90`: Helper functions
-- **Always consult Fortran code** before implementing new interpolation logic
-
-## Key Architectural Decisions (Locked)
-
-1. **Out-of-range policy:** Default is `Clamp` (matches Fortran implicit behavior)
-2. **Precision:** Double throughout (templatable later if needed)
-3. **Table I/O:** HDF5 only (no NetCDF, no discovery frameworks)
+1. **Out-of-range policy:** Default `Clamp` (matches Fortran)
+2. **Precision:** Double throughout
+3. **Table I/O:** HDF5 only
 4. **GPU backend:** CUDA first, HIP/DPCPP later
 5. **Memory layout:** Explicit row-major with precomputed strides
-6. **Device qualification:** All interpolation kernels are `AMREX_GPU_HOST_DEVICE`
 
-## Current Implementation Snapshot
-
-- **Layout & Strides:** `WeakLibReader/src/Layout.hpp` provides `Layout` and `MakeLayout` helpers that precompute row-major strides and sub-slice utilities (`SliceLeading`), keeping device functions inline and `noexcept`.
-- **Index Lookup:** `WeakLibReader/src/IndexDelta.hpp` implements `IndexAndDeltaLin/Log10`, returning clamped cell indices and interpolation fractions plus an out-of-range flag to honor the configured policy.
-- **Interpolation Kernels:** `WeakLibReader/src/InterpBasis.hpp` supplies linear through penta-linear blending and partial derivatives. `WeakLibReader/src/AxisTypes.hpp` provides axis metadata (`Axis`, `MakeAxis`), out-of-range policy (`InterpConfig`), and internal helpers used by higher-level APIs.
-- **Log-Wrapped APIs:** `WeakLibReader/src/InterpLogTable.hpp` and `WeakLibReader/src/LogInterpolate.hpp` layer pow10/offset handling, symmetric plane helpers, and derivative evaluators that replicate the Fortran log-table entry points.
-- **HDF5 Loader:** `WeakLibReader/src/Hdf5Loader.hpp` reads axis metadata + value datasets, validates monotonicity, and materializes tables into `amrex::TableData<double,4>` while preserving axis storage for interpolation.
-- **Build & Tests:** `CMakeLists.txt` exposes the headers as an INTERFACE target with AMReX/OpenMP/HDF5 includes; `test/test_log_interpolate.cpp` and `test/test_hdf5_loader.cpp` cover interpolation kernels, policies, symmetry helpers, weighted sums, derivatives, and HDF5 round-trips via the bundled Catch shim.
-
-## Performance Notes
-
-- Precompute strides; pass compact axis/layout structs by value.
-- Avoid branching in weight calc; coalesce reads; no dynamic allocations in kernels.
-- Keep device functions `noexcept`; return status flags when needed.
-
-## Security & Quality
-
-- **Validation:** Host-side checks for axis monotonicity, Log10 domain positivity
-- **Error handling:** Out-of-range policy configurable; device code returns status flags
-- **No unsafe operations:** No raw pointer arithmetic without bounds (use `Layout::Offset`)
-
-## Getting Help
-
-- **Fortran reference:** Inspect `ref/weaklib/*.F90` for original implementation
-
-## Do’s and Don’ts for Agents
+## Do's and Don'ts
 
 **Do**
+- Read existing files before proposing changes
+- Add tests for new features; verify against `ref/weaklib/` for interpolation changes
+- Preserve numerical behavior at boundaries and mixed Linear/Log10 axes
+- Use `Layout::Offset` for bounds-safe data access
+- Ensure HDF5 loader retains axis storage backing `Axis` pointers
 
-- Preserve numerical behavior at boundaries and under mixed Linear/Log10 axes.
-- Keep device code free of STL containers and dynamic allocations.
-- Provide small, `constexpr` helpers; keep functions `AMREX_GPU_HOST_DEVICE`.
-- Ensure HDF5 loader retains axis storage backing the raw pointers returned in `Axis`.
-
-**Don’t**
-
-- Don’t add alternate table I/O formats beyond the sanctioned HDF5 loader.
-- Don’t add OpenACC or non‑AMReX GPU pragmas.
+**Don't**
+- Add I/O formats beyond HDF5
+- Use STL containers or dynamic allocations in device code
+- Add OpenACC or non-AMReX GPU pragmas
+- Skip host-side validation (monotonicity, Log10 positivity)

--- a/README.md
+++ b/README.md
@@ -4,50 +4,116 @@
 
 GPU-friendly C++ reimplementation of WeakLib's equation-of-state and opacity interpolators. The library mirrors the original Fortran routines under `ref/weaklib/`, provides AMReX-ready device functions, and ships with a lightweight regression suite.
 
+## Features
+
+- 1D-5D log-space interpolation with compile-time dimension dispatch
+- GPU-ready kernels (`AMREX_GPU_HOST_DEVICE` qualified)
+- Configurable out-of-range policies: `Clamp`, `Error`, `FillNaN`
+- Derivative computation for 2D-4D interpolation
+- HDF5 table loading with MPI broadcast support
+- Numerical parity with Fortran reference (≤1e-12 relative error)
+
 ## Requirements
 
 - CMake ≥ 3.18
 - C++17-capable compiler
-- AMReX headers (point `AMREX_ROOT` to your installation)
-- OpenMP runtime if AMReX was built with OpenMP (e.g. `libomp` on macOS)
-- HDF5 C library (for table loader + unit tests)
+- AMReX (point `AMREX_ROOT` to your installation)
+- OpenMP runtime
+- HDF5 C library
 
-## Configure & Build
+## Build
 
 ```bash
-# Configure (fill in your AMReX path; an installed AMReX CMake package is used when available)
-cmake -S . -B build \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DAMREX_ROOT=/path/to/amrex \
-      -DOpenMP_CXX_FLAGS='-Xpreprocessor -fopenmp' \
-      -DOpenMP_CXX_LIB_NAMES=omp \
-      -DOpenMP_omp_LIBRARY=$(brew --prefix libomp)/lib/libomp.dylib
-
-# Build library + tests
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DAMREX_ROOT=/path/to/amrex
 cmake --build build -j
 ```
 
-## Tests
-
+**macOS note:** If using Homebrew's libomp, add OpenMP flags:
 ```bash
-ctest --test-dir build -j
+-DOpenMP_CXX_FLAGS='-Xpreprocessor -fopenmp' \
+-DOpenMP_CXX_LIB_NAMES=omp \
+-DOpenMP_omp_LIBRARY=$(brew --prefix libomp)/lib/libomp.dylib
 ```
 
-The regression suite runs via a bundled Catch2-style shim. It exercises:
+## Test
 
-- 2D log interpolation vs. bilinear expectation
-- FillNaN out-of-range policy
-- Aligned 2D plane symmetry and weighted sums
-- Derivative wrappers (`LogInterpolateDifferentiateSingleVariable*`)
-- HDF5 loader round-trip into `amrex::TableData`
+```bash
+ctest --test-dir build --output-on-failure
+```
+
+The suite exercises 2D-5D interpolation, out-of-range policies, derivatives, symmetric plane helpers, and HDF5 round-trips.
+
+## Usage Example
+
+```cpp
+#include "Hdf5Loader.hpp"
+#include "LogInterpolate.hpp"
+
+using namespace WeakLibReader;
+
+// Load table from HDF5
+Hdf5Table table;
+auto status = LoadHdf5Table("opacity.h5", table);
+if (status != Hdf5LoadStatus::Success) { /* handle error */ }
+
+// Get table view
+TableView view = table.View();
+
+// 3D interpolation at a single point
+double d = 1.0e10, t = 0.5, y = 300.0;
+InterpConfig cfg{OutOfRangePolicy::Clamp};
+double result = LogInterpolateSingleVariable3DCustomPoint(
+    d, t, y,
+    view.axes[0].grid, view.axes[0].n,
+    view.axes[1].grid, view.axes[1].n,
+    view.axes[2].grid, view.axes[2].n,
+    view.data, 0.0, cfg);
+```
+
+## API Overview
+
+### Core Types
+
+| Type | Description |
+|------|-------------|
+| `Axis` | Grid metadata: pointer, size, scale (Linear/Log10) |
+| `Layout` | Row-major strides for N-D data |
+| `InterpConfig` | Out-of-range policy configuration |
+| `Hdf5Table` | Host-side table storage (owns data + axes) |
+| `TableView` | Read-only view into loaded table |
+| `TableDevice` | Device-side table copy |
+
+### Key Functions
+
+| Function | Description |
+|----------|-------------|
+| `LoadHdf5Table()` | Load HDF5 into `amrex::TableData` |
+| `LoadHdf5TableParallel()` | MPI-aware loader (rank 0 reads, broadcasts) |
+| `MakeDeviceCopy()` | Copy host table to GPU device |
+| `LogInterpolateSingleVariable*DCustomPoint()` | Single-point N-D interpolation |
+| `LogInterpolateSingleVariable*DCustom()` | Batch N-D interpolation |
+| `LogInterpolateDifferentiateSingleVariable*()` | Interpolation with derivatives |
+
+### HDF5 File Format
+
+```
+/values              # N-D array (row-major layout)
+/axis0               # 1D array with "scale" attribute ("linear" or "log10")
+/axis1               # ...
+```
+
+## Project Structure
+
+```
+WeakLibReader/src/   # Header-only library (8 headers)
+ref/weaklib/         # Fortran reference implementation
+test/                # Regression tests (39 test cases)
+```
 
 ## Fortran Parity
 
-Original routines live under `ref/weaklib/`. The C++ API mirrors the Fortran functions (indices, weights, log handling) and targets ≤ 1e-12 relative agreement. Use the regression suite as a starting point when adding additional parity checks.
+Original routines live under `ref/weaklib/`. The C++ API mirrors Fortran functions (indices, weights, log handling) and targets ≤1e-12 relative agreement.
 
-## Notes
+## Contributing
 
-- The AMReX CUDA demo is a placeholder; integrate once the GPU kernels are ready.
-- Headers include `AMReX_GpuQualifiers.H` and `AMReX_Extension.H`; ensure your include path covers `${AMREX_ROOT}/include`.
-- HDF5 tables load into `amrex::TableData<double,4>`; for 5D datasets the final two axes are flattened when allocating the table storage while preserving the raw row-major layout for interpolation.
-- Use `LoadHdf5TableParallel` when running under MPI to let a single rank hit the filesystem and broadcast the loaded table to peers.
+PRs require CI pass. See `CLAUDE.md` for code conventions and design principles.


### PR DESCRIPTION
## Summary
- Streamline CLAUDE.md from 154 to 85 lines while preserving essential agent guidance
- Enhance README.md from 54 to 120 lines with usage example and API overview

## Test plan
- [x] Build passes: `cmake --build build -j`
- [x] All tests pass: `ctest --test-dir build --output-on-failure`