### PR TITLE
Add WeakLib EOS table loader

### DIFF
--- a/src/WeakLibReader_Hdf5Types.hpp
+++ b/src/WeakLibReader_Hdf5Types.hpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <cstdint>
+#include <vector>
 
 #include "WeakLibReader_Layout.hpp"
 #include "WeakLibReader_AxisTypes.hpp"
@@ -24,7 +25,11 @@ enum class Hdf5LoadStatus : std::uint8_t {
   AxisNotMonotone,
   AxisInvalidScale,
   AxisReadFailed,
-  IncompatibleDatasetExtent
+  IncompatibleDatasetExtent,
+  GroupOpenFailed,
+  LogInterpReadFailed,
+  OffsetsReadFailed,
+  VariableCountMismatch
 };
 
 struct Hdf5LoadConfig {
@@ -84,6 +89,100 @@ struct Hdf5Table {
     view.layout = layout;
     view.data = values.const_table().p;
     for (int dim = 0; dim < 5; ++dim) {
+      view.axes[dim] = axes[dim];
+    }
+    return view;
+  }
+};
+
+// WeakLib EOS table variable indices (matching WeakLib convention)
+enum class EosVariable : int {
+  Pressure = 0,
+  EntropyPerBaryon = 1,
+  InternalEnergyDensity = 2,
+  ElectronChemicalPotential = 3,
+  ProtonChemicalPotential = 4,
+  NeutronChemicalPotential = 5,
+  ProtonMassFraction = 6,
+  NeutronMassFraction = 7,
+  AlphaMassFraction = 8,
+  HeavyMassFraction = 9,
+  HeavyChargeNumber = 10,
+  HeavyMassNumber = 11,
+  HeavyBindingEnergy = 12,
+  ThermalEnergy = 13,
+  Gamma1 = 14
+};
+
+constexpr int kEosVariableCount = 15;
+
+// Single WeakLib EOS table (3D: rho, T, Ye)
+struct WeakLibEosTable {
+  static constexpr int nd = 3;
+  Layout layout{};
+  Axis axes[3]{};  // [0]=rho, [1]=T, [2]=Ye
+  std::array<int, 3> extents{{1, 1, 1}};
+
+  // Selected variables (user chooses which to load)
+  std::vector<amrex::TableData<double, 4>> variables{};
+  std::vector<EosVariable> loadedVariables{};
+  std::vector<double> offsets{};
+
+  // Axis backing storage
+  std::array<amrex::Vector<double>, 3> axisStorage{};
+
+  WeakLibEosTable() = default;
+  WeakLibEosTable(WeakLibEosTable&&) = default;
+  WeakLibEosTable& operator=(WeakLibEosTable&&) = default;
+  WeakLibEosTable(const WeakLibEosTable&) = delete;
+  WeakLibEosTable& operator=(const WeakLibEosTable&) = delete;
+
+  [[nodiscard]] double* VariableDataPtr(int idx) noexcept
+  {
+    return variables[static_cast<std::size_t>(idx)].table().p;
+  }
+
+  [[nodiscard]] const double* VariableDataPtr(int idx) const noexcept
+  {
+    return variables[static_cast<std::size_t>(idx)].const_table().p;
+  }
+
+  [[nodiscard]] TableView ViewForVariable(int idx) const noexcept
+  {
+    TableView view{};
+    view.nd = nd;
+    view.layout = layout;
+    view.data = VariableDataPtr(idx);
+    for (int dim = 0; dim < nd; ++dim) {
+      view.axes[dim] = axes[dim];
+    }
+    return view;
+  }
+};
+
+// Device-side copy of WeakLib EOS table
+struct WeakLibEosTableDevice {
+  static constexpr int nd = 3;
+  Layout layout{};
+  Axis axes[3]{};
+
+  std::vector<amrex::TableData<double, 4>> variables{};
+  std::vector<EosVariable> loadedVariables{};
+  std::vector<double> offsets{};
+  std::array<amrex::Gpu::DeviceVector<double>, 3> axisStorage{};
+
+  [[nodiscard]] const double* VariableDataPtr(int idx) const noexcept
+  {
+    return variables[static_cast<std::size_t>(idx)].const_table().p;
+  }
+
+  [[nodiscard]] TableView ViewForVariable(int idx) const noexcept
+  {
+    TableView view{};
+    view.nd = nd;
+    view.layout = layout;
+    view.data = VariableDataPtr(idx);
+    for (int dim = 0; dim < nd; ++dim) {
       view.axes[dim] = axes[dim];
     }
     return view;

--- a/src/WeakLibReader_WeakLibEosLoader.hpp
+++ b/src/WeakLibReader_WeakLibEosLoader.hpp
@@ -1,0 +1,253 @@
+#pragma once
+
+#include <AMReX_Arena.H>
+#include <AMReX_Array.H>
+#include <AMReX_GpuContainers.H>
+#include <AMReX_ParallelDescriptor.H>
+
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "WeakLibReader_Hdf5Types.hpp"
+#include "detail/WeakLibReader_WeakLibEosLoaderDetail.hpp"
+
+namespace WeakLibReader {
+
+struct WeakLibEosLoadConfig {
+  // Variables to load (empty = load all 15 variables)
+  std::vector<EosVariable> variablesToLoad{};
+};
+
+inline Hdf5LoadStatus LoadWeakLibEosTable(const std::string& filePath,
+                                           WeakLibEosTable& output,
+                                           const WeakLibEosLoadConfig& cfg = WeakLibEosLoadConfig{})
+{
+  WeakLibEosTable result;
+
+  detail::ScopedHandle file(H5Fopen(filePath.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT), H5Fclose);
+  if (!file.Valid()) {
+    return Hdf5LoadStatus::FileOpenFailed;
+  }
+
+  // Load axes from /ThermoState group
+  const Hdf5LoadStatus axisStatus = detail::LoadEosAxes(file.Get(), result);
+  if (axisStatus != Hdf5LoadStatus::Success) {
+    return axisStatus;
+  }
+
+  // Load offsets from /DependentVariables/Offsets
+  const Hdf5LoadStatus offsetsStatus = detail::LoadEosOffsets(file.Get(), result.offsets);
+  if (offsetsStatus != Hdf5LoadStatus::Success) {
+    return offsetsStatus;
+  }
+
+  // Determine which variables to load
+  std::vector<EosVariable> varsToLoad;
+  if (cfg.variablesToLoad.empty()) {
+    varsToLoad.reserve(kEosVariableCount);
+    for (int i = 0; i < kEosVariableCount; ++i) {
+      varsToLoad.push_back(static_cast<EosVariable>(i));
+    }
+  } else {
+    varsToLoad = cfg.variablesToLoad;
+  }
+
+  // Load each variable
+  result.loadedVariables = varsToLoad;
+  result.variables.resize(varsToLoad.size());
+  for (std::size_t i = 0; i < varsToLoad.size(); ++i) {
+    const Hdf5LoadStatus varStatus = detail::LoadEosVariable(
+        file.Get(), varsToLoad[i], result.extents, result.variables[i]);
+    if (varStatus != Hdf5LoadStatus::Success) {
+      return varStatus;
+    }
+  }
+
+  // Compute layout
+  std::array<int, 5> extents5{{result.extents[0], result.extents[1], result.extents[2], 1, 1}};
+  result.layout = MakeLayout(extents5.data(), result.nd);
+
+  output = std::move(result);
+  return Hdf5LoadStatus::Success;
+}
+
+inline WeakLibEosTableDevice MakeDeviceCopy(const WeakLibEosTable& host,
+                                             amrex::Arena* arena = amrex::The_Device_Arena())
+{
+  WeakLibEosTableDevice device{};
+  device.layout = host.layout;
+  device.loadedVariables = host.loadedVariables;
+  device.offsets = host.offsets;
+
+  const amrex::Array<int, 4> lo{{0, 0, 0, 0}};
+  const amrex::Array<int, 4> hi{{host.extents[0] - 1, host.extents[1] - 1, host.extents[2] - 1, 0}};
+
+  // Copy all variables
+  device.variables.resize(host.variables.size());
+  for (std::size_t i = 0; i < host.variables.size(); ++i) {
+    device.variables[i].resize(lo, hi, arena);
+    device.variables[i].copy(host.variables[i]);
+  }
+
+  // Copy axes
+  for (int dim = 0; dim < host.nd; ++dim) {
+    const amrex::Vector<double>& hostAxis = host.axisStorage[dim];
+    amrex::Gpu::DeviceVector<double>& deviceAxis = device.axisStorage[dim];
+    deviceAxis.resize(hostAxis.size());
+    if (!hostAxis.empty()) {
+      amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                       hostAxis.begin(), hostAxis.end(),
+                       deviceAxis.begin());
+    }
+    device.axes[dim].grid = deviceAxis.data();
+    device.axes[dim].n = static_cast<int>(deviceAxis.size());
+    device.axes[dim].scale = host.axes[dim].scale;
+  }
+
+  return device;
+}
+
+inline Hdf5LoadStatus LoadWeakLibEosTableParallel(
+    const std::string& filePath,
+    WeakLibEosTable& output,
+    const WeakLibEosLoadConfig& cfg = WeakLibEosLoadConfig{},
+    int readerRank = amrex::ParallelDescriptor::IOProcessorNumber())
+{
+  const int nProcs = amrex::ParallelDescriptor::NProcs();
+  if (nProcs <= 1) {
+    return LoadWeakLibEosTable(filePath, output, cfg);
+  }
+
+  int root = readerRank;
+  if (root < 0 || root >= nProcs) {
+    root = amrex::ParallelDescriptor::IOProcessorNumber();
+  }
+
+  const int myRank = amrex::ParallelDescriptor::MyProc();
+
+  WeakLibEosTable localTable;
+  Hdf5LoadStatus status = Hdf5LoadStatus::Success;
+  if (myRank == root) {
+    status = LoadWeakLibEosTable(filePath, localTable, cfg);
+  }
+
+  int statusInt = static_cast<int>(status);
+  amrex::ParallelDescriptor::Bcast(&statusInt, 1, root);
+  status = static_cast<Hdf5LoadStatus>(statusInt);
+  if (status != Hdf5LoadStatus::Success) {
+    return status;
+  }
+
+  // Broadcast header: nd, extents, numVariables, numOffsets
+  int header[6] = {0, 1, 1, 1, 0, 0};
+  if (myRank == root) {
+    header[0] = localTable.nd;
+    header[1] = localTable.extents[0];
+    header[2] = localTable.extents[1];
+    header[3] = localTable.extents[2];
+    header[4] = static_cast<int>(localTable.loadedVariables.size());
+    header[5] = static_cast<int>(localTable.offsets.size());
+  }
+  amrex::ParallelDescriptor::Bcast(header, 6, root);
+
+  const int numVars = header[4];
+  const int numOffsets = header[5];
+
+  // Broadcast axis counts and scales
+  int axisCounts[3] = {0, 0, 0};
+  int axisScales[3] = {static_cast<int>(AxisScale::Linear),
+                       static_cast<int>(AxisScale::Linear),
+                       static_cast<int>(AxisScale::Linear)};
+  if (myRank == root) {
+    for (int dim = 0; dim < 3; ++dim) {
+      axisCounts[dim] = localTable.axes[dim].n;
+      axisScales[dim] = static_cast<int>(localTable.axes[dim].scale);
+    }
+  }
+  amrex::ParallelDescriptor::Bcast(axisCounts, 3, root);
+  amrex::ParallelDescriptor::Bcast(axisScales, 3, root);
+
+  // Broadcast loaded variable indices
+  std::vector<int> varIndices(static_cast<std::size_t>(numVars));
+  if (myRank == root) {
+    for (std::size_t i = 0; i < localTable.loadedVariables.size(); ++i) {
+      varIndices[i] = static_cast<int>(localTable.loadedVariables[i]);
+    }
+  }
+  if (numVars > 0) {
+    amrex::ParallelDescriptor::Bcast(varIndices.data(), numVars, root);
+  }
+
+  // Allocate on non-root ranks
+  const std::size_t totalSize = static_cast<std::size_t>(header[1]) *
+                                static_cast<std::size_t>(header[2]) *
+                                static_cast<std::size_t>(header[3]);
+
+  if (myRank != root) {
+    output = WeakLibEosTable{};
+    output.extents = {{header[1], header[2], header[3]}};
+
+    std::array<int, 5> extents5{{header[1], header[2], header[3], 1, 1}};
+    output.layout = MakeLayout(extents5.data(), WeakLibEosTable::nd);
+
+    // Allocate axes
+    for (int dim = 0; dim < 3; ++dim) {
+      amrex::Vector<double>& storage = output.axisStorage[dim];
+      storage.resize(static_cast<std::size_t>(axisCounts[dim]));
+      output.axes[dim].grid = storage.empty() ? nullptr : storage.data();
+      output.axes[dim].n = axisCounts[dim];
+      output.axes[dim].scale = static_cast<AxisScale>(axisScales[dim]);
+    }
+
+    // Allocate variables
+    const auto numVarsSize = static_cast<std::size_t>(numVars);
+    output.loadedVariables.resize(numVarsSize);
+    output.variables.resize(numVarsSize);
+    const amrex::Array<int, 4> lo{{0, 0, 0, 0}};
+    const amrex::Array<int, 4> hi{{header[1] - 1, header[2] - 1, header[3] - 1, 0}};
+    for (std::size_t i = 0; i < numVarsSize; ++i) {
+      output.loadedVariables[i] = static_cast<EosVariable>(varIndices[i]);
+      output.variables[i].resize(lo, hi, amrex::The_Pinned_Arena());
+    }
+
+    // Allocate offsets
+    output.offsets.resize(static_cast<std::size_t>(numOffsets));
+  }
+
+  // Broadcast offsets
+  if (numOffsets > 0) {
+    double* offsetPtr = (myRank == root)
+                            ? localTable.offsets.data()
+                            : output.offsets.data();
+    amrex::ParallelDescriptor::Bcast(offsetPtr, numOffsets, root);
+  }
+
+  // Broadcast axes
+  for (int dim = 0; dim < 3; ++dim) {
+    const int count = axisCounts[dim];
+    if (count <= 0) continue;
+    double* axisPtr = (myRank == root)
+                          ? localTable.axisStorage[dim].data()
+                          : output.axisStorage[dim].data();
+    amrex::ParallelDescriptor::Bcast(axisPtr, count, root);
+  }
+
+  // Broadcast variable data
+  for (std::size_t v = 0; v < static_cast<std::size_t>(numVars); ++v) {
+    double* dataPtr = (myRank == root) ? localTable.variables[v].table().p
+                                       : output.variables[v].table().p;
+    if (totalSize > 0) {
+      amrex::ParallelDescriptor::Bcast(dataPtr, static_cast<int>(totalSize), root);
+    }
+  }
+
+  if (myRank == root) {
+    output = std::move(localTable);
+  }
+
+  return status;
+}
+
+} // namespace WeakLibReader

--- a/src/detail/WeakLibReader_WeakLibEosLoaderDetail.hpp
+++ b/src/detail/WeakLibReader_WeakLibEosLoaderDetail.hpp
@@ -1,0 +1,257 @@
+#pragma once
+
+#include <AMReX_TableData.H>
+#include <AMReX_Vector.H>
+
+#include <array>
+#include <vector>
+
+#include "../WeakLibReader_Hdf5Types.hpp"
+#include "WeakLibReader_Hdf5LoaderDetail.hpp"
+
+#include <hdf5.h>
+
+namespace WeakLibReader {
+namespace detail {
+
+// Dataset paths in WeakLib EOS HDF5 files
+constexpr const char* kThermoStateGroup = "/ThermoState";
+constexpr const char* kDependentVarsGroup = "/DependentVariables";
+constexpr const char* kDensityDataset = "Density";
+constexpr const char* kTemperatureDataset = "Temperature";
+constexpr const char* kElectronFractionDataset = "Electron Fraction";
+constexpr const char* kLogInterpDataset = "LogInterp";
+constexpr const char* kOffsetsDataset = "Offsets";
+
+// Variable name mapping (matches WeakLib HDF5 dataset names)
+inline const char* EosVariableName(EosVariable var) noexcept
+{
+  switch (var) {
+    case EosVariable::Pressure: return "Pressure";
+    case EosVariable::EntropyPerBaryon: return "Entropy Per Baryon";
+    case EosVariable::InternalEnergyDensity: return "Internal Energy Density";
+    case EosVariable::ElectronChemicalPotential: return "Electron Chemical Potential";
+    case EosVariable::ProtonChemicalPotential: return "Proton Chemical Potential";
+    case EosVariable::NeutronChemicalPotential: return "Neutron Chemical Potential";
+    case EosVariable::ProtonMassFraction: return "Proton Mass Fraction";
+    case EosVariable::NeutronMassFraction: return "Neutron Mass Fraction";
+    case EosVariable::AlphaMassFraction: return "Alpha Mass Fraction";
+    case EosVariable::HeavyMassFraction: return "Heavy Mass Fraction";
+    case EosVariable::HeavyChargeNumber: return "Heavy Charge Number";
+    case EosVariable::HeavyMassNumber: return "Heavy Mass Number";
+    case EosVariable::HeavyBindingEnergy: return "Heavy Binding Energy";
+    case EosVariable::ThermalEnergy: return "Thermal Energy";
+    case EosVariable::Gamma1: return "Gamma1";
+    default: return "";
+  }
+}
+
+// Read LogInterp array to determine axis scales
+// Returns array of AxisScale values: [rho, T, Ye]
+inline Hdf5LoadStatus ReadLogInterp(hid_t thermoGroup, std::array<AxisScale, 3>& scales)
+{
+  ScopedHandle dataset(H5Dopen(thermoGroup, kLogInterpDataset, H5P_DEFAULT), H5Dclose);
+  if (!dataset.Valid()) {
+    return Hdf5LoadStatus::LogInterpReadFailed;
+  }
+
+  ScopedHandle space(H5Dget_space(dataset.Get()), H5Sclose);
+  if (!space.Valid()) {
+    return Hdf5LoadStatus::LogInterpReadFailed;
+  }
+
+  hsize_t length = 0;
+  if (H5Sget_simple_extent_dims(space.Get(), &length, nullptr) < 0 || length < 3) {
+    return Hdf5LoadStatus::LogInterpReadFailed;
+  }
+
+  std::vector<int> logInterp(static_cast<std::size_t>(length));
+  if (H5Dread(dataset.Get(), H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, logInterp.data()) < 0) {
+    return Hdf5LoadStatus::LogInterpReadFailed;
+  }
+
+  // LogInterp[i] = 1 means Log10, 0 means Linear
+  for (int i = 0; i < 3; ++i) {
+    scales[i] = (logInterp[i] != 0) ? AxisScale::Log10 : AxisScale::Linear;
+  }
+
+  return Hdf5LoadStatus::Success;
+}
+
+// Read a single axis from the ThermoState group
+inline Hdf5LoadStatus ReadEosAxis(hid_t thermoGroup,
+                                   const char* datasetName,
+                                   int expectedSize,
+                                   AxisScale scale,
+                                   amrex::Vector<double>& storage,
+                                   Axis& axis)
+{
+  ScopedHandle dataset(H5Dopen(thermoGroup, datasetName, H5P_DEFAULT), H5Dclose);
+  if (!dataset.Valid()) {
+    return Hdf5LoadStatus::AxisDatasetOpenFailed;
+  }
+
+  ScopedHandle space(H5Dget_space(dataset.Get()), H5Sclose);
+  if (!space.Valid()) {
+    return Hdf5LoadStatus::AxisReadFailed;
+  }
+
+  const int rank = H5Sget_simple_extent_ndims(space.Get());
+  if (rank != 1) {
+    return Hdf5LoadStatus::AxisReadFailed;
+  }
+
+  hsize_t length = 0;
+  if (H5Sget_simple_extent_dims(space.Get(), &length, nullptr) < 0) {
+    return Hdf5LoadStatus::AxisReadFailed;
+  }
+
+  if (expectedSize > 0 && static_cast<int>(length) != expectedSize) {
+    return Hdf5LoadStatus::AxisExtentMismatch;
+  }
+
+  storage.resize(static_cast<std::size_t>(length));
+  if (H5Dread(dataset.Get(), H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, storage.data()) < 0) {
+    return Hdf5LoadStatus::AxisReadFailed;
+  }
+
+  if (!ValidateAxis(storage, scale)) {
+    return Hdf5LoadStatus::AxisNotMonotone;
+  }
+
+  axis.grid = storage.data();
+  axis.n = static_cast<int>(storage.size());
+  axis.scale = scale;
+
+  return Hdf5LoadStatus::Success;
+}
+
+// Load all axes from the ThermoState group
+inline Hdf5LoadStatus LoadEosAxes(hid_t file, WeakLibEosTable& table)
+{
+  ScopedHandle thermoGroup(H5Gopen(file, kThermoStateGroup, H5P_DEFAULT), H5Gclose);
+  if (!thermoGroup.Valid()) {
+    return Hdf5LoadStatus::GroupOpenFailed;
+  }
+
+  // Read LogInterp to determine axis scales
+  std::array<AxisScale, 3> scales{};
+  Hdf5LoadStatus logInterpStatus = ReadLogInterp(thermoGroup.Get(), scales);
+  if (logInterpStatus != Hdf5LoadStatus::Success) {
+    return logInterpStatus;
+  }
+
+  // Read Density axis (axis 0) - determines rho extent
+  Hdf5LoadStatus status = ReadEosAxis(thermoGroup.Get(), kDensityDataset, -1, scales[0],
+                                       table.axisStorage[0], table.axes[0]);
+  if (status != Hdf5LoadStatus::Success) {
+    return status;
+  }
+  table.extents[0] = table.axes[0].n;
+
+  // Read Temperature axis (axis 1) - determines T extent
+  status = ReadEosAxis(thermoGroup.Get(), kTemperatureDataset, -1, scales[1],
+                       table.axisStorage[1], table.axes[1]);
+  if (status != Hdf5LoadStatus::Success) {
+    return status;
+  }
+  table.extents[1] = table.axes[1].n;
+
+  // Read Electron Fraction axis (axis 2) - determines Ye extent
+  status = ReadEosAxis(thermoGroup.Get(), kElectronFractionDataset, -1, scales[2],
+                       table.axisStorage[2], table.axes[2]);
+  if (status != Hdf5LoadStatus::Success) {
+    return status;
+  }
+  table.extents[2] = table.axes[2].n;
+
+  return Hdf5LoadStatus::Success;
+}
+
+// Load offsets from /DependentVariables/Offsets
+inline Hdf5LoadStatus LoadEosOffsets(hid_t file, std::vector<double>& offsets)
+{
+  ScopedHandle depVarsGroup(H5Gopen(file, kDependentVarsGroup, H5P_DEFAULT), H5Gclose);
+  if (!depVarsGroup.Valid()) {
+    return Hdf5LoadStatus::GroupOpenFailed;
+  }
+
+  ScopedHandle dataset(H5Dopen(depVarsGroup.Get(), kOffsetsDataset, H5P_DEFAULT), H5Dclose);
+  if (!dataset.Valid()) {
+    return Hdf5LoadStatus::OffsetsReadFailed;
+  }
+
+  ScopedHandle space(H5Dget_space(dataset.Get()), H5Sclose);
+  if (!space.Valid()) {
+    return Hdf5LoadStatus::OffsetsReadFailed;
+  }
+
+  hsize_t length = 0;
+  if (H5Sget_simple_extent_dims(space.Get(), &length, nullptr) < 0) {
+    return Hdf5LoadStatus::OffsetsReadFailed;
+  }
+
+  offsets.resize(static_cast<std::size_t>(length));
+  if (H5Dread(dataset.Get(), H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, offsets.data()) < 0) {
+    return Hdf5LoadStatus::OffsetsReadFailed;
+  }
+
+  return Hdf5LoadStatus::Success;
+}
+
+// Load a single EOS variable from /DependentVariables/<name>
+inline Hdf5LoadStatus LoadEosVariable(hid_t file,
+                                       EosVariable var,
+                                       const std::array<int, 3>& extents,
+                                       amrex::TableData<double, 4>& output)
+{
+  ScopedHandle depVarsGroup(H5Gopen(file, kDependentVarsGroup, H5P_DEFAULT), H5Gclose);
+  if (!depVarsGroup.Valid()) {
+    return Hdf5LoadStatus::GroupOpenFailed;
+  }
+
+  const char* varName = EosVariableName(var);
+  ScopedHandle dataset(H5Dopen(depVarsGroup.Get(), varName, H5P_DEFAULT), H5Dclose);
+  if (!dataset.Valid()) {
+    return Hdf5LoadStatus::DatasetOpenFailed;
+  }
+
+  ScopedHandle space(H5Dget_space(dataset.Get()), H5Sclose);
+  if (!space.Valid()) {
+    return Hdf5LoadStatus::DatasetReadFailed;
+  }
+
+  const int rank = H5Sget_simple_extent_ndims(space.Get());
+  if (rank != 3) {
+    return Hdf5LoadStatus::DatasetRankInvalid;
+  }
+
+  // WeakLib stores data as (Ye, T, rho) in HDF5 file (Fortran-order)
+  // Our C++ layout is (rho, T, Ye) so we expect reversed dims
+  hsize_t dims[3] = {0, 0, 0};
+  if (H5Sget_simple_extent_dims(space.Get(), dims, nullptr) < 0) {
+    return Hdf5LoadStatus::DatasetReadFailed;
+  }
+
+  // Verify shape: HDF5 stores (Ye, T, rho), so dims[0]=Ye, dims[1]=T, dims[2]=rho
+  if (static_cast<int>(dims[0]) != extents[2] ||
+      static_cast<int>(dims[1]) != extents[1] ||
+      static_cast<int>(dims[2]) != extents[0]) {
+    return Hdf5LoadStatus::IncompatibleDatasetExtent;
+  }
+
+  // Allocate output
+  const amrex::Array<int, 4> lo{{0, 0, 0, 0}};
+  const amrex::Array<int, 4> hi{{extents[0] - 1, extents[1] - 1, extents[2] - 1, 0}};
+  output.resize(lo, hi, amrex::The_Pinned_Arena());
+
+  // Read data
+  if (H5Dread(dataset.Get(), H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, output.table().p) < 0) {
+    return Hdf5LoadStatus::DatasetReadFailed;
+  }
+
+  return Hdf5LoadStatus::Success;
+}
+
+} // namespace detail
+} // namespace WeakLibReader

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,8 @@ set(TEST_SOURCES
   test_log_interpolate_deriv.cpp
   test_log_interpolate_basis.cpp
   test_log_interpolate_kernel.cpp
-  test_hdf5_loader.cpp)
+  test_hdf5_loader.cpp
+  test_weaklib_eos_loader.cpp)
 
 add_executable(WeakLibReaderTests ${TEST_SOURCES})
 

--- a/test/include/test_amrex_guard.hpp
+++ b/test/include/test_amrex_guard.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <AMReX.H>
+
+namespace test_utils {
+
+/// Global AMReX guard that initializes once and finalizes at program exit.
+/// This avoids the MPI re-initialization error that occurs when each test
+/// creates its own AmrexGuard (MPI cannot be re-initialized after finalization).
+struct GlobalAmrexGuard {
+  GlobalAmrexGuard()
+  {
+    int argc = 0;
+    char** argv = nullptr;
+    amrex::Initialize(argc, argv);
+  }
+  ~GlobalAmrexGuard() { amrex::Finalize(); }
+
+  static GlobalAmrexGuard& Instance()
+  {
+    static GlobalAmrexGuard guard;
+    return guard;
+  }
+};
+
+/// Per-test helper that ensures AMReX is initialized (via the global guard)
+struct AmrexGuard {
+  AmrexGuard() { (void)GlobalAmrexGuard::Instance(); }
+};
+
+} // namespace test_utils

--- a/test/test_hdf5_loader.cpp
+++ b/test/test_hdf5_loader.cpp
@@ -2,8 +2,8 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "WeakLibReader_Hdf5Loader.hpp"
+#include "test_amrex_guard.hpp"
 
-#include <AMReX.H>
 #include <AMReX_Arena.H>
 #include <AMReX_GpuContainers.H>
 #include <AMReX_GpuDevice.H>
@@ -19,29 +19,7 @@ namespace {
 
 constexpr double kTol = 1.0e-12;
 
-/// Global AMReX guard that initializes once and finalizes at program exit.
-/// This avoids the MPI re-initialization error that occurs when each test
-/// creates its own AmrexGuard (MPI cannot be re-initialized after finalization).
-struct GlobalAmrexGuard {
-  GlobalAmrexGuard()
-  {
-    int argc = 0;
-    char** argv = nullptr;
-    amrex::Initialize(argc, argv);
-  }
-  ~GlobalAmrexGuard() { amrex::Finalize(); }
-
-  static GlobalAmrexGuard& Instance()
-  {
-    static GlobalAmrexGuard guard;
-    return guard;
-  }
-};
-
-/// Per-test helper that ensures AMReX is initialized (via the global guard)
-struct AmrexGuard {
-  AmrexGuard() { (void)GlobalAmrexGuard::Instance(); }
-};
+using test_utils::AmrexGuard;
 
 /// RAII helper that temporarily silences HDF5 automatic error printing.
 /// Used in tests that intentionally trigger HDF5 errors.

--- a/test/test_weaklib_eos_loader.cpp
+++ b/test/test_weaklib_eos_loader.cpp
@@ -1,0 +1,343 @@
+#define SIMPLE_CATCH_NO_MAIN
+#include <catch2/catch_test_macros.hpp>
+
+#include "WeakLibReader_WeakLibEosLoader.hpp"
+#include "test_amrex_guard.hpp"
+
+#include <AMReX_Arena.H>
+#include <AMReX_GpuContainers.H>
+#include <AMReX_GpuDevice.H>
+#include <AMReX_TableData.H>
+#include <hdf5.h>
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr double kTol = 1.0e-12;
+
+// Path to the real WeakLib EOS table file
+// This file must exist for the tests to run
+const std::string kEosTablePath =
+    "/Users/liwei/docker-workspace/repos/weaklib-tables/SFHo/LowRes/wl-EOS-SFHo-15-25-50.h5";
+
+using test_utils::AmrexGuard;
+
+/// RAII helper that temporarily silences HDF5 automatic error printing.
+struct ScopedHdf5ErrorSilencer {
+  H5E_auto2_t oldFunc = nullptr;
+  void* oldClientData = nullptr;
+
+  ScopedHdf5ErrorSilencer()
+  {
+    H5Eget_auto2(H5E_DEFAULT, &oldFunc, &oldClientData);
+    H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
+  }
+
+  ~ScopedHdf5ErrorSilencer()
+  {
+    H5Eset_auto2(H5E_DEFAULT, oldFunc, oldClientData);
+  }
+};
+
+bool EosTableFileExists()
+{
+  return std::filesystem::exists(kEosTablePath);
+}
+
+} // namespace
+
+TEST_CASE("WeakLib EOS loader loads axes correctly", "[weaklib][eos][loader]")
+{
+  AmrexGuard amrex{};
+
+  if (!EosTableFileExists()) {
+    return;
+  }
+
+  WeakLibReader::WeakLibEosTable table;
+
+  // Load only one variable to minimize memory usage
+  WeakLibReader::WeakLibEosLoadConfig cfg;
+  cfg.variablesToLoad = {WeakLibReader::EosVariable::Pressure};
+
+  const auto status = WeakLibReader::LoadWeakLibEosTable(kEosTablePath, table, cfg);
+
+  REQUIRE(status == WeakLibReader::Hdf5LoadStatus::Success);
+
+  // Verify axis dimensions (expected: 185, 81, 30)
+  CHECK(table.extents[0] == 185);  // Density
+  CHECK(table.extents[1] == 81);   // Temperature
+  CHECK(table.extents[2] == 30);   // Electron Fraction
+
+  // Verify axis counts match extents
+  CHECK(table.axes[0].n == 185);
+  CHECK(table.axes[1].n == 81);
+  CHECK(table.axes[2].n == 30);
+
+  // Verify axis scales (expected: Log10, Log10, Linear based on LogInterp)
+  CHECK(table.axes[0].scale == WeakLibReader::AxisScale::Log10);  // Density
+  CHECK(table.axes[1].scale == WeakLibReader::AxisScale::Log10);  // Temperature
+  CHECK(table.axes[2].scale == WeakLibReader::AxisScale::Linear); // Electron Fraction
+
+  // Verify axis grid pointers are valid
+  REQUIRE(table.axes[0].grid != nullptr);
+  REQUIRE(table.axes[1].grid != nullptr);
+  REQUIRE(table.axes[2].grid != nullptr);
+
+  // Verify axis values are monotonically increasing
+  for (int i = 1; i < table.axes[0].n; ++i) {
+    CHECK(table.axes[0].grid[i] > table.axes[0].grid[i - 1]);
+  }
+  for (int i = 1; i < table.axes[1].n; ++i) {
+    CHECK(table.axes[1].grid[i] > table.axes[1].grid[i - 1]);
+  }
+  for (int i = 1; i < table.axes[2].n; ++i) {
+    CHECK(table.axes[2].grid[i] > table.axes[2].grid[i - 1]);
+  }
+
+  // Verify Log10 axes have positive values
+  for (int i = 0; i < table.axes[0].n; ++i) {
+    CHECK(table.axes[0].grid[i] > 0.0);
+  }
+  for (int i = 0; i < table.axes[1].n; ++i) {
+    CHECK(table.axes[1].grid[i] > 0.0);
+  }
+}
+
+TEST_CASE("WeakLib EOS loader loads single variable correctly", "[weaklib][eos][loader]")
+{
+  AmrexGuard amrex{};
+
+  if (!EosTableFileExists()) {
+    return;
+  }
+
+  WeakLibReader::WeakLibEosTable table;
+
+  WeakLibReader::WeakLibEosLoadConfig cfg;
+  cfg.variablesToLoad = {WeakLibReader::EosVariable::Pressure};
+
+  const auto status = WeakLibReader::LoadWeakLibEosTable(kEosTablePath, table, cfg);
+
+  REQUIRE(status == WeakLibReader::Hdf5LoadStatus::Success);
+
+  // Verify only one variable was loaded
+  CHECK(table.loadedVariables.size() == 1);
+  CHECK(table.loadedVariables[0] == WeakLibReader::EosVariable::Pressure);
+  CHECK(table.variables.size() == 1);
+
+  // Verify data pointer is valid
+  const double* data = table.VariableDataPtr(0);
+  REQUIRE(data != nullptr);
+
+  // Verify layout
+  CHECK(table.layout.nd == 3);
+  CHECK(table.layout.n[0] == 185);
+  CHECK(table.layout.n[1] == 81);
+  CHECK(table.layout.n[2] == 30);
+
+  // Verify we can create a TableView
+  const auto view = table.ViewForVariable(0);
+  CHECK(view.nd == 3);
+  CHECK(view.data == data);
+}
+
+TEST_CASE("WeakLib EOS loader loads multiple variables", "[weaklib][eos][loader]")
+{
+  AmrexGuard amrex{};
+
+  if (!EosTableFileExists()) {
+    return;
+  }
+
+  WeakLibReader::WeakLibEosTable table;
+
+  WeakLibReader::WeakLibEosLoadConfig cfg;
+  cfg.variablesToLoad = {
+    WeakLibReader::EosVariable::Pressure,
+    WeakLibReader::EosVariable::EntropyPerBaryon,
+    WeakLibReader::EosVariable::InternalEnergyDensity
+  };
+
+  const auto status = WeakLibReader::LoadWeakLibEosTable(kEosTablePath, table, cfg);
+
+  REQUIRE(status == WeakLibReader::Hdf5LoadStatus::Success);
+
+  // Verify all three variables were loaded
+  CHECK(table.loadedVariables.size() == 3);
+  CHECK(table.loadedVariables[0] == WeakLibReader::EosVariable::Pressure);
+  CHECK(table.loadedVariables[1] == WeakLibReader::EosVariable::EntropyPerBaryon);
+  CHECK(table.loadedVariables[2] == WeakLibReader::EosVariable::InternalEnergyDensity);
+  CHECK(table.variables.size() == 3);
+
+  // Verify each variable has its own data
+  const double* data0 = table.VariableDataPtr(0);
+  const double* data1 = table.VariableDataPtr(1);
+  const double* data2 = table.VariableDataPtr(2);
+  REQUIRE(data0 != nullptr);
+  REQUIRE(data1 != nullptr);
+  REQUIRE(data2 != nullptr);
+
+  // Data pointers should be different
+  CHECK(data0 != data1);
+  CHECK(data1 != data2);
+  CHECK(data0 != data2);
+}
+
+TEST_CASE("WeakLib EOS loader loads offsets", "[weaklib][eos][loader]")
+{
+  AmrexGuard amrex{};
+
+  if (!EosTableFileExists()) {
+    return;
+  }
+
+  WeakLibReader::WeakLibEosTable table;
+
+  WeakLibReader::WeakLibEosLoadConfig cfg;
+  cfg.variablesToLoad = {WeakLibReader::EosVariable::Pressure};
+
+  const auto status = WeakLibReader::LoadWeakLibEosTable(kEosTablePath, table, cfg);
+
+  REQUIRE(status == WeakLibReader::Hdf5LoadStatus::Success);
+
+  // Verify offsets were loaded (should be 15 for all variables)
+  CHECK(table.offsets.size() == 15);
+}
+
+TEST_CASE("WeakLib EOS loader device copy works", "[weaklib][eos][loader][device]")
+{
+  AmrexGuard amrex{};
+
+  if (!EosTableFileExists()) {
+    return;
+  }
+
+  WeakLibReader::WeakLibEosTable table;
+
+  WeakLibReader::WeakLibEosLoadConfig cfg;
+  cfg.variablesToLoad = {WeakLibReader::EosVariable::Pressure};
+
+  const auto status = WeakLibReader::LoadWeakLibEosTable(kEosTablePath, table, cfg);
+  REQUIRE(status == WeakLibReader::Hdf5LoadStatus::Success);
+
+  // Create device copy
+  const auto deviceTable = WeakLibReader::MakeDeviceCopy(table);
+
+  // Verify device table properties
+  CHECK(deviceTable.layout.nd == 3);
+  CHECK(deviceTable.loadedVariables.size() == 1);
+  CHECK(deviceTable.loadedVariables[0] == WeakLibReader::EosVariable::Pressure);
+  CHECK(deviceTable.offsets.size() == 15);
+
+  // Verify device axes
+  CHECK(deviceTable.axes[0].n == 185);
+  CHECK(deviceTable.axes[1].n == 81);
+  CHECK(deviceTable.axes[2].n == 30);
+  CHECK(deviceTable.axes[0].scale == WeakLibReader::AxisScale::Log10);
+  CHECK(deviceTable.axes[1].scale == WeakLibReader::AxisScale::Log10);
+  CHECK(deviceTable.axes[2].scale == WeakLibReader::AxisScale::Linear);
+
+  // Round-trip variable data back to host and verify
+  const std::size_t totalSize = 185 * 81 * 30;
+  amrex::TableData<double, 4> roundtrip;
+  const amrex::Array<int, 4> lo{{0, 0, 0, 0}};
+  const amrex::Array<int, 4> hi{{184, 80, 29, 0}};
+  roundtrip.resize(lo, hi, amrex::The_Pinned_Arena());
+  roundtrip.copy(deviceTable.variables[0]);
+
+  const double* originalPtr = table.VariableDataPtr(0);
+  const double* roundtripPtr = roundtrip.const_table().p;
+  for (std::size_t i = 0; i < totalSize; ++i) {
+    CHECK(roundtripPtr[i] == Catch::Approx(originalPtr[i]).margin(kTol));
+  }
+
+  // Round-trip axis data and verify
+  for (int dim = 0; dim < 3; ++dim) {
+    const auto& deviceAxis = deviceTable.axisStorage[dim];
+    std::vector<double> hostAxis(deviceAxis.size());
+    amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                     deviceAxis.begin(), deviceAxis.end(),
+                     hostAxis.begin());
+    REQUIRE(hostAxis.size() == table.axisStorage[dim].size());
+    for (std::size_t i = 0; i < hostAxis.size(); ++i) {
+      CHECK(hostAxis[i] == Catch::Approx(table.axisStorage[dim][i]).margin(kTol));
+    }
+  }
+}
+
+TEST_CASE("WeakLib EOS loader ViewForVariable works", "[weaklib][eos][loader]")
+{
+  AmrexGuard amrex{};
+
+  if (!EosTableFileExists()) {
+    return;
+  }
+
+  WeakLibReader::WeakLibEosTable table;
+
+  WeakLibReader::WeakLibEosLoadConfig cfg;
+  cfg.variablesToLoad = {WeakLibReader::EosVariable::Pressure};
+
+  const auto status = WeakLibReader::LoadWeakLibEosTable(kEosTablePath, table, cfg);
+  REQUIRE(status == WeakLibReader::Hdf5LoadStatus::Success);
+
+  // Get view for the pressure variable
+  const auto view = table.ViewForVariable(0);
+
+  CHECK(view.nd == 3);
+  CHECK(view.data == table.VariableDataPtr(0));
+
+  // Verify axes are copied correctly
+  CHECK(view.axes[0].n == table.axes[0].n);
+  CHECK(view.axes[0].scale == table.axes[0].scale);
+  CHECK(view.axes[1].n == table.axes[1].n);
+  CHECK(view.axes[1].scale == table.axes[1].scale);
+  CHECK(view.axes[2].n == table.axes[2].n);
+  CHECK(view.axes[2].scale == table.axes[2].scale);
+
+  // Verify layout is copied
+  CHECK(view.layout.nd == table.layout.nd);
+  CHECK(view.layout.n[0] == table.layout.n[0]);
+  CHECK(view.layout.n[1] == table.layout.n[1]);
+  CHECK(view.layout.n[2] == table.layout.n[2]);
+}
+
+TEST_CASE("WeakLib EOS loader returns error for non-existent file", "[weaklib][eos][loader][error]")
+{
+  AmrexGuard amrex{};
+  ScopedHdf5ErrorSilencer silencer{};
+
+  WeakLibReader::WeakLibEosTable table;
+  const auto status = WeakLibReader::LoadWeakLibEosTable("/nonexistent/path.h5", table);
+
+  CHECK(status == WeakLibReader::Hdf5LoadStatus::FileOpenFailed);
+}
+
+TEST_CASE("WeakLib EOS loader parallel load works in single-process mode", "[weaklib][eos][loader][parallel]")
+{
+  AmrexGuard amrex{};
+
+  if (!EosTableFileExists()) {
+    return;
+  }
+
+  WeakLibReader::WeakLibEosTable table;
+
+  WeakLibReader::WeakLibEosLoadConfig cfg;
+  cfg.variablesToLoad = {WeakLibReader::EosVariable::Pressure};
+
+  const auto status = WeakLibReader::LoadWeakLibEosTableParallel(kEosTablePath, table, cfg);
+
+  REQUIRE(status == WeakLibReader::Hdf5LoadStatus::Success);
+
+  // Verify same results as non-parallel load
+  CHECK(table.extents[0] == 185);
+  CHECK(table.extents[1] == 81);
+  CHECK(table.extents[2] == 30);
+  CHECK(table.loadedVariables.size() == 1);
+  CHECK(table.loadedVariables[0] == WeakLibReader::EosVariable::Pressure);
+}


### PR DESCRIPTION
## Summary
- Add `WeakLibEosLoader` for loading 3D EOS tables (rho, T, Ye) from WeakLib HDF5 files
- Introduce `WeakLibEosTable` and `WeakLibEosTableDevice` structs for host/device storage
- Add `EosVariable` enum for indexing EOS table variables (pressure, entropy, etc.)
- Extend `Hdf5LoadStatus` with EOS-specific error codes
- Refactor test infrastructure by extracting `AmrexGuard` to reusable header

## Test plan
- [ ] Verify `test_weaklib_eos_loader.cpp` passes with a valid WeakLib EOS HDF5 file
- [ ] Run full test suite with `scripts/check.sh`
- [ ] Test GPU offloading with `CopyToDevice` on CUDA-enabled system