### PR TITLE
Refactor interpolation APIs to accept Axis arrays, remove redundant extents field

### DIFF
--- a/src/Hdf5Loader.hpp
+++ b/src/Hdf5Loader.hpp
@@ -54,16 +54,14 @@ inline Hdf5LoadStatus LoadHdf5Table(const std::string& filePath,
     }
     extents[dim] = static_cast<int>(source);
   }
-  result.extents = extents;
-
-  const std::size_t totalSize = detail::ComputeTotalSize(rank, extents);
+  const std::size_t totalSize = detail::ComputeTotalSize(rank, extents.data());
   if (totalSize == 0) {
     return Hdf5LoadStatus::IncompatibleDatasetExtent;
   }
 
   const amrex::Array<int, 4> lo{{0, 0, 0, 0}};
   bool extentOverflow = false;
-  amrex::Array<int, 4> hi = detail::MakeHiArray(rank, extents, extentOverflow);
+  amrex::Array<int, 4> hi = detail::MakeHiArray(rank, extents.data(), extentOverflow);
   if (extentOverflow) {
     return Hdf5LoadStatus::IncompatibleDatasetExtent;
   }
@@ -74,12 +72,12 @@ inline Hdf5LoadStatus LoadHdf5Table(const std::string& filePath,
     return Hdf5LoadStatus::DatasetReadFailed;
   }
 
-  const Hdf5LoadStatus axisStatus = detail::LoadAxes(file.Get(), rank, cfg, result);
+  const Hdf5LoadStatus axisStatus = detail::LoadAxes(file.Get(), rank, extents.data(), cfg, result);
   if (axisStatus != Hdf5LoadStatus::Success) {
     return axisStatus;
   }
 
-  result.layout = MakeLayout(result.extents.data(), result.nd);
+  result.layout = MakeLayout(extents.data(), result.nd);
   output = std::move(result);
   return Hdf5LoadStatus::Success;
 }
@@ -93,7 +91,7 @@ inline TableDevice MakeDeviceCopy(const Hdf5Table& host,
 
   const amrex::Array<int, 4> lo{{0, 0, 0, 0}};
   bool overflow = false;
-  const amrex::Array<int, 4> hi = detail::MakeHiArray(host.nd, host.extents, overflow);
+  const amrex::Array<int, 4> hi = detail::MakeHiArray(host.nd, host.layout.n, overflow);
   AMREX_ASSERT(!overflow);
 
   device.values.resize(lo, hi, arena);
@@ -157,7 +155,7 @@ inline Hdf5LoadStatus LoadHdf5TableParallel(const std::string& filePath,
   if (myRank == root) {
     header[0] = localTable.nd;
     for (int dim = 0; dim < 5; ++dim) {
-      header[1 + dim] = localTable.extents[dim];
+      header[1 + dim] = localTable.layout.n[dim];
     }
   }
   amrex::ParallelDescriptor::Bcast(header, 6, root);
@@ -185,7 +183,7 @@ inline Hdf5LoadStatus LoadHdf5TableParallel(const std::string& filePath,
   amrex::ParallelDescriptor::Bcast(axisCounts, 5, root);
   amrex::ParallelDescriptor::Bcast(axisScales, 5, root);
 
-  const std::size_t totalSize = detail::ComputeTotalSize(nd, extents);
+  const std::size_t totalSize = detail::ComputeTotalSize(nd, extents.data());
   if (totalSize > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
     return Hdf5LoadStatus::IncompatibleDatasetExtent;
   }
@@ -193,15 +191,14 @@ inline Hdf5LoadStatus LoadHdf5TableParallel(const std::string& filePath,
   if (myRank != root) {
     output = Hdf5Table{};
     output.nd = nd;
-    output.extents = extents;
     bool overflow = false;
     const amrex::Array<int, 4> lo{{0, 0, 0, 0}};
-    const amrex::Array<int, 4> hi = detail::MakeHiArray(nd, output.extents, overflow);
+    const amrex::Array<int, 4> hi = detail::MakeHiArray(nd, extents.data(), overflow);
     if (overflow || totalSize == 0) {
       return Hdf5LoadStatus::IncompatibleDatasetExtent;
     }
     output.values.resize(lo, hi, amrex::The_Pinned_Arena());
-    output.layout = MakeLayout(output.extents.data(), output.nd);
+    output.layout = MakeLayout(extents.data(), output.nd);
     for (int dim = 0; dim < 5; ++dim) {
       amrex::Vector<double>& storage = output.axisStorage[dim];
       storage.resize(static_cast<std::size_t>(axisCounts[dim]));

--- a/src/Hdf5Types.hpp
+++ b/src/Hdf5Types.hpp
@@ -62,7 +62,6 @@ struct TableDevice {
 
 struct Hdf5Table {
   int nd = 0;
-  std::array<int, 5> extents{{1, 1, 1, 1, 1}};
   Layout layout{};
   Axis axes[5]{};
   amrex::TableData<double, 4> values{};

--- a/src/Layout.hpp
+++ b/src/Layout.hpp
@@ -4,6 +4,8 @@
 #include <AMReX_Extension.H>
 #include <cstddef>
 
+#include "AxisTypes.hpp"
+
 namespace WeakLibReader {
 
 struct Layout {
@@ -69,6 +71,16 @@ Layout MakeLayout(const int* extents, int nd) noexcept
     stride *= static_cast<std::size_t>(extents[dim]);
   }
   return layout;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+Layout MakeLayoutFromAxes(const Axis* axes, int nd) noexcept
+{
+  int extents[5] = {1, 1, 1, 1, 1};
+  for (int dim = 0; dim < nd; ++dim) {
+    extents[dim] = axes[dim].n;
+  }
+  return MakeLayout(extents, nd);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/src/detail/Hdf5LoaderDetail.hpp
+++ b/src/detail/Hdf5LoaderDetail.hpp
@@ -2,7 +2,6 @@
 
 #include <AMReX_Vector.H>
 
-#include <array>
 #include <cctype>
 #include <cstring>
 #include <limits>
@@ -133,7 +132,7 @@ inline bool ValidateAxis(const amrex::Vector<double>& values, AxisScale scale)
   return true;
 }
 
-inline amrex::Array<int, 4> MakeHiArray(int nd, const std::array<int, 5>& extents,
+inline amrex::Array<int, 4> MakeHiArray(int nd, const int* extents,
                                         bool& overflow) noexcept
 {
   amrex::Array<int, 4> hi{{0, 0, 0, 0}};
@@ -160,7 +159,7 @@ inline amrex::Array<int, 4> MakeHiArray(int nd, const std::array<int, 5>& extent
   return hi;
 }
 
-inline std::size_t ComputeTotalSize(int nd, const std::array<int, 5>& extents)
+inline std::size_t ComputeTotalSize(int nd, const int* extents)
 {
   std::size_t size = 1;
   const std::size_t maxSize = std::numeric_limits<std::size_t>::max();
@@ -179,6 +178,7 @@ inline std::size_t ComputeTotalSize(int nd, const std::array<int, 5>& extents)
 
 inline Hdf5LoadStatus LoadAxes(hid_t file,
                                int nd,
+                               const int* extents,
                                const Hdf5LoadConfig& cfg,
                                Hdf5Table& table)
 {
@@ -204,7 +204,7 @@ inline Hdf5LoadStatus LoadAxes(hid_t file,
       return Hdf5LoadStatus::AxisReadFailed;
     }
 
-    if (length != static_cast<hsize_t>(table.extents[dim])) {
+    if (length != static_cast<hsize_t>(extents[dim])) {
       return Hdf5LoadStatus::AxisExtentMismatch;
     }
 

--- a/src/detail/LogInterpolateDeriv.hpp
+++ b/src/detail/LogInterpolateDeriv.hpp
@@ -10,37 +10,29 @@ namespace WeakLibReader {
 /// GPU-optimized 3D log-interpolation with derivatives (single point)
 inline int LogInterpolateDifferentiateSingleVariable3DCustomPoint(
     double d, double t, double y,
-    const double* gridD, int nD,
-    const double* gridT, int nT,
-    const double* gridY, int nY,
+    const Axis axes[3],
     const double* data,
     double offset,
     double& interpolant,
     double derivatives[3]) noexcept
 {
   if (data == nullptr ||
-      gridD == nullptr || gridT == nullptr || gridY == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr || axes[2].grid == nullptr) {
     return 1;
   }
 
-  Axis axesLocal[3] = {
-      MakeAxis(gridD, nD, AxisScale::Log10),
-      MakeAxis(gridT, nT, AxisScale::Log10),
-      MakeAxis(gridY, nY, AxisScale::Linear)};
-  int extents[3] = {nD, nT, nY};
-  const Layout layout = MakeLayout(extents, 3);
+  constexpr int ND = 3;
+  const Layout layout = MakeLayoutFromAxes(axes, ND);
 
   detail::LogInterpolateDifferentiateSingleVariable3DCustomPointImpl(
-      d, t, y, data, layout, axesLocal, offset, interpolant, derivatives);
+      d, t, y, data, layout, axes, offset, interpolant, derivatives);
   return 0;
 }
 
 /// GPU-optimized 3D log-interpolation with derivatives (batch)
 inline int LogInterpolateDifferentiateSingleVariable3DCustom(
     const double* d, const double* t, const double* y, std::size_t count,
-    const double* gridD, int nD,
-    const double* gridT, int nT,
-    const double* gridY, int nY,
+    const Axis axes[3],
     const double* data,
     double offset,
     double* interpolants,
@@ -48,23 +40,19 @@ inline int LogInterpolateDifferentiateSingleVariable3DCustom(
 {
   if (d == nullptr || t == nullptr || y == nullptr ||
       data == nullptr || interpolants == nullptr || derivatives == nullptr ||
-      gridD == nullptr || gridT == nullptr || gridY == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr || axes[2].grid == nullptr) {
     return 1;
   }
 
-  Axis axesLocal[3] = {
-      MakeAxis(gridD, nD, AxisScale::Log10),
-      MakeAxis(gridT, nT, AxisScale::Log10),
-      MakeAxis(gridY, nY, AxisScale::Linear)};
-  int extents[3] = {nD, nT, nY};
-  const Layout layout = MakeLayout(extents, 3);
+  constexpr int ND = 3;
+  const Layout layout = MakeLayoutFromAxes(axes, ND);
 
   for (std::size_t i = 0; i < count; ++i) {
     double deriv[3] = {0.0, 0.0, 0.0};
     double interp = 0.0;
     detail::LogInterpolateDifferentiateSingleVariable3DCustomPointImpl(
         d[i], t[i], y[i],
-        data, layout, axesLocal,
+        data, layout, axes,
         offset, interp, deriv);
     interpolants[i] = interp;
     derivatives[i * 3 + 0] = deriv[0];
@@ -77,9 +65,7 @@ inline int LogInterpolateDifferentiateSingleVariable3DCustom(
 inline int LogInterpolateDifferentiateSingleVariable2D2DCustomPoint(
     const double* logE, std::size_t sizeE,
     double logT, double logX,
-    const double* gridE, int nE,
-    const double* gridT, int nT,
-    const double* gridX, int nX,
+    const Axis axes[3],
     const double* data,
     double offset,
     double* interpolantPlane,
@@ -88,30 +74,26 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustomPoint(
 {
   if (logE == nullptr || data == nullptr ||
       interpolantPlane == nullptr || derivativeTPlane == nullptr || derivativeXPlane == nullptr ||
-      gridE == nullptr || gridT == nullptr || gridX == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr || axes[2].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0) {
     return 0;
   }
 
-  Axis axes[4] = {
-      MakeAxis(gridE, nE, AxisScale::Linear),
-      MakeAxis(gridE, nE, AxisScale::Linear),
-      MakeAxis(gridT, nT, AxisScale::Linear),
-      MakeAxis(gridX, nX, AxisScale::Linear)};
-  int extents[4] = {nE, nE, nT, nX};
-  const Layout layout = MakeLayout(extents, 4);
+  constexpr int ND = 4;
+  Axis internalAxes[ND] = {axes[0], axes[0], axes[1], axes[2]};
+  const Layout layout = MakeLayoutFromAxes(internalAxes, ND);
 
   int idxT = 0;
   int idxX = 0;
   double fracT = 0.0;
   double fracX = 0.0;
-  detail::IndexAndDelta(axes[2], logT, idxT, fracT);
-  detail::IndexAndDelta(axes[3], logX, idxX, fracX);
+  detail::IndexAndDelta(axes[1], logT, idxT, fracT);
+  detail::IndexAndDelta(axes[2], logX, idxX, fracX);
 
-  const double spanT = axes[2].grid[idxT + 1] - axes[2].grid[idxT];
-  const double spanX = axes[3].grid[idxX + 1] - axes[3].grid[idxX];
+  const double spanT = axes[1].grid[idxT + 1] - axes[1].grid[idxT];
+  const double spanX = axes[2].grid[idxX + 1] - axes[2].grid[idxX];
 
   const double aT = 1.0 / (spanT * math::Pow10(logT));
   const double aX = 1.0 / (spanX * math::Pow10(logX));
@@ -119,7 +101,7 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustomPoint(
   for (std::size_t j = 0; j < sizeE; ++j) {
     int idxE2 = 0;
     double fracE2 = 0.0;
-    detail::IndexAndDelta(axes[1], logE[j], idxE2, fracE2);
+    detail::IndexAndDelta(axes[0], logE[j], idxE2, fracE2);
 
     for (std::size_t i = 0; i <= j; ++i) {
       int idxE1 = 0;
@@ -151,9 +133,7 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustomPoint(
 inline int LogInterpolateDifferentiateSingleVariable2D2DCustom(
     const double* logE, std::size_t sizeE,
     const double* logT, const double* logX, std::size_t count,
-    const double* gridE, int nE,
-    const double* gridT, int nT,
-    const double* gridX, int nX,
+    const Axis axes[3],
     const double* data,
     double offset,
     double* interpolant,
@@ -163,7 +143,7 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustom(
   if (logE == nullptr || logT == nullptr || logX == nullptr ||
       data == nullptr || interpolant == nullptr ||
       derivativeT == nullptr || derivativeX == nullptr ||
-      gridE == nullptr || gridT == nullptr || gridX == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr || axes[2].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0 || count == 0) {
@@ -178,9 +158,7 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustom(
     const int rc = LogInterpolateDifferentiateSingleVariable2D2DCustomPoint(
         logE, sizeE,
         logT[l], logX[l],
-        gridE, nE,
-        gridT, nT,
-        gridX, nX,
+        axes,
         data, offset,
         planeInterp, planeDerivT, planeDerivX);
     if (rc != 0) {
@@ -194,8 +172,7 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustom(
 inline int LogInterpolateDifferentiateSingleVariable2D2DCustomAlignedPoint(
     std::size_t sizeE,
     double logT, double logX,
-    const double* gridT, int nT,
-    const double* gridX, int nX,
+    const Axis axes[2],
     const double* data,
     double offset,
     double* interpolantPlane,
@@ -203,22 +180,18 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustomAlignedPoint(
     double* derivativeXPlane) noexcept
 {
   if (data == nullptr || interpolantPlane == nullptr ||
-      derivativeTPlane == nullptr || derivativeXPlane == nullptr ||
-      gridT == nullptr || gridX == nullptr) {
+      derivativeTPlane == nullptr || derivativeXPlane == nullptr) {
     return 1;
   }
   if (sizeE == 0) {
     return 0;
   }
 
-  Axis axes[2] = {
-      MakeAxis(gridT, nT, AxisScale::Linear),
-      MakeAxis(gridX, nX, AxisScale::Linear)};
   int extents[4] = {
       static_cast<int>(sizeE),
       static_cast<int>(sizeE),
-      nT,
-      nX};
+      axes[0].n,
+      axes[1].n};
   const Layout layout = MakeLayout(extents, 4);
 
   int idxT = 0;
@@ -261,8 +234,7 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustomAlignedPoint(
 inline int LogInterpolateDifferentiateSingleVariable2D2DCustomAligned(
     std::size_t sizeE,
     const double* logT, const double* logX, std::size_t count,
-    const double* gridT, int nT,
-    const double* gridX, int nX,
+    const Axis axes[2],
     const double* data,
     double offset,
     double* interpolant,
@@ -271,8 +243,7 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustomAligned(
 {
   if (logT == nullptr || logX == nullptr ||
       data == nullptr || interpolant == nullptr ||
-      derivativeT == nullptr || derivativeX == nullptr ||
-      gridT == nullptr || gridX == nullptr) {
+      derivativeT == nullptr || derivativeX == nullptr) {
     return 1;
   }
   if (sizeE == 0 || count == 0) {
@@ -286,7 +257,7 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustomAligned(
     double* planeDerivX = derivativeX + k * planeSize;
     const int rc = LogInterpolateDifferentiateSingleVariable2D2DCustomAlignedPoint(
         sizeE, logT[k], logX[k],
-        gridT, nT, gridX, nX,
+        axes,
         data, offset,
         planeInterp, planeDerivT, planeDerivX);
     if (rc != 0) {

--- a/src/detail/LogInterpolatePoint.hpp
+++ b/src/detail/LogInterpolatePoint.hpp
@@ -13,23 +13,16 @@ namespace WeakLibReader {
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 double LogInterpolateSingleVariable2DCustomPoint(
     double x0, double x1,
-    const double* grid0, int n0,
-    const double* grid1, int n1,
+    const Axis axes[2],
     const double* data,
     double offset) noexcept
 {
-  if (data == nullptr || grid0 == nullptr || grid1 == nullptr) {
+  if (data == nullptr || axes[0].grid == nullptr || axes[1].grid == nullptr) {
     return std::numeric_limits<double>::quiet_NaN();
   }
-  // Compile-time known dimensionality (eliminates runtime branching!)
   constexpr int ND = 2;
-  Axis axes[ND] = {
-      MakeAxis(grid0, n0, AxisScale::Linear),
-      MakeAxis(grid1, n1, AxisScale::Linear)};
-  int extents[ND] = {n0, n1};
-  const Layout layout = MakeLayout(extents, ND);
+  const Layout layout = MakeLayoutFromAxes(axes, ND);
   double coords[ND] = {x0, x1};
-  // Template parameter known at compile time - zero branching!
   return detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
 }
 
@@ -37,22 +30,17 @@ double LogInterpolateSingleVariable2DCustomPoint(
 /// Uses compile-time dimensionality for zero runtime branching
 inline int LogInterpolateSingleVariable2DCustom(
     const double* x0, const double* x1, std::size_t count,
-    const double* grid0, int n0,
-    const double* grid1, int n1,
+    const Axis axes[2],
     const double* data,
     double offset,
     double* out) noexcept
 {
   if (x0 == nullptr || x1 == nullptr || out == nullptr ||
-      data == nullptr || grid0 == nullptr || grid1 == nullptr) {
+      data == nullptr || axes[0].grid == nullptr || axes[1].grid == nullptr) {
     return 1;
   }
   constexpr int ND = 2;
-  Axis axes[ND] = {
-      MakeAxis(grid0, n0, AxisScale::Linear),
-      MakeAxis(grid1, n1, AxisScale::Linear)};
-  int extents[ND] = {n0, n1};
-  const Layout layout = MakeLayout(extents, ND);
+  const Layout layout = MakeLayoutFromAxes(axes, ND);
   for (std::size_t i = 0; i < count; ++i) {
     double coords[ND] = {x0[i], x1[i]};
     out[i] = detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
@@ -65,22 +53,16 @@ inline int LogInterpolateSingleVariable2DCustom(
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 double LogInterpolateSingleVariable3DCustomPoint(
     double x0, double x1, double x2,
-    const double* grid0, int n0,
-    const double* grid1, int n1,
-    const double* grid2, int n2,
+    const Axis axes[3],
     const double* data,
     double offset) noexcept
 {
-  if (data == nullptr || grid0 == nullptr || grid1 == nullptr || grid2 == nullptr) {
+  if (data == nullptr ||
+      axes[0].grid == nullptr || axes[1].grid == nullptr || axes[2].grid == nullptr) {
     return std::numeric_limits<double>::quiet_NaN();
   }
   constexpr int ND = 3;
-  Axis axes[ND] = {
-      MakeAxis(grid0, n0, AxisScale::Log10),
-      MakeAxis(grid1, n1, AxisScale::Log10),
-      MakeAxis(grid2, n2, AxisScale::Linear)};
-  int extents[ND] = {n0, n1, n2};
-  const Layout layout = MakeLayout(extents, ND);
+  const Layout layout = MakeLayoutFromAxes(axes, ND);
   double coords[ND] = {x0, x1, x2};
   return detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
 }
@@ -89,25 +71,18 @@ double LogInterpolateSingleVariable3DCustomPoint(
 /// Uses compile-time dimensionality for zero runtime branching
 inline int LogInterpolateSingleVariable3DCustom(
     const double* x0, const double* x1, const double* x2, std::size_t count,
-    const double* grid0, int n0,
-    const double* grid1, int n1,
-    const double* grid2, int n2,
+    const Axis axes[3],
     const double* data,
     double offset,
     double* out) noexcept
 {
   if (x0 == nullptr || x1 == nullptr || x2 == nullptr ||
       out == nullptr || data == nullptr ||
-      grid0 == nullptr || grid1 == nullptr || grid2 == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr || axes[2].grid == nullptr) {
     return 1;
   }
   constexpr int ND = 3;
-  Axis axes[ND] = {
-      MakeAxis(grid0, n0, AxisScale::Log10),
-      MakeAxis(grid1, n1, AxisScale::Log10),
-      MakeAxis(grid2, n2, AxisScale::Linear)};
-  int extents[ND] = {n0, n1, n2};
-  const Layout layout = MakeLayout(extents, ND);
+  const Layout layout = MakeLayoutFromAxes(axes, ND);
   for (std::size_t i = 0; i < count; ++i) {
     double coords[ND] = {x0[i], x1[i], x2[i]};
     out[i] = detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
@@ -120,25 +95,17 @@ inline int LogInterpolateSingleVariable3DCustom(
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 double LogInterpolateSingleVariable4DCustomPoint(
     double x0, double x1, double x2, double x3,
-    const double* grid0, int n0,
-    const double* grid1, int n1,
-    const double* grid2, int n2,
-    const double* grid3, int n3,
+    const Axis axes[4],
     const double* data,
     double offset) noexcept
 {
-  if (data == nullptr || grid0 == nullptr || grid1 == nullptr ||
-      grid2 == nullptr || grid3 == nullptr) {
+  if (data == nullptr ||
+      axes[0].grid == nullptr || axes[1].grid == nullptr ||
+      axes[2].grid == nullptr || axes[3].grid == nullptr) {
     return std::numeric_limits<double>::quiet_NaN();
   }
   constexpr int ND = 4;
-  Axis axes[ND] = {
-      MakeAxis(grid0, n0, AxisScale::Linear),
-      MakeAxis(grid1, n1, AxisScale::Linear),
-      MakeAxis(grid2, n2, AxisScale::Linear),
-      MakeAxis(grid3, n3, AxisScale::Linear)};
-  int extents[ND] = {n0, n1, n2, n3};
-  const Layout layout = MakeLayout(extents, ND);
+  const Layout layout = MakeLayoutFromAxes(axes, ND);
   double coords[ND] = {x0, x1, x2, x3};
   return detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
 }
@@ -148,27 +115,19 @@ double LogInterpolateSingleVariable4DCustomPoint(
 inline int LogInterpolateSingleVariable4DCustom(
     const double* x0, const double* x1, const double* x2, const double* x3,
     std::size_t count,
-    const double* grid0, int n0,
-    const double* grid1, int n1,
-    const double* grid2, int n2,
-    const double* grid3, int n3,
+    const Axis axes[4],
     const double* data,
     double offset,
     double* out) noexcept
 {
   if (x0 == nullptr || x1 == nullptr || x2 == nullptr || x3 == nullptr ||
       out == nullptr || data == nullptr ||
-      grid0 == nullptr || grid1 == nullptr || grid2 == nullptr || grid3 == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr ||
+      axes[2].grid == nullptr || axes[3].grid == nullptr) {
     return 1;
   }
   constexpr int ND = 4;
-  Axis axes[ND] = {
-      MakeAxis(grid0, n0, AxisScale::Linear),
-      MakeAxis(grid1, n1, AxisScale::Linear),
-      MakeAxis(grid2, n2, AxisScale::Linear),
-      MakeAxis(grid3, n3, AxisScale::Linear)};
-  int extents[ND] = {n0, n1, n2, n3};
-  const Layout layout = MakeLayout(extents, ND);
+  const Layout layout = MakeLayoutFromAxes(axes, ND);
   for (std::size_t i = 0; i < count; ++i) {
     double coords[ND] = {x0[i], x1[i], x2[i], x3[i]};
     out[i] = detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);

--- a/src/detail/LogInterpolateSum.hpp
+++ b/src/detail/LogInterpolateSum.hpp
@@ -12,30 +12,25 @@ inline int SumLogInterpolateSingleVariable2D2DCustomAligned(
     std::size_t sizeE,
     const double* logD, std::size_t nAlpha,
     const double* logT, std::size_t count,
-    const double* gridD, int nD,
-    const double* gridT, int nT,
+    const Axis axes[2],
     const double* alpha,
     const double* data,
     double offset,
     double* out) noexcept
 {
   if (logD == nullptr || logT == nullptr || data == nullptr ||
-      alpha == nullptr || out == nullptr ||
-      gridD == nullptr || gridT == nullptr) {
+      alpha == nullptr || out == nullptr) {
     return 1;
   }
   if (sizeE == 0 || nAlpha == 0 || count == 0) {
     return 0;
   }
 
-  Axis axes[2] = {
-      MakeAxis(gridD, nD, AxisScale::Linear),
-      MakeAxis(gridT, nT, AxisScale::Linear)};
   int extents[4] = {
       static_cast<int>(sizeE),
       static_cast<int>(sizeE),
-      nD,
-      nT};
+      axes[0].n,
+      axes[1].n};
   const Layout layout = MakeLayout(extents, 4);
 
   const std::size_t planeSize = sizeE * sizeE;

--- a/src/detail/LogInterpolateSweep.hpp
+++ b/src/detail/LogInterpolateSweep.hpp
@@ -11,16 +11,14 @@ namespace WeakLibReader {
 inline int LogInterpolateSingleVariable1D3DCustomPoint(
     const double* logE, std::size_t sizeE,
     double logD, double logT, double y,
-    const double* gridE, int nE,
-    const double* gridD, int nD,
-    const double* gridT, int nT,
-    const double* gridY, int nY,
+    const Axis axes[4],
     const double* data,
     double offset,
     double* out) noexcept
 {
   if (logE == nullptr || out == nullptr || data == nullptr ||
-      gridE == nullptr || gridD == nullptr || gridT == nullptr || gridY == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr ||
+      axes[2].grid == nullptr || axes[3].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0) {
@@ -28,13 +26,7 @@ inline int LogInterpolateSingleVariable1D3DCustomPoint(
   }
 
   constexpr int ND = 4;
-  Axis axes[ND] = {
-      MakeAxis(gridE, nE, AxisScale::Linear),
-      MakeAxis(gridD, nD, AxisScale::Linear),
-      MakeAxis(gridT, nT, AxisScale::Linear),
-      MakeAxis(gridY, nY, AxisScale::Linear)};
-  int extents[ND] = {nE, nD, nT, nY};
-  const Layout layout = MakeLayout(extents, ND);
+  const Layout layout = MakeLayoutFromAxes(axes, ND);
 
   for (std::size_t i = 0; i < sizeE; ++i) {
     double coords[ND] = {logE[i], logD, logT, y};
@@ -48,17 +40,15 @@ inline int LogInterpolateSingleVariable1D3DCustomPoint(
 inline int LogInterpolateSingleVariable1D3DCustom(
     const double* logE, std::size_t sizeE,
     const double* logD, const double* logT, const double* y, std::size_t count,
-    const double* gridE, int nE,
-    const double* gridD, int nD,
-    const double* gridT, int nT,
-    const double* gridY, int nY,
+    const Axis axes[4],
     const double* data,
     double offset,
     double* out) noexcept
 {
   if (logE == nullptr || logD == nullptr || logT == nullptr || y == nullptr ||
       out == nullptr || data == nullptr ||
-      gridE == nullptr || gridD == nullptr || gridT == nullptr || gridY == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr ||
+      axes[2].grid == nullptr || axes[3].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0 || count == 0) {
@@ -66,13 +56,7 @@ inline int LogInterpolateSingleVariable1D3DCustom(
   }
 
   constexpr int ND = 4;
-  Axis axes[ND] = {
-      MakeAxis(gridE, nE, AxisScale::Linear),
-      MakeAxis(gridD, nD, AxisScale::Linear),
-      MakeAxis(gridT, nT, AxisScale::Linear),
-      MakeAxis(gridY, nY, AxisScale::Linear)};
-  int extents[ND] = {nE, nD, nT, nY};
-  const Layout layout = MakeLayout(extents, ND);
+  const Layout layout = MakeLayoutFromAxes(axes, ND);
 
   for (std::size_t j = 0; j < count; ++j) {
     double* row = out + j * sizeE;
@@ -89,15 +73,13 @@ inline int LogInterpolateSingleVariable1D3DCustom(
 inline int LogInterpolateSingleVariable2D2DCustomPoint(
     const double* logE, std::size_t sizeE,
     double logT, double logX,
-    const double* gridE, int nE,
-    const double* gridT, int nT,
-    const double* gridX, int nX,
+    const Axis axes[3],
     const double* data,
     double offset,
     double* out) noexcept
 {
   if (logE == nullptr || data == nullptr || out == nullptr ||
-      gridE == nullptr || gridT == nullptr || gridX == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr || axes[2].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0) {
@@ -105,18 +87,13 @@ inline int LogInterpolateSingleVariable2D2DCustomPoint(
   }
 
   constexpr int ND = 4;
-  Axis axes[ND] = {
-      MakeAxis(gridE, nE, AxisScale::Linear),
-      MakeAxis(gridE, nE, AxisScale::Linear),
-      MakeAxis(gridT, nT, AxisScale::Linear),
-      MakeAxis(gridX, nX, AxisScale::Linear)};
-  int extents[ND] = {nE, nE, nT, nX};
-  const Layout layout = MakeLayout(extents, ND);
+  Axis internalAxes[ND] = {axes[0], axes[0], axes[1], axes[2]};
+  const Layout layout = MakeLayoutFromAxes(internalAxes, ND);
 
   for (std::size_t j = 0; j < sizeE; ++j) {
     for (std::size_t i = 0; i <= j; ++i) {
       double coords[ND] = {logE[i], logE[j], logT, logX};
-      const double value = detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
+      const double value = detail::LogInterpolatedValueDirect<ND>(data, layout, internalAxes, coords, offset);
       detail::StoreSymmetric(out, sizeE, i, j, value);
     }
   }
@@ -128,16 +105,14 @@ inline int LogInterpolateSingleVariable2D2DCustomPoint(
 inline int LogInterpolateSingleVariable2D2DCustom(
     const double* logE, std::size_t sizeE,
     const double* logT, const double* logX, std::size_t count,
-    const double* gridE, int nE,
-    const double* gridT, int nT,
-    const double* gridX, int nX,
+    const Axis axes[3],
     const double* data,
     double offset,
     double* out) noexcept
 {
   if (logE == nullptr || logT == nullptr || logX == nullptr ||
       out == nullptr || data == nullptr ||
-      gridE == nullptr || gridT == nullptr || gridX == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr || axes[2].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0 || count == 0) {
@@ -145,13 +120,8 @@ inline int LogInterpolateSingleVariable2D2DCustom(
   }
 
   constexpr int ND = 4;
-  Axis axes[ND] = {
-      MakeAxis(gridE, nE, AxisScale::Linear),
-      MakeAxis(gridE, nE, AxisScale::Linear),
-      MakeAxis(gridT, nT, AxisScale::Linear),
-      MakeAxis(gridX, nX, AxisScale::Linear)};
-  int extents[ND] = {nE, nE, nT, nX};
-  const Layout layout = MakeLayout(extents, ND);
+  Axis internalAxes[ND] = {axes[0], axes[0], axes[1], axes[2]};
+  const Layout layout = MakeLayoutFromAxes(internalAxes, ND);
 
   const std::size_t planeSize = sizeE * sizeE;
   for (std::size_t l = 0; l < count; ++l) {
@@ -159,7 +129,7 @@ inline int LogInterpolateSingleVariable2D2DCustom(
     for (std::size_t j = 0; j < sizeE; ++j) {
       for (std::size_t i = 0; i <= j; ++i) {
         double coords[ND] = {logE[i], logE[j], logT[l], logX[l]};
-        const double value = detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
+        const double value = detail::LogInterpolatedValueDirect<ND>(data, layout, internalAxes, coords, offset);
         detail::StoreSymmetric(plane, sizeE, i, j, value);
       }
     }
@@ -171,8 +141,7 @@ inline int LogInterpolateSingleVariable2D2DCustom(
 inline int LogInterpolateSingleVariable2D2DCustomAlignedPoint(
     std::size_t sizeE,
     double logT, double logX,
-    const double* gridT, int nT,
-    const double* gridX, int nX,
+    const Axis axes[2],
     const double* data,
     double offset,
     double* out) noexcept
@@ -184,14 +153,11 @@ inline int LogInterpolateSingleVariable2D2DCustomAlignedPoint(
     return 0;
   }
 
-  Axis axes[2] = {
-      MakeAxis(gridT, nT, AxisScale::Linear),
-      MakeAxis(gridX, nX, AxisScale::Linear)};
   int extents[4] = {
       static_cast<int>(sizeE),
       static_cast<int>(sizeE),
-      nT,
-      nX};
+      axes[0].n,
+      axes[1].n};
   const Layout layout = MakeLayout(extents, 4);
 
   int idxT = 0;
@@ -217,14 +183,12 @@ inline int LogInterpolateSingleVariable2D2DCustomAlignedPoint(
 inline int LogInterpolateSingleVariable2D2DCustomAligned(
     std::size_t sizeE,
     const double* logT, const double* logX, std::size_t count,
-    const double* gridT, int nT,
-    const double* gridX, int nX,
+    const Axis axes[2],
     const double* data,
     double offset,
     double* out) noexcept
 {
-  if (logT == nullptr || logX == nullptr || data == nullptr || out == nullptr ||
-      gridT == nullptr || gridX == nullptr) {
+  if (logT == nullptr || logX == nullptr || data == nullptr || out == nullptr) {
     return 1;
   }
   if (sizeE == 0 || count == 0) {
@@ -236,7 +200,7 @@ inline int LogInterpolateSingleVariable2D2DCustomAligned(
     double* plane = out + k * planeSize;
     const int rc = LogInterpolateSingleVariable2D2DCustomAlignedPoint(
         sizeE, logT[k], logX[k],
-        gridT, nT, gridX, nX,
+        axes,
         data, offset, plane);
     if (rc != 0) {
       return rc;

--- a/test/test_hdf5_loader.cpp
+++ b/test/test_hdf5_loader.cpp
@@ -135,10 +135,6 @@ TEST_CASE("HDF5 loader reads table and axes", "[hdf5][loader]")
   REQUIRE(status == WeakLibReader::Hdf5LoadStatus::Success);
   REQUIRE(table.nd == 3);
 
-  CHECK(table.extents[0] == 2);
-  CHECK(table.extents[1] == 3);
-  CHECK(table.extents[2] == 4);
-
   const WeakLibReader::Layout& layout = table.layout;
   CHECK(layout.nd == 3);
   CHECK(layout.n[0] == 2);
@@ -171,7 +167,7 @@ TEST_CASE("HDF5 loader reads table and axes", "[hdf5][loader]")
   const amrex::Array<int, 4> lo{{0, 0, 0, 0}};
   bool overflow = false;
   const amrex::Array<int, 4> hi =
-      WeakLibReader::detail::MakeHiArray(table.nd, table.extents, overflow);
+      WeakLibReader::detail::MakeHiArray(table.nd, table.layout.n, overflow);
   REQUIRE_FALSE(overflow);
   roundtrip.resize(lo, hi, amrex::The_Pinned_Arena());
   roundtrip.copy(deviceTable.values);
@@ -180,7 +176,7 @@ TEST_CASE("HDF5 loader reads table and axes", "[hdf5][loader]")
   const double* roundtripPtr = roundtrip.const_table().p;
   std::size_t total = 1;
   for (int dim = 0; dim < table.nd; ++dim) {
-    total *= static_cast<std::size_t>(table.extents[dim]);
+    total *= static_cast<std::size_t>(table.layout.n[dim]);
   }
   for (std::size_t i = 0; i < total; ++i) {
     CHECK(roundtripPtr[i] == Catch::Approx(originalPtr[i]).margin(kTol));
@@ -575,13 +571,6 @@ TEST_CASE("HDF5 loader handles 5D tables correctly", "[hdf5][loader][5d]")
   REQUIRE(status == WeakLibReader::Hdf5LoadStatus::Success);
   REQUIRE(table.nd == 5);
 
-  // Verify extents (C-order)
-  CHECK(table.extents[0] == 2);
-  CHECK(table.extents[1] == 3);
-  CHECK(table.extents[2] == 4);
-  CHECK(table.extents[3] == 5);
-  CHECK(table.extents[4] == 6);
-
   // Verify layout
   CHECK(table.layout.nd == 5);
   CHECK(table.layout.n[0] == 2);
@@ -614,7 +603,7 @@ TEST_CASE("HDF5 loader handles 5D tables correctly", "[hdf5][loader][5d]")
   const amrex::Array<int, 4> lo{{0, 0, 0, 0}};
   bool overflow = false;
   const amrex::Array<int, 4> hi =
-      WeakLibReader::detail::MakeHiArray(table.nd, table.extents, overflow);
+      WeakLibReader::detail::MakeHiArray(table.nd, table.layout.n, overflow);
   REQUIRE_FALSE(overflow);
   roundtrip.resize(lo, hi, amrex::The_Pinned_Arena());
   roundtrip.copy(deviceTable.values);

--- a/test/test_log_interpolate_2d.cpp
+++ b/test/test_log_interpolate_2d.cpp
@@ -27,10 +27,7 @@ TEST_CASE("2D log interpolation matches bilinear expectation", "[loginterp][2d]"
       std::log10(4.0),
       std::log10(5.0)};
 
-  const int extents[2] = {2, 2};
-  const Layout layout = MakeLayout(extents, 2);
-
-  Axis axes[2] = {
+  const Axis axes[2] = {
       MakeAxis(gridX.data(), 2, AxisScale::Linear),
       MakeAxis(gridY.data(), 2, AxisScale::Linear)};
 
@@ -38,8 +35,7 @@ TEST_CASE("2D log interpolation matches bilinear expectation", "[loginterp][2d]"
   const double y = 2.0;
   const double result = LogInterpolateSingleVariable2DCustomPoint(
       x, y,
-      gridX.data(), 2,
-      gridY.data(), 2,
+      axes,
       table.data(), 0.0);
 
   const double dX = (x - gridX[0]) / (gridX[1] - gridX[0]);
@@ -71,10 +67,13 @@ TEST_CASE("Batch 2D log interpolation matches point wrapper", "[loginterp][2d][b
   std::array<double, 3> x1{1.0, 2.0, 3.0};
   std::array<double, 3> out{};
 
+  const Axis axes[2] = {
+      MakeAxis(gridX.data(), 2, AxisScale::Linear),
+      MakeAxis(gridY.data(), 2, AxisScale::Linear)};
+
   const int rc = LogInterpolateSingleVariable2DCustom(
       x0.data(), x1.data(), x0.size(),
-      gridX.data(), 2,
-      gridY.data(), 2,
+      axes,
       table.data(),
       0.0,
       out.data());
@@ -83,8 +82,7 @@ TEST_CASE("Batch 2D log interpolation matches point wrapper", "[loginterp][2d][b
   for (std::size_t i = 0; i < x0.size(); ++i) {
     const double point = LogInterpolateSingleVariable2DCustomPoint(
         x0[i], x1[i],
-        gridX.data(), 2,
-        gridY.data(), 2,
+        axes,
         table.data(),
         0.0);
     CHECK(out[i] == Catch::Approx(point).margin(kTol));

--- a/test/test_log_interpolate_3d.cpp
+++ b/test/test_log_interpolate_3d.cpp
@@ -39,14 +39,17 @@ TEST_CASE("3D log interpolation matches trilinear expectation", "[loginterp][3d]
     }
   }
 
+  const Axis axes[3] = {
+      MakeAxis(gridX.data(), 2, AxisScale::Log10),
+      MakeAxis(gridY.data(), 2, AxisScale::Log10),
+      MakeAxis(gridZ.data(), 2, AxisScale::Linear)};
+
   const double x = 1.5;
   const double y = 2.0;
   const double z = 0.4;
   const double result = LogInterpolateSingleVariable3DCustomPoint(
       x, y, z,
-      gridX.data(), 2,
-      gridY.data(), 2,
-      gridZ.data(), 2,
+      axes,
       table.data(), 0.0);
 
   // Compute expected via trilinear interpolation in log space
@@ -98,6 +101,11 @@ TEST_CASE("Batch 3D log interpolation matches point wrapper", "[loginterp][3d][b
     }
   }
 
+  const Axis axes[3] = {
+      MakeAxis(gridX.data(), 2, AxisScale::Log10),
+      MakeAxis(gridY.data(), 2, AxisScale::Log10),
+      MakeAxis(gridZ.data(), 2, AxisScale::Linear)};
+
   std::array<double, 3> x0{1.0, 1.5, 2.0};
   std::array<double, 3> x1{1.0, 2.0, 3.0};
   std::array<double, 3> x2{0.0, 0.5, 1.0};
@@ -105,9 +113,7 @@ TEST_CASE("Batch 3D log interpolation matches point wrapper", "[loginterp][3d][b
 
   const int rc = LogInterpolateSingleVariable3DCustom(
       x0.data(), x1.data(), x2.data(), x0.size(),
-      gridX.data(), 2,
-      gridY.data(), 2,
-      gridZ.data(), 2,
+      axes,
       table.data(),
       0.0,
       out.data());
@@ -116,9 +122,7 @@ TEST_CASE("Batch 3D log interpolation matches point wrapper", "[loginterp][3d][b
   for (std::size_t i = 0; i < x0.size(); ++i) {
     const double point = LogInterpolateSingleVariable3DCustomPoint(
         x0[i], x1[i], x2[i],
-        gridX.data(), 2,
-        gridY.data(), 2,
-        gridZ.data(), 2,
+        axes,
         table.data(),
         0.0);
     CHECK(out[i] == Catch::Approx(point).margin(kTol));

--- a/test/test_log_interpolate_4d5d.cpp
+++ b/test/test_log_interpolate_4d5d.cpp
@@ -43,24 +43,22 @@ TEST_CASE("4D log interpolation matches quadrilinear expectation", "[loginterp][
     }
   }
 
+  Axis axes[4] = {
+      MakeAxis(gridA.data(), 2, AxisScale::Linear),
+      MakeAxis(gridB.data(), 2, AxisScale::Linear),
+      MakeAxis(gridC.data(), 2, AxisScale::Linear),
+      MakeAxis(gridD.data(), 2, AxisScale::Linear)};
+
   const double a = 1.5;
   const double b = 2.0;
   const double c = 0.4;
   const double d = 7.0;
   const double result = LogInterpolateSingleVariable4DCustomPoint(
       a, b, c, d,
-      gridA.data(), 2,
-      gridB.data(), 2,
-      gridC.data(), 2,
-      gridD.data(), 2,
+      axes,
       table.data(), 0.0);
 
   // Verify by computing via 4D wrapper
-  Axis axes[4] = {
-      MakeAxis(gridA.data(), 2, AxisScale::Linear),
-      MakeAxis(gridB.data(), 2, AxisScale::Linear),
-      MakeAxis(gridC.data(), 2, AxisScale::Linear),
-      MakeAxis(gridD.data(), 2, AxisScale::Linear)};
   double coords[4] = {a, b, c, d};
   const double expected = detail::LogInterpolatedValueDirect<4>(
       table.data(), layout, axes, coords, 0.0);
@@ -98,12 +96,15 @@ TEST_CASE("Batch 4D log interpolation matches point wrapper", "[loginterp][4d][b
   std::array<double, 3> x3{5.0, 7.0, 9.0};
   std::array<double, 3> out{};
 
+  const Axis axes[4] = {
+      MakeAxis(gridA.data(), 2, AxisScale::Linear),
+      MakeAxis(gridB.data(), 2, AxisScale::Linear),
+      MakeAxis(gridC.data(), 2, AxisScale::Linear),
+      MakeAxis(gridD.data(), 2, AxisScale::Linear)};
+
   const int rc = LogInterpolateSingleVariable4DCustom(
       x0.data(), x1.data(), x2.data(), x3.data(), x0.size(),
-      gridA.data(), 2,
-      gridB.data(), 2,
-      gridC.data(), 2,
-      gridD.data(), 2,
+      axes,
       table.data(),
       0.0,
       out.data());
@@ -112,10 +113,7 @@ TEST_CASE("Batch 4D log interpolation matches point wrapper", "[loginterp][4d][b
   for (std::size_t i = 0; i < x0.size(); ++i) {
     const double point = LogInterpolateSingleVariable4DCustomPoint(
         x0[i], x1[i], x2[i], x3[i],
-        gridA.data(), 2,
-        gridB.data(), 2,
-        gridC.data(), 2,
-        gridD.data(), 2,
+        axes,
         table.data(),
         0.0);
     CHECK(out[i] == Catch::Approx(point).margin(kTol));
@@ -438,23 +436,20 @@ TEST_CASE("1D3D sweep batch matches direct interpolation", "[loginterp][4d][batc
   std::array<double, count> y{0.25, 0.75};
   std::array<double, sizeE * count> out{};
 
-  const int rc = LogInterpolateSingleVariable1D3DCustom(
-      logE.data(), sizeE,
-      logD.data(), logT.data(), y.data(), count,
-      gridE.data(), 2,
-      gridD.data(), 2,
-      gridT.data(), 2,
-      gridY.data(), 2,
-      table.data(),
-      0.0,
-      out.data());
-  REQUIRE(rc == 0);
-
   Axis axes[4] = {
       MakeAxis(gridE.data(), 2, AxisScale::Linear),
       MakeAxis(gridD.data(), 2, AxisScale::Linear),
       MakeAxis(gridT.data(), 2, AxisScale::Linear),
       MakeAxis(gridY.data(), 2, AxisScale::Linear)};
+
+  const int rc = LogInterpolateSingleVariable1D3DCustom(
+      logE.data(), sizeE,
+      logD.data(), logT.data(), y.data(), count,
+      axes,
+      table.data(),
+      0.0,
+      out.data());
+  REQUIRE(rc == 0);
 
   for (std::size_t j = 0; j < count; ++j) {
     for (std::size_t i = 0; i < sizeE; ++i) {
@@ -502,14 +497,17 @@ TEST_CASE("1D3D single point matches batch with count=1", "[loginterp][4d][1d3d]
   const double logT = 15.0;
   const double y = 0.5;
 
+  const Axis axes[4] = {
+      MakeAxis(gridE.data(), 2, AxisScale::Linear),
+      MakeAxis(gridD.data(), 2, AxisScale::Linear),
+      MakeAxis(gridT.data(), 2, AxisScale::Linear),
+      MakeAxis(gridY.data(), 2, AxisScale::Linear)};
+
   std::array<double, sizeE> outPoint{};
   const int rcPoint = LogInterpolateSingleVariable1D3DCustomPoint(
       logE.data(), sizeE,
       logD, logT, y,
-      gridE.data(), 2,
-      gridD.data(), 2,
-      gridT.data(), 2,
-      gridY.data(), 2,
+      axes,
       table.data(),
       0.0,
       outPoint.data());
@@ -524,10 +522,7 @@ TEST_CASE("1D3D single point matches batch with count=1", "[loginterp][4d][1d3d]
   const int rcBatch = LogInterpolateSingleVariable1D3DCustom(
       logE.data(), sizeE,
       logDArr.data(), logTArr.data(), yArr.data(), 1,
-      gridE.data(), 2,
-      gridD.data(), 2,
-      gridT.data(), 2,
-      gridY.data(), 2,
+      axes,
       table.data(),
       0.0,
       outBatch.data());

--- a/test/test_log_interpolate_deriv.cpp
+++ b/test/test_log_interpolate_deriv.cpp
@@ -82,9 +82,7 @@ TEST_CASE("Log derivative wrapper matches direct kernel for 3D tables", "[logint
   double deriv[3] = {0.0, 0.0, 0.0};
   const int rc = LogInterpolateDifferentiateSingleVariable3DCustomPoint(
       dCoord, tCoord, yCoord,
-      gridD.data(), 2,
-      gridT.data(), 2,
-      gridY.data(), 2,
+      axes,
       table.data(),
       0.0, interpolated, deriv);
   REQUIRE(rc == 0);
@@ -150,8 +148,7 @@ TEST_CASE("Aligned derivative wrapper mirrors kernel output", "[loginterp][deriv
 
   const int rc = LogInterpolateDifferentiateSingleVariable2D2DCustomAlignedPoint(
       sizeE, logTCoord, logXCoord,
-      gridT.data(), 2,
-      gridX.data(), 2,
+      axes,
       table.data(),
       0.0,
       planeInterp.data(),
@@ -216,14 +213,17 @@ TEST_CASE("Batch 3D derivative matches point version", "[loginterp][3d][derivati
   std::array<double, count> tCoord{10.0, 50.0, 80.0};
   std::array<double, count> yCoord{0.2, 0.5, 0.8};
 
+  const Axis axes[3] = {
+      MakeAxis(gridD.data(), 2, AxisScale::Log10),
+      MakeAxis(gridT.data(), 2, AxisScale::Log10),
+      MakeAxis(gridY.data(), 2, AxisScale::Linear)};
+
   std::array<double, count> interpBatch{};
   std::array<double, count * 3> derivBatch{};
 
   const int rcBatch = LogInterpolateDifferentiateSingleVariable3DCustom(
       dCoord.data(), tCoord.data(), yCoord.data(), count,
-      gridD.data(), 2,
-      gridT.data(), 2,
-      gridY.data(), 2,
+      axes,
       table.data(),
       0.0,
       interpBatch.data(),
@@ -236,9 +236,7 @@ TEST_CASE("Batch 3D derivative matches point version", "[loginterp][3d][derivati
 
     const int rcPoint = LogInterpolateDifferentiateSingleVariable3DCustomPoint(
         dCoord[i], tCoord[i], yCoord[i],
-        gridD.data(), 2,
-        gridT.data(), 2,
-        gridY.data(), 2,
+        axes,
         table.data(),
         0.0,
         interpPoint, derivPoint);
@@ -287,12 +285,15 @@ TEST_CASE("Batch 2D2D derivative matches point version", "[loginterp][2d2d][deri
   std::array<double, planeSize * count> derivTBatch{};
   std::array<double, planeSize * count> derivXBatch{};
 
+  const Axis axes[3] = {
+      MakeAxis(gridE.data(), static_cast<int>(sizeE), AxisScale::Linear),
+      MakeAxis(gridT.data(), 2, AxisScale::Linear),
+      MakeAxis(gridX.data(), 2, AxisScale::Linear)};
+
   const int rcBatch = LogInterpolateDifferentiateSingleVariable2D2DCustom(
       gridE.data(), sizeE,
       logT.data(), logX.data(), count,
-      gridE.data(), static_cast<int>(sizeE),
-      gridT.data(), 2,
-      gridX.data(), 2,
+      axes,
       table.data(),
       0.0,
       interpBatch.data(),
@@ -308,9 +309,7 @@ TEST_CASE("Batch 2D2D derivative matches point version", "[loginterp][2d2d][deri
     const int rcPoint = LogInterpolateDifferentiateSingleVariable2D2DCustomPoint(
         gridE.data(), sizeE,
         logT[k], logX[k],
-        gridE.data(), static_cast<int>(sizeE),
-        gridT.data(), 2,
-        gridX.data(), 2,
+        axes,
         table.data(),
         0.0,
         interpPoint.data(),
@@ -366,11 +365,14 @@ TEST_CASE("Batch aligned 2D2D derivative matches point version", "[loginterp][2d
   std::array<double, planeSize * count> derivTBatch{};
   std::array<double, planeSize * count> derivXBatch{};
 
+  const Axis axes[2] = {
+      MakeAxis(gridT.data(), 2, AxisScale::Linear),
+      MakeAxis(gridX.data(), 2, AxisScale::Linear)};
+
   const int rcBatch = LogInterpolateDifferentiateSingleVariable2D2DCustomAligned(
       sizeE,
       logT.data(), logX.data(), count,
-      gridT.data(), 2,
-      gridX.data(), 2,
+      axes,
       table.data(),
       0.0,
       interpBatch.data(),
@@ -386,8 +388,7 @@ TEST_CASE("Batch aligned 2D2D derivative matches point version", "[loginterp][2d
     const int rcPoint = LogInterpolateDifferentiateSingleVariable2D2DCustomAlignedPoint(
         sizeE,
         logT[k], logX[k],
-        gridT.data(), 2,
-        gridX.data(), 2,
+        axes,
         table.data(),
         0.0,
         interpPoint.data(),

--- a/test/test_log_interpolate_sweep.cpp
+++ b/test/test_log_interpolate_sweep.cpp
@@ -53,8 +53,7 @@ TEST_CASE("Aligned 2D plane interpolation mirrors underlying kernel", "[loginter
 
   const int rc = LogInterpolateSingleVariable2D2DCustomAlignedPoint(
       sizeE, logT, logX,
-      gridT.data(), 2,
-      gridX.data(), 2,
+      axes,
       table.data(), 0.0, plane.data());
   REQUIRE(rc == 0);
 
@@ -125,8 +124,7 @@ TEST_CASE("Weighted sum aligned helper reproduces manual accumulation", "[logint
       sizeE,
       logD.data(), nAlpha,
       logT.data(), count,
-      gridD.data(), 2,
-      gridT.data(), 2,
+      axes,
       alpha.data(),
       table.data(),
       0.0,
@@ -188,17 +186,20 @@ TEST_CASE("Non-aligned 2D2D single point interpolation", "[loginterp][2d2d][nona
   const double logX = 2.0;
   std::array<double, sizeE * sizeE> out{};
 
+  const Axis axes[3] = {
+      MakeAxis(gridE.data(), static_cast<int>(sizeE), AxisScale::Linear),
+      MakeAxis(gridT.data(), 2, AxisScale::Linear),
+      MakeAxis(gridX.data(), 2, AxisScale::Linear)};
+
   const int rc = LogInterpolateSingleVariable2D2DCustomPoint(
       gridE.data(), sizeE, logT, logX,
-      gridE.data(), static_cast<int>(sizeE),
-      gridT.data(), 2,
-      gridX.data(), 2,
+      axes,
       table.data(), 0.0, out.data());
   REQUIRE(rc == 0);
 
   // Verify output against direct 4D interpolation
   // The function uses symmetric storage: out[i,j] = out[j,i] = interp(E[i], E[j], T, X)
-  Axis axes[4] = {
+  Axis internalAxes[4] = {
       MakeAxis(gridE.data(), static_cast<int>(sizeE), AxisScale::Linear),
       MakeAxis(gridE.data(), static_cast<int>(sizeE), AxisScale::Linear),
       MakeAxis(gridT.data(), 2, AxisScale::Linear),
@@ -209,7 +210,7 @@ TEST_CASE("Non-aligned 2D2D single point interpolation", "[loginterp][2d2d][nona
       // For i <= j, coords are (E[i], E[j], T, X)
       double coords[4] = {gridE[i], gridE[j], logT, logX};
       const double expected = detail::LogInterpolatedValueDirect<4>(
-          table.data(), layout, axes, coords, 0.0);
+          table.data(), layout, internalAxes, coords, 0.0);
       // Check both symmetric positions
       const std::size_t lower = j * sizeE + i;
       const std::size_t upper = i * sizeE + j;
@@ -249,12 +250,15 @@ TEST_CASE("Non-aligned 2D2D batch interpolation", "[loginterp][2d2d][nonaligned]
   const std::array<double, count> logX{1.5, 2.5};
   std::array<double, sizeE * sizeE * count> out{};
 
+  const Axis axes[3] = {
+      MakeAxis(gridE.data(), static_cast<int>(sizeE), AxisScale::Linear),
+      MakeAxis(gridT.data(), 2, AxisScale::Linear),
+      MakeAxis(gridX.data(), 2, AxisScale::Linear)};
+
   const int rc = LogInterpolateSingleVariable2D2DCustom(
       gridE.data(), sizeE,
       logT.data(), logX.data(), count,
-      gridE.data(), static_cast<int>(sizeE),
-      gridT.data(), 2,
-      gridX.data(), 2,
+      axes,
       table.data(), 0.0, out.data());
   REQUIRE(rc == 0);
 
@@ -263,9 +267,7 @@ TEST_CASE("Non-aligned 2D2D batch interpolation", "[loginterp][2d2d][nonaligned]
     std::array<double, sizeE * sizeE> plane{};
     const int rcPoint = LogInterpolateSingleVariable2D2DCustomPoint(
         gridE.data(), sizeE, logT[l], logX[l],
-        gridE.data(), static_cast<int>(sizeE),
-        gridT.data(), 2,
-        gridX.data(), 2,
+        axes,
         table.data(), 0.0, plane.data());
     REQUIRE(rcPoint == 0);
 
@@ -306,11 +308,14 @@ TEST_CASE("Batch aligned 2D2D matches point version", "[loginterp][2d2d][aligned
   const std::size_t planeSize = sizeE * sizeE;
   std::array<double, planeSize * count> outBatch{};
 
+  const Axis axes[2] = {
+      MakeAxis(gridT.data(), 2, AxisScale::Linear),
+      MakeAxis(gridX.data(), 2, AxisScale::Linear)};
+
   const int rcBatch = LogInterpolateSingleVariable2D2DCustomAligned(
       sizeE,
       logT.data(), logX.data(), count,
-      gridT.data(), 2,
-      gridX.data(), 2,
+      axes,
       table.data(),
       0.0,
       outBatch.data());
@@ -320,8 +325,7 @@ TEST_CASE("Batch aligned 2D2D matches point version", "[loginterp][2d2d][aligned
     std::array<double, planeSize> outPoint{};
     const int rcPoint = LogInterpolateSingleVariable2D2DCustomAlignedPoint(
         sizeE, logT[k], logX[k],
-        gridT.data(), 2,
-        gridX.data(), 2,
+        axes,
         table.data(),
         0.0,
         outPoint.data());


### PR DESCRIPTION
## Summary
- Replaces individual `grid`, `n`, `AxisScale` parameters with `const Axis[]` in all public interpolation functions (2D/3D/4D point, batch, sweep, derivative, and sum variants), reducing parameter counts and eliminating redundant `MakeAxis` calls inside each function.
- Removes `Hdf5Table::extents` field since `Layout::n` already stores the same information, and updates the HDF5 loader and `MakeDeviceCopy` accordingly.
- Adds `MakeLayoutFromAxes` helper in `Layout.hpp` to construct a `Layout` directly from an `Axis` array.
- Updates detail helpers (`MakeHiArray`, `ComputeTotalSize`, `LoadAxes`) to accept `const int*` instead of `std::array<int,5>`.

## Test plan
- [ ] All existing interpolation tests (2D, 3D, 4D/5D, derivative, sweep) pass with updated Axis-array signatures
- [ ] HDF5 loader tests pass without `extents` field
- [ ] `scripts/check.sh` passes (build + test)