### PR TITLE
Fix CMake CMP0144 policy warning for AMREX_ROOT variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+cmake_policy(SET CMP0144 NEW)
 
 project(WeakLibReader
   VERSION 0.1.0


### PR DESCRIPTION
## Summary
- Add `cmake_policy(SET CMP0144 NEW)` to suppress the CMake warning about uppercase `AMREX_ROOT` variable usage with `find_package`

## Test plan
- [x] Run `cmake -S . -B build` and verify no CMP0144 warning appears