### PR TITLE
Add tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ coverage/
 *.swp
 *.swo
 *~
+tags
 .project
 .cproject
 .settings/


### PR DESCRIPTION
## Summary
- Add `tags` to `.gitignore` to ignore ctags/etags files generated by editors for code navigation

## Test plan
- Verify `tags` files are no longer tracked by git