### PR TITLE
Clean up test files: use named constant for tolerance, remove stale comments

### DIFF
--- a/test/test_hdf5_loader.cpp
+++ b/test/test_hdf5_loader.cpp
@@ -17,6 +17,8 @@
 
 namespace {
 
+constexpr double kTol = 1.0e-12;
+
 /// Global AMReX guard that initializes once and finalizes at program exit.
 /// This avoids the MPI re-initialization error that occurs when each test
 /// creates its own AmrexGuard (MPI cannot be re-initialized after finalization).
@@ -181,7 +183,7 @@ TEST_CASE("HDF5 loader reads table and axes", "[hdf5][loader]")
     total *= static_cast<std::size_t>(table.extents[dim]);
   }
   for (std::size_t i = 0; i < total; ++i) {
-    CHECK(roundtripPtr[i] == Catch::Approx(originalPtr[i]).margin(1.0e-12));
+    CHECK(roundtripPtr[i] == Catch::Approx(originalPtr[i]).margin(kTol));
   }
 
   for (int dim = 0; dim < table.nd; ++dim) {
@@ -192,7 +194,7 @@ TEST_CASE("HDF5 loader reads table and axes", "[hdf5][loader]")
                      hostAxis.begin());
     REQUIRE(hostAxis.size() == table.axisStorage[dim].size());
     for (std::size_t i = 0; i < hostAxis.size(); ++i) {
-      CHECK(hostAxis[i] == Catch::Approx(table.axisStorage[dim][i]).margin(1.0e-12));
+      CHECK(hostAxis[i] == Catch::Approx(table.axisStorage[dim][i]).margin(kTol));
     }
   }
 
@@ -204,7 +206,7 @@ TEST_CASE("HDF5 loader reads table and axes", "[hdf5][loader]")
   CHECK(parallelTable.layout.n[0] == table.layout.n[0]);
   CHECK(parallelTable.axes[2].scale == table.axes[2].scale);
   const double* parallelData = parallelTable.DataPtr();
-  CHECK(parallelData[idx] == Catch::Approx(data[idx]).margin(1.0e-12));
+  CHECK(parallelData[idx] == Catch::Approx(data[idx]).margin(kTol));
 
   std::filesystem::remove(filePath);
 }
@@ -621,7 +623,7 @@ TEST_CASE("HDF5 loader handles 5D tables correctly", "[hdf5][loader][5d]")
   const double* originalPtr = table.DataPtr();
   const double* roundtripPtr = roundtrip.const_table().p;
   for (std::size_t i = 0; i < totalSize; ++i) {
-    CHECK(roundtripPtr[i] == Catch::Approx(originalPtr[i]).margin(1.0e-12));
+    CHECK(roundtripPtr[i] == Catch::Approx(originalPtr[i]).margin(kTol));
   }
 
   // Verify device axis data
@@ -633,7 +635,7 @@ TEST_CASE("HDF5 loader handles 5D tables correctly", "[hdf5][loader][5d]")
                      hostAxis.begin());
     REQUIRE(hostAxis.size() == table.axisStorage[dim].size());
     for (std::size_t i = 0; i < hostAxis.size(); ++i) {
-      CHECK(hostAxis[i] == Catch::Approx(table.axisStorage[dim][i]).margin(1.0e-12));
+      CHECK(hostAxis[i] == Catch::Approx(table.axisStorage[dim][i]).margin(kTol));
     }
   }
 

--- a/test/test_log_interpolate_2d.cpp
+++ b/test/test_log_interpolate_2d.cpp
@@ -151,11 +151,6 @@ TEST_CASE("Template instantiation compiles for all dimensions", "[compile-time]"
 {
   using namespace WeakLibReader;
 
-  // This test verifies that our templated functions instantiate correctly
-  // for all supported dimensions. The actual function calls don't execute
-  // (they're in unreachable code), but the compiler still instantiates the
-  // templates, ensuring they compile without errors.
-
   if (false) {  // Never executed, but forces template instantiation
     double dummy_data[32] = {};
     int dummy_indices[5] = {};

--- a/test/test_log_interpolate_3d.cpp
+++ b/test/test_log_interpolate_3d.cpp
@@ -124,14 +124,3 @@ TEST_CASE("Batch 3D log interpolation matches point wrapper", "[loginterp][3d][b
     CHECK(out[i] == Catch::Approx(point).margin(kTol));
   }
 }
-
-// Note: The test "Invalid log coordinate triggers error code" was removed as part
-// of Issue #67. The defensive validation in ComputeAxisScale was removed because:
-// 1. HDF5 loader guarantees valid axes at load time
-// 2. IndexAndDelta validates coordinates for Log10 axes
-// 3. Invalid coordinates are programming errors caught by AMREX_ASSERT in debug builds
-// 4. The Fortran reference has no such runtime validation
-
-// Note: The test "Zero-span axis yields NaN under FillNaN policy" was removed as part
-// of Issue #70. OutOfRangePolicy and InterpConfig have been removed to match Fortran
-// behavior where out-of-range coordinates simply extrapolate.


### PR DESCRIPTION
## Summary
- Extract tolerance constant `kTol` in `test_hdf5_loader.cpp` for consistency with other test files
- Remove outdated comment in `test_log_interpolate_2d.cpp`
- Remove obsolete comments referencing removed tests in `test_log_interpolate_3d.cpp`

## Test plan
- [x] All existing tests pass
- [x] No functional changes, only cleanup