### PR TITLE
docs: document WeakLib EOS loader, Cactus integration, and new types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,15 @@ test/                                       # Regression tests (Catch2)
   test_log_interpolate_deriv.cpp            # Derivative tests
   test_log_interpolate_kernel.cpp           # Kernel unit tests
   test_log_interpolate_sweep.cpp            # Sweep operation tests
+  test_weaklib_eos_loader.cpp               # WeakLib EOS table loader tests
 ref/weaklib/                                # Fortran reference implementation
   wlInterpolationModule.F90                 # Main interpolation routines
   wlInterpolationUtilitiesModule.F90        # Utility functions
+  wlIOModuleHDF.F90                         # HDF5 I/O module
   wlKindModule.f90                          # Kind parameter definitions
+cactus_interface/                           # Cactus thorn integration
+  WeakLibReader/                            # Library thorn
+  TestWeakLibReader/                        # Test thorn with example usage
 scripts/                                    # Build & test automation
   build.sh                                  # Build only
   test.sh                                   # Run tests only
@@ -74,12 +79,31 @@ Set `VERBOSE=1` for full test output (e.g., `VERBOSE=1 scripts/test.sh`).
 
 ## HDF5 Table Format
 
+### Simple Format (Generic Tables)
+
 ```
 /values              # N-D array (row-major)
 /axis0, /axis1, ...  # 1D arrays with "scale" attribute ("linear" or "log10")
 ```
 
 Validation: monotonic ascending, positive values for Log10 axes.
+
+### Native WeakLib EOS Format
+
+```
+/ThermoState/
+  Dimensions[3]                     # Grid dimensions [nRho, nT, nYe]
+  Density[nRho]                     # Density axis (log10 scale)
+  Temperature[nT]                   # Temperature axis (log10 scale)
+  Electron Fraction[nYe]            # Ye axis (linear scale)
+/DependentVariables/
+  nVariables                        # Number of dependent variables
+  Names[], Units[], Offsets[]       # Variable metadata
+  iPressure, iEntropyPerBaryon, ... # Index mappings for each variable
+  {variable_name}[nYe,nT,nRho]      # Variable data arrays
+```
+
+Use `LoadWeakLibEosTable()` for single variables or `LoadWeakLibEosTableFull()` for complete tables.
 
 ## Fortran Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,15 @@ test/                                       # Regression tests (Catch2)
   test_log_interpolate_deriv.cpp            # Derivative tests
   test_log_interpolate_kernel.cpp           # Kernel unit tests
   test_log_interpolate_sweep.cpp            # Sweep operation tests
+  test_weaklib_eos_loader.cpp               # WeakLib EOS table loader tests
 ref/weaklib/                                # Fortran reference implementation
   wlInterpolationModule.F90                 # Main interpolation routines
   wlInterpolationUtilitiesModule.F90        # Utility functions
+  wlIOModuleHDF.F90                         # HDF5 I/O module
   wlKindModule.f90                          # Kind parameter definitions
+cactus_interface/                           # Cactus thorn integration
+  WeakLibReader/                            # Library thorn
+  TestWeakLibReader/                        # Test thorn with example usage
 scripts/                                    # Build & test automation
   build.sh                                  # Build only
   test.sh                                   # Run tests only
@@ -74,12 +79,31 @@ Set `VERBOSE=1` for full test output (e.g., `VERBOSE=1 scripts/test.sh`).
 
 ## HDF5 Table Format
 
+### Simple Format (Generic Tables)
+
 ```
 /values              # N-D array (row-major)
 /axis0, /axis1, ...  # 1D arrays with "scale" attribute ("linear" or "log10")
 ```
 
 Validation: monotonic ascending, positive values for Log10 axes.
+
+### Native WeakLib EOS Format
+
+```
+/ThermoState/
+  Dimensions[3]                     # Grid dimensions [nRho, nT, nYe]
+  Density[nRho]                     # Density axis (log10 scale)
+  Temperature[nT]                   # Temperature axis (log10 scale)
+  Electron Fraction[nYe]            # Ye axis (linear scale)
+/DependentVariables/
+  nVariables                        # Number of dependent variables
+  Names[], Units[], Offsets[]       # Variable metadata
+  iPressure, iEntropyPerBaryon, ... # Index mappings for each variable
+  {variable_name}[nYe,nT,nRho]      # Variable data arrays
+```
+
+Use `LoadWeakLibEosTable()` for single variables or `LoadWeakLibEosTableFull()` for complete tables.
 
 ## Fortran Reference
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ GPU-friendly C++ reimplementation of WeakLib's equation-of-state and opacity int
 - Out-of-range coordinates extrapolate naturally (matches Fortran)
 - Derivative computation for 2D-4D interpolation
 - HDF5 table loading with MPI broadcast support
+- Native WeakLib EOS table loading (full and single-variable)
+- Cactus framework integration (thorns provided)
 - Numerical parity with Fortran reference (≤1e-12 relative error)
 
 ## Requirements
@@ -80,6 +82,9 @@ double result = LogInterpolateSingleVariable3DCustomPoint(
 | `Hdf5Table` | Host-side table storage (owns data + axes) |
 | `TableView` | Read-only view into loaded table |
 | `TableDevice` | Device-side table copy |
+| `WeakLibEosTable` | Full EOS table storage with all variables and metadata |
+| `WeakLibEosTableDevice` | Device copy of full EOS table |
+| `WeakLibEosIndices` | Index mappings for EOS dependent variables |
 
 ### Key Functions
 
@@ -87,6 +92,8 @@ double result = LogInterpolateSingleVariable3DCustomPoint(
 |----------|-------------|
 | `LoadHdf5Table()` | Load HDF5 into `amrex::TableData` |
 | `LoadHdf5TableParallel()` | MPI-aware loader (rank 0 reads, broadcasts) |
+| `LoadWeakLibEosTable()` | Load single variable from native WeakLib format |
+| `LoadWeakLibEosTableFull()` | Load complete EOS table with all metadata |
 | `MakeDeviceCopy()` | Copy host table to GPU device |
 | `LogInterpolateSingleVariable*DCustomPoint()` | Single-point N-D interpolation |
 | `LogInterpolateSingleVariable*DCustom()` | Batch N-D interpolation |
@@ -94,18 +101,36 @@ double result = LogInterpolateSingleVariable3DCustomPoint(
 
 ### HDF5 File Format
 
+#### Simple Format (Generic Tables)
+
 ```
 /values              # N-D array (row-major layout)
 /axis0               # 1D array with "scale" attribute ("linear" or "log10")
 /axis1               # ...
 ```
 
+#### Native WeakLib EOS Format
+
+```
+/ThermoState/
+  Dimensions[3]                     # Grid dimensions [nRho, nT, nYe]
+  Density[nRho]                     # Density axis (log10 scale)
+  Temperature[nT]                   # Temperature axis (log10 scale)
+  Electron Fraction[nYe]            # Ye axis (linear scale)
+/DependentVariables/
+  nVariables                        # Number of dependent variables
+  Names[], Units[], Offsets[]       # Variable metadata
+  iPressure, iEntropyPerBaryon, ... # Index mappings for each variable
+  {variable_name}[nYe,nT,nRho]      # Variable data arrays
+```
+
 ## Project Structure
 
 ```
-src/                 # Header-only library (8 headers)
-ref/weaklib/         # Fortran reference implementation
-test/                # Regression tests (39 test cases)
+src/                 # Header-only library
+ref/weaklib/         # Fortran reference implementation (incl. wlIOModuleHDF.F90)
+test/                # Regression tests
+cactus_interface/    # Cactus thorn integration (WeakLibReader, TestWeakLibReader)
 ```
 
 ## Fortran Parity


### PR DESCRIPTION
## Summary

- Document the new `test_weaklib_eos_loader.cpp` test file in repository structure
- Add `wlIOModuleHDF.F90` to the Fortran reference file listings
- Document the `cactus_interface/` directory with WeakLibReader and TestWeakLibReader thorns
- Add native WeakLib EOS HDF5 format documentation alongside the existing simple format
- Add new core types: `WeakLibEosTable`, `WeakLibEosTableDevice`, `WeakLibEosIndices`
- Add new loader functions: `LoadWeakLibEosTable()`, `LoadWeakLibEosTableFull()`

## Test plan

- [x] Verified `scripts/check.sh` passes (build and tests)
- [x] Reviewed updated documentation for accuracy and consistency across CLAUDE.md, AGENTS.md, and README.md