### PR TITLE
Remove verbose and redundant comments from header files

### DIFF
--- a/WeakLibReader/src/Hdf5Loader.hpp
+++ b/WeakLibReader/src/Hdf5Loader.hpp
@@ -1,10 +1,5 @@
 #pragma once
 
-// Hdf5Loader.hpp - Umbrella header for HDF5 table loading
-//
-// This header includes all HDF5 loading functionality. Users should
-// continue to #include "Hdf5Loader.hpp" for the complete API.
-
 #include <AMReX_Arena.H>
 #include <AMReX_Array.H>
 #include <AMReX_GpuContainers.H>

--- a/WeakLibReader/src/InterpLogTable.hpp
+++ b/WeakLibReader/src/InterpLogTable.hpp
@@ -1,10 +1,5 @@
 #pragma once
 
-// InterpLogTable.hpp - Umbrella header for log-space interpolation kernels
-//
-// This header includes all low-level log-interpolation functionality.
-// Users should continue to #include "InterpLogTable.hpp" for the complete API.
-
 #include "detail/InterpLogTablePoint.hpp"
 #include "detail/InterpLogTableDeriv.hpp"
 #include "detail/InterpLogTableSlice.hpp"

--- a/WeakLibReader/src/LogInterpolate.hpp
+++ b/WeakLibReader/src/LogInterpolate.hpp
@@ -1,10 +1,5 @@
 #pragma once
 
-// LogInterpolate.hpp - Umbrella header for log-space interpolation API
-//
-// This header includes all log-interpolation functionality. Users should
-// continue to #include "LogInterpolate.hpp" for the complete API.
-
 #include "detail/LogInterpolateCore.hpp"
 #include "detail/LogInterpolatePoint.hpp"
 #include "detail/LogInterpolateSweep.hpp"

--- a/WeakLibReader/src/detail/InterpLogTableDeriv.hpp
+++ b/WeakLibReader/src/detail/InterpLogTableDeriv.hpp
@@ -1,10 +1,5 @@
 #pragma once
 
-// InterpLogTableDeriv.hpp - 2D-4D derivative interpolation kernels
-//
-// Low-level log-space interpolation functions that compute both
-// interpolated values and partial derivatives.
-
 #include <AMReX_GpuQualifiers.H>
 
 #include "../InterpBasis.hpp"
@@ -149,10 +144,6 @@ void LinearInterpDeriv4DPoint(int i0, int i1, int i2, int i3,
                                                p0011, p1011, p0111, p1111,
                                                d0, d1, d2);
 }
-
-// ============================================================================
-// Template-based compile-time dispatch wrapper for GPU optimization
-// ============================================================================
 
 /// Template wrapper for dimension-specific log-interpolation with derivatives (compile-time dispatch)
 /// @tparam ND Number of dimensions (2-4), known at compile time

--- a/WeakLibReader/src/detail/InterpLogTablePoint.hpp
+++ b/WeakLibReader/src/detail/InterpLogTablePoint.hpp
@@ -1,10 +1,5 @@
 #pragma once
 
-// InterpLogTablePoint.hpp - 1D-5D point interpolation kernels
-//
-// Low-level log-space interpolation functions for single points.
-// Uses precomputed indices and fractions from IndexDelta.hpp.
-
 #include <AMReX_GpuQualifiers.H>
 
 #include "../InterpBasis.hpp"
@@ -161,10 +156,6 @@ double LinearInterp5DPoint(int i0, int i1, int i2, int i3, int i4,
                                  p00111, p10111, p01111, p11111,
                                  d0, d1, d2, d3, d4)) - os;
 }
-
-// ============================================================================
-// Template-based compile-time dispatch wrapper for GPU optimization
-// ============================================================================
 
 /// Template wrapper for dimension-specific log-interpolation (compile-time dispatch)
 /// @tparam ND Number of dimensions (1-5), known at compile time

--- a/WeakLibReader/src/detail/InterpLogTableSlice.hpp
+++ b/WeakLibReader/src/detail/InterpLogTableSlice.hpp
@@ -1,10 +1,5 @@
 #pragma once
 
-// InterpLogTableSlice.hpp - Aligned slice interpolation operations
-//
-// Functions for interpolating on pre-sliced arrays where leading
-// dimensions are fixed (aligned). Used for sweep operations.
-
 #include <AMReX_GpuQualifiers.H>
 
 #include "InterpLogTablePoint.hpp"

--- a/WeakLibReader/src/detail/LogInterpolateCore.hpp
+++ b/WeakLibReader/src/detail/LogInterpolateCore.hpp
@@ -11,15 +11,6 @@
 namespace WeakLibReader {
 namespace detail {
 
-// ============================================================================
-// GPU-Optimized Template-Based Interpolation Core Functions
-// ============================================================================
-// These templates use compile-time dimensionality (ND) to eliminate all
-// runtime branching, improving GPU performance by avoiding warp divergence.
-// The 'if constexpr' statements are resolved at compile time, generating
-// specialized code for each dimension with zero runtime overhead.
-// ============================================================================
-
 /// GPU-optimized log-interpolation using compile-time dimension dispatch
 /// @tparam ND Number of dimensions (1-5), known at compile time
 /// @param data Raw data array in row-major order (log10-stored values)
@@ -38,16 +29,9 @@ double LogInterpolatedValueDirect(const double* data,
                                   double offset,
                                   const InterpConfig& cfg) noexcept
 {
-  // Fixed-size arrays: compiler can optimize/unroll the loop below
   int indices[ND];
   double fractions[ND];
 
-  // Index lookup for each dimension
-  // Note: Loop used intentionally (not explicit unrolling) because:
-  // 1. Compile-time ND means loop fully unrolls automatically (zero overhead)
-  // 2. Keeps code maintainable across all dimensions (1D-5D)
-  // 3. Modern compilers generate identical code to hand-unrolled version
-  // 4. GPU: All threads execute same unrolled instructions (no divergence)
   for (int d = 0; d < ND; ++d) {
     bool out = IndexAndDelta(axes[d], coords[d], indices[d], fractions[d]);
     if (out) {


### PR DESCRIPTION
## Summary
- Remove umbrella header descriptions from 3 public headers
- Remove verbose header comments from 3 detail headers
- Remove decorated design block and implementation notes from LogInterpolateCore.hpp
- Remove section separator comments with === decorators

## Test plan
- [x] Build passes (`scripts/build.sh`)
- [x] All tests pass (`scripts/test.sh`)