### PR TITLE
Fix EOS table destruction order crash in TestWeakLibReader

### DIFF
--- a/cactus_interface/TestWeakLibReader/schedule.ccl
+++ b/cactus_interface/TestWeakLibReader/schedule.ccl
@@ -13,3 +13,9 @@ SCHEDULE TestWeakLibReader_Init AT INITIAL AFTER TestWeakLibReader_LoadTable
   LANG: C
   WRITES: energy(everywhere)
 } "Initialize grid function"
+
+SCHEDULE TestWeakLibReader_Cleanup AT TERMINATE
+{
+  LANG: C
+  OPTIONS: global
+} "Clean up EOS table before AMReX finalizes"

--- a/cactus_interface/TestWeakLibReader/src/testweaklibreader.cxx
+++ b/cactus_interface/TestWeakLibReader/src/testweaklibreader.cxx
@@ -3,19 +3,32 @@
 #include <cctk_Parameters.h>
 #include <loop_device.hxx>
 
+#include <memory>
+
 #include <WeakLibReader_Hdf5Loader.hpp>
 
 namespace TestWeakLibReader {
+
+std::unique_ptr<WeakLibReader::WeakLibEosTable> eos_table;
 
 extern "C" void TestWeakLibReader_LoadTable(CCTK_ARGUMENTS) {
   DECLARE_CCTK_PARAMETERS;
 
   CCTK_INFO("Loading EOS table");
 
-  WeakLibReader::Hdf5Table table;
-  const auto status = WeakLibReader::LoadWeakLibEosTable(eos_table_file, "Pressure", table);
+  eos_table = std::make_unique<WeakLibReader::WeakLibEosTable>();
 
-  assert(status == WeakLibReader::Hdf5LoadStatus::Success);
+  const auto status =
+      WeakLibReader::LoadWeakLibEosTableFull(eos_table_file, *eos_table);
+
+  if (status != WeakLibReader::Hdf5LoadStatus::Success) {
+    CCTK_ERROR("Failed to load EOS table");
+  }
+}
+
+extern "C" void TestWeakLibReader_Cleanup(CCTK_ARGUMENTS) {
+  CCTK_INFO("Cleaning up EOS table");
+  eos_table.reset();
 }
 
 extern "C" void TestWeakLibReader_Init(CCTK_ARGUMENTS) {
@@ -24,7 +37,6 @@ extern "C" void TestWeakLibReader_Init(CCTK_ARGUMENTS) {
 
   CCTK_INFO("Initializing grid function");
 
-  // Launch a kernel on the GPU device
   grid.loop_all_device<0, 0, 0>(
       grid.nghostzones, [=](const Loop::PointDesc &p) { energy(p.I) = 0.0; });
 }


### PR DESCRIPTION
## Summary
- Fix destruction order bug where global `eos_table` destructor runs after AMReX finalizes, causing crash when `TableData::clear()` tries to free memory
- Use `std::unique_ptr` for `eos_table` and add explicit cleanup at `TERMINATE` schedule point
- Use `LoadWeakLibEosTableFull` to load complete EOS table
- Replace `assert` with `CCTK_ERROR` for proper production error handling

## Test plan
- [ ] Run TestWeakLibReader thorn and verify clean exit without crash at program termination
- [ ] Verify EOS table loads successfully from configured `eos_table_file` parameter