### PR TITLE
Simplify ComputeAxisScale for GPU performance

### DIFF
--- a/src/detail/LogInterpolateCore.hpp
+++ b/src/detail/LogInterpolateCore.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <AMReX_BLassert.H>
 #include <AMReX_GpuQualifiers.H>
 #include <cstddef>
 #include <limits>
@@ -81,57 +82,38 @@ inline void FillNaNVector(double* values, std::size_t count, std::size_t stride)
   }
 }
 
-inline bool ComputeLinearAxisScale(const Axis& axis, int idx, double& scale) noexcept
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void ComputeLinearAxisScale(const Axis& axis, int idx, double& scale) noexcept
 {
-  if (axis.grid == nullptr) {
-    scale = std::numeric_limits<double>::quiet_NaN();
-    return false;
-  }
+  AMREX_ASSERT(axis.grid != nullptr);
   const double span = axis.grid[idx + 1] - axis.grid[idx];
-  if (!(span > 0.0)) {
-    scale = std::numeric_limits<double>::quiet_NaN();
-    return false;
-  }
+  AMREX_ASSERT(span > 0.0);
   scale = math::Ln10 / span;
-  return true;
 }
 
-inline bool ComputeLogAxisScale(const Axis& axis, int idx, double coord,
-                                double& scale) noexcept
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void ComputeLogAxisScale(const Axis& axis, int idx, double coord,
+                         double& scale) noexcept
 {
-  if (axis.grid == nullptr) {
-    scale = std::numeric_limits<double>::quiet_NaN();
-    return false;
-  }
-  if (!(coord > 0.0)) {
-    scale = std::numeric_limits<double>::quiet_NaN();
-    return false;
-  }
+  AMREX_ASSERT(axis.grid != nullptr);
+  AMREX_ASSERT(coord > 0.0);
   const double ratio = axis.grid[idx + 1] / axis.grid[idx];
-  if (!(ratio > 0.0)) {
-    scale = std::numeric_limits<double>::quiet_NaN();
-    return false;
-  }
+  AMREX_ASSERT(ratio > 0.0);
   const double denom = math::Log10(ratio);
-  if (denom == 0.0) {
-    scale = std::numeric_limits<double>::quiet_NaN();
-    return false;
-  }
+  AMREX_ASSERT(denom != 0.0);
   scale = 1.0 / (coord * denom);
-  return true;
 }
 
-inline bool ComputeAxisScale(const Axis& axis, int idx, double coord,
-                             double& scale) noexcept
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void ComputeAxisScale(const Axis& axis, int idx, double coord,
+                      double& scale) noexcept
 {
-  if (axis.grid == nullptr) {
-    scale = std::numeric_limits<double>::quiet_NaN();
-    return false;
-  }
+  AMREX_ASSERT(axis.grid != nullptr);
   if (axis.scale == AxisScale::Linear) {
-    return ComputeLinearAxisScale(axis, idx, scale);
+    ComputeLinearAxisScale(axis, idx, scale);
+  } else {
+    ComputeLogAxisScale(axis, idx, coord, scale);
   }
-  return ComputeLogAxisScale(axis, idx, coord, scale);
 }
 
 inline void SetNaN(double& value0, double& value1, double& value2) noexcept
@@ -208,10 +190,7 @@ bool LogInterpolatedDerivativeDirect(const double* data,
     }
 
     // Compute axis scale for derivative calculation
-    if (!ComputeAxisScale(axes[d], indices[d], coords[d], scales[d])) {
-      SetNaN<ND>(interpolant, derivatives);
-      return false;
-    }
+    ComputeAxisScale(axes[d], indices[d], coords[d], scales[d]);
   }
 
   // Compile-time dispatch to dimension-specific derivative kernel

--- a/test/test_log_interpolate_3d.cpp
+++ b/test/test_log_interpolate_3d.cpp
@@ -125,42 +125,12 @@ TEST_CASE("Batch 3D log interpolation matches point wrapper", "[loginterp][3d][b
   }
 }
 
-TEST_CASE("Invalid log coordinate triggers error code", "[loginterp][invalid]")
-{
-  using namespace WeakLibReader;
-
-  const std::array<double, 2> gridD{1.0, 10.0};
-  const std::array<double, 2> gridT{1.0, 100.0};
-  const std::array<double, 2> gridY{0.0, 1.0};
-
-  const int extents[3] = {2, 2, 2};
-  const Layout layout = MakeLayout(extents, 3);
-
-  std::array<double, 8> table{};
-  for (int id = 0; id < 2; ++id) {
-    for (int it = 0; it < 2; ++it) {
-      for (int iy = 0; iy < 2; ++iy) {
-        table[layout.Offset(id, it, iy)] = std::log10(1.0 + 0.1 * id + 0.2 * it + 0.3 * iy);
-      }
-    }
-  }
-
-  double interpolant = 0.0;
-  double deriv[3] = {0.0, 0.0, 0.0};
-  const int rc = LogInterpolateDifferentiateSingleVariable3DCustomPoint(
-      -1.0, 2.0, 0.3,   // invalid log axis coord
-      gridD.data(), 2,
-      gridT.data(), 2,
-      gridY.data(), 2,
-      table.data(),
-      0.0,
-      interpolant, deriv);
-  CHECK(rc == 4);
-  CHECK(std::isnan(interpolant));
-  CHECK(std::isnan(deriv[0]));
-  CHECK(std::isnan(deriv[1]));
-  CHECK(std::isnan(deriv[2]));
-}
+// Note: The test "Invalid log coordinate triggers error code" was removed as part
+// of Issue #67. The defensive validation in ComputeAxisScale was removed because:
+// 1. HDF5 loader guarantees valid axes at load time
+// 2. IndexAndDelta validates coordinates for Log10 axes
+// 3. Invalid coordinates are programming errors caught by AMREX_ASSERT in debug builds
+// 4. The Fortran reference has no such runtime validation
 
 TEST_CASE("Zero-span axis yields NaN under FillNaN policy", "[loginterp][invalid]")
 {


### PR DESCRIPTION
## Summary
- Replace runtime validation checks in `ComputeAxisScale` functions with `AMREX_ASSERT` debug assertions
- Add `AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE` attributes to enable proper GPU compilation
- Remove redundant error handling in caller since functions no longer return bool

## Test plan
- [x] All interpolation tests pass (`scripts/check.sh`)
- [x] All 11 HDF5 loader tests pass
- [x] No compiler warnings introduced
- [x] Manual review of diff confirms only intended changes

Closes #67