### PR TITLE
Simplify CMakeLists.txt files for clarity and maintainability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,60 +5,61 @@ project(WeakLibReader
   VERSION 0.1.0
   LANGUAGES C CXX)
 
+# C++ standard settings
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# AMReX location: check cache, then environment variables
 set(AMREX_ROOT "" CACHE PATH "Root directory of the AMReX installation")
-if (NOT AMREX_ROOT AND DEFINED ENV{AMREX_ROOT})
-  set(AMREX_ROOT "$ENV{AMREX_ROOT}")
-endif()
-if (NOT AMREX_ROOT AND DEFINED ENV{AMREX_HOME})
-  set(AMREX_ROOT "$ENV{AMREX_HOME}")
+if(NOT AMREX_ROOT)
+  if(DEFINED ENV{AMREX_ROOT})
+    set(AMREX_ROOT "$ENV{AMREX_ROOT}")
+  elseif(DEFINED ENV{AMREX_HOME})
+    set(AMREX_ROOT "$ENV{AMREX_HOME}")
+  endif()
 endif()
 
-# Prefer an installed AMReX CMake package when available.
-find_package(AMReX QUIET CONFIG
-  HINTS
-    ${AMREX_ROOT}
-    ${AMREX_ROOT}/lib/cmake
-    ${AMREX_ROOT}/lib64/cmake)
-
+# Required dependencies
 find_package(OpenMP REQUIRED)
 find_package(HDF5 REQUIRED COMPONENTS C)
 
-if (AMReX_FOUND)
-  set(AMREX_TARGET AMReX::amrex)
-else()
+# AMReX: prefer CMake package, fall back to manual detection
+find_package(AMReX QUIET CONFIG
+  HINTS ${AMREX_ROOT} ${AMREX_ROOT}/lib/cmake ${AMREX_ROOT}/lib64/cmake)
+
+if(NOT AMReX_FOUND)
+  # Manual fallback: locate headers and library directly
   find_path(AMREX_INCLUDE_DIR
     NAMES AMReX_GpuQualifiers.H
-    HINTS
-      ${AMREX_ROOT}
-      ${AMREX_ROOT}/include
-    PATH_SUFFIXES
-      include)
+    HINTS ${AMREX_ROOT}
+    PATH_SUFFIXES include)
 
-  if (NOT AMREX_INCLUDE_DIR)
-    message(FATAL_ERROR "Failed to locate AMReX headers. Set AMREX_ROOT (or cache variable AMREX_INCLUDE_DIR) to the AMReX installation path containing AMReX_GpuQualifiers.H.")
+  if(NOT AMREX_INCLUDE_DIR)
+    message(FATAL_ERROR
+      "Failed to locate AMReX headers. "
+      "Set AMREX_ROOT to the AMReX installation path containing AMReX_GpuQualifiers.H.")
   endif()
 
   find_library(AMREX_LIBRARY
     NAMES amrex
-    HINTS
-      ${AMREX_ROOT}
-      ${AMREX_ROOT}/lib
-      ${AMREX_ROOT}/lib64)
-  if (NOT AMREX_LIBRARY)
-    message(FATAL_ERROR "Failed to locate libamrex. Set AMREX_ROOT to the AMReX installation prefix containing lib/libamrex.")
+    HINTS ${AMREX_ROOT}
+    PATH_SUFFIXES lib lib64)
+
+  if(NOT AMREX_LIBRARY)
+    message(FATAL_ERROR
+      "Failed to locate libamrex. "
+      "Set AMREX_ROOT to the AMReX installation prefix containing lib/libamrex.")
   endif()
 
+  # Create imported target to match the CMake package interface
   add_library(AMReX::amrex UNKNOWN IMPORTED)
   set_target_properties(AMReX::amrex PROPERTIES
-    IMPORTED_LOCATION ${AMREX_LIBRARY}
-    INTERFACE_INCLUDE_DIRECTORIES ${AMREX_INCLUDE_DIR})
-  set(AMREX_TARGET AMReX::amrex)
+    IMPORTED_LOCATION "${AMREX_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${AMREX_INCLUDE_DIR}")
 endif()
 
+# Header-only library target
 add_library(WeakLibReader INTERFACE)
 target_include_directories(WeakLibReader INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/WeakLibReader/src>
@@ -66,8 +67,8 @@ target_include_directories(WeakLibReader INTERFACE
 target_link_libraries(WeakLibReader INTERFACE
   OpenMP::OpenMP_CXX
   HDF5::HDF5
-  ${AMREX_TARGET})
+  AMReX::amrex)
 
+# Tests
 enable_testing()
-
 add_subdirectory(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_executable(WeakLibReaderTests
+# All test files compiled into a single executable
+set(TEST_SOURCES
   test_log_interpolate_2d.cpp
   test_log_interpolate_3d.cpp
   test_log_interpolate_4d5d.cpp
@@ -8,14 +9,11 @@ add_executable(WeakLibReaderTests
   test_log_interpolate_kernel.cpp
   test_hdf5_loader.cpp)
 
-target_include_directories(WeakLibReaderTests
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include)
+add_executable(WeakLibReaderTests ${TEST_SOURCES})
 
-target_link_libraries(WeakLibReaderTests
-  PRIVATE
-    WeakLibReader)
+target_include_directories(WeakLibReaderTests PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-add_test(
-  NAME WeakLibReader.LogInterpolation
-  COMMAND WeakLibReaderTests)
+target_link_libraries(WeakLibReaderTests PRIVATE WeakLibReader)
+
+add_test(NAME WeakLibReader.LogInterpolation COMMAND WeakLibReaderTests)


### PR DESCRIPTION
## Summary
- Combine env variable checks with `elseif` for clearer fallback chain
- Remove `AMREX_TARGET` variable; use `AMReX::amrex` directly
- Use `PATH_SUFFIXES` instead of explicit subdir hints in find commands
- Quote variables in `set_target_properties` for paths with spaces
- Group required dependencies (OpenMP, HDF5) before AMReX detection
- Add section comments for navigability
- Extract test sources to `TEST_SOURCES` variable in test/CMakeLists.txt

## Test plan
- [x] Build passes (`scripts/build.sh`)
- [x] All tests pass (`scripts/check.sh`)