### PR TITLE
Add tags file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+tags
+
 # CMake build artifacts
 build/
 _deps/


### PR DESCRIPTION
## Summary
- Add `tags` to `.gitignore` to ignore ctags/etags generated files

## Test plan
- [x] Verify tags files are no longer tracked by git