### PR TITLE
Add scripts/check.sh for combined build and test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,7 @@ test/
 ## Build & Test
 
 ```bash
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DAMREX_ROOT=/path/to/amrex
-cmake --build build -j
-ctest --test-dir build --output-on-failure
+scripts/check.sh
 ```
 
 ## HDF5 Table Format

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,27 @@
+# Build Scripts
+
+Wrapper scripts that provide quiet output on success.
+
+## Usage
+
+```bash
+# Build (assumes build/ directory is already configured)
+./scripts/build.sh
+
+# Run tests
+./scripts/test.sh
+
+# Run build and test together
+./scripts/check.sh
+```
+
+## Configuration
+
+Environment variables:
+- `BUILD_DIR` - Build directory (default: `build`)
+- `JOBS` - Parallel jobs for build (default: auto-detected)
+
+## Output
+
+- Success: Single line with checkmark
+- Failure: Full captured output followed by non-zero exit

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUILD_DIR="${BUILD_DIR:-build}"
+JOBS="${JOBS:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)}"
+
+# Create temp file for output capture
+output_file=$(mktemp)
+trap 'rm -f "$output_file"' EXIT
+
+# Run build and capture output
+if cmake --build "$BUILD_DIR" -j"$JOBS" >"$output_file" 2>&1; then
+    echo "Build ✓"
+else
+    exit_code=$?
+    cat "$output_file"
+    exit $exit_code
+fi

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Run build first, then test
+"$SCRIPT_DIR/build.sh" && "$SCRIPT_DIR/test.sh"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUILD_DIR="${BUILD_DIR:-build}"
+
+# Create temp file for output capture
+output_file=$(mktemp)
+trap 'rm -f "$output_file"' EXIT
+
+# Run tests and capture output
+if ctest --test-dir "$BUILD_DIR" --output-on-failure >"$output_file" 2>&1; then
+    echo "Test ✓"
+else
+    exit_code=$?
+    cat "$output_file"
+    exit $exit_code
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/check.sh` that runs build then test with quiet output
- Add `scripts/build.sh` and `scripts/test.sh` wrapper scripts
- Add `scripts/README.md` documenting script usage
- Simplify `CLAUDE.md` Build & Test section to use `scripts/check.sh`

## Test plan
- [x] Verify `scripts/check.sh` is executable
- [x] Run `./scripts/check.sh` and confirm "Build ✓" then "Test ✓" output