### PR TITLE
Add parallel MPI broadcast variants for WeakLib EOS loaders

### DIFF
--- a/src/WeakLibReader_Hdf5Loader.hpp
+++ b/src/WeakLibReader_Hdf5Loader.hpp
@@ -563,4 +563,278 @@ inline Hdf5LoadStatus LoadHdf5TableParallel(const std::string& filePath,
   return status;
 }
 
+inline Hdf5LoadStatus LoadWeakLibEosTableParallel(
+    const std::string& filePath,
+    const std::string& variableName,
+    Hdf5Table& output,
+    int readerRank = amrex::ParallelDescriptor::IOProcessorNumber())
+{
+  // Single-rank fallback
+  const int nProcs = amrex::ParallelDescriptor::NProcs();
+  if (nProcs <= 1) {
+    return LoadWeakLibEosTable(filePath, variableName, output);
+  }
+
+  // Validate readerRank
+  int root = readerRank;
+  if (root < 0 || root >= nProcs) {
+    root = amrex::ParallelDescriptor::IOProcessorNumber();
+  }
+
+  const int myRank = amrex::ParallelDescriptor::MyProc();
+
+  // Root rank loads the table
+  Hdf5Table localTable;
+  Hdf5LoadStatus status = Hdf5LoadStatus::Success;
+  if (myRank == root) {
+    status = LoadWeakLibEosTable(filePath, variableName, localTable);
+  }
+
+  // Broadcast status
+  int statusInt = static_cast<int>(status);
+  amrex::ParallelDescriptor::Bcast(&statusInt, 1, root);
+  status = static_cast<Hdf5LoadStatus>(statusInt);
+  if (status != Hdf5LoadStatus::Success) {
+    return status;
+  }
+
+  // Broadcast header: [nd, extents x5]
+  int header[6] = {0, 1, 1, 1, 1, 1};
+  if (myRank == root) {
+    header[0] = localTable.nd;
+    for (int dim = 0; dim < 5; ++dim) {
+      header[1 + dim] = localTable.extents[dim];
+    }
+  }
+  amrex::ParallelDescriptor::Bcast(header, 6, root);
+
+  const int nd = header[0];
+  std::array<int, 5> extents{{1, 1, 1, 1, 1}};
+  for (int dim = 0; dim < 5; ++dim) {
+    extents[dim] = header[1 + dim];
+  }
+
+  // Broadcast axis metadata
+  int axisCounts[5] = {0, 0, 0, 0, 0};
+  int axisScales[5] = {0, 0, 0, 0, 0};
+  if (myRank == root) {
+    for (int dim = 0; dim < 5; ++dim) {
+      axisCounts[dim] = localTable.axes[dim].n;
+      axisScales[dim] = static_cast<int>(localTable.axes[dim].scale);
+    }
+  }
+  amrex::ParallelDescriptor::Bcast(axisCounts, 5, root);
+  amrex::ParallelDescriptor::Bcast(axisScales, 5, root);
+
+  // Compute total size and validate
+  const std::size_t totalSize = detail::ComputeTotalSize(nd, extents);
+  if (totalSize > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+    return Hdf5LoadStatus::IncompatibleDatasetExtent;
+  }
+
+  // Non-root ranks allocate storage
+  if (myRank != root) {
+    output = Hdf5Table{};
+    output.nd = nd;
+    output.extents = extents;
+    bool overflow = false;
+    const amrex::Array<int, 4> lo{{0, 0, 0, 0}};
+    const amrex::Array<int, 4> hi = detail::MakeHiArray(nd, extents, overflow);
+    if (overflow || totalSize == 0) {
+      return Hdf5LoadStatus::IncompatibleDatasetExtent;
+    }
+    output.values.resize(lo, hi, amrex::The_Pinned_Arena());
+    output.layout = MakeLayout(output.extents.data(), output.nd);
+    for (int dim = 0; dim < 5; ++dim) {
+      amrex::Vector<double>& storage = output.axisStorage[dim];
+      storage.resize(static_cast<std::size_t>(axisCounts[dim]));
+      if (!storage.empty()) {
+        output.axes[dim].grid = storage.data();
+      } else {
+        output.axes[dim].grid = nullptr;
+      }
+      output.axes[dim].n = axisCounts[dim];
+      output.axes[dim].scale = static_cast<AxisScale>(axisScales[dim]);
+    }
+  }
+
+  // Broadcast values data
+  double* dataPtr = (myRank == root)
+                        ? localTable.values.table().p
+                        : output.values.table().p;
+  if (totalSize > 0) {
+    amrex::ParallelDescriptor::Bcast(dataPtr, static_cast<int>(totalSize), root);
+  }
+
+  // Broadcast axis grids
+  for (int dim = 0; dim < 5; ++dim) {
+    const int count = axisCounts[dim];
+    if (count <= 0) {
+      continue;
+    }
+    double* axisPtr = (myRank == root)
+                          ? localTable.axisStorage[dim].data()
+                          : output.axisStorage[dim].data();
+    amrex::ParallelDescriptor::Bcast(axisPtr, count, root);
+  }
+
+  // Root moves its local table to output
+  if (myRank == root) {
+    output = std::move(localTable);
+  }
+
+  return status;
+}
+
+inline Hdf5LoadStatus LoadWeakLibEosTableFullParallel(
+    const std::string& filePath,
+    WeakLibEosTable& output,
+    int readerRank = amrex::ParallelDescriptor::IOProcessorNumber())
+{
+  // Single-rank fallback
+  const int nProcs = amrex::ParallelDescriptor::NProcs();
+  if (nProcs <= 1) {
+    return LoadWeakLibEosTableFull(filePath, output);
+  }
+
+  // Validate readerRank
+  int root = readerRank;
+  if (root < 0 || root >= nProcs) {
+    root = amrex::ParallelDescriptor::IOProcessorNumber();
+  }
+
+  const int myRank = amrex::ParallelDescriptor::MyProc();
+
+  // Root rank loads the table
+  WeakLibEosTable localTable;
+  Hdf5LoadStatus status = Hdf5LoadStatus::Success;
+  if (myRank == root) {
+    status = LoadWeakLibEosTableFull(filePath, localTable);
+  }
+
+  // Broadcast status
+  int statusInt = static_cast<int>(status);
+  amrex::ParallelDescriptor::Bcast(&statusInt, 1, root);
+  status = static_cast<Hdf5LoadStatus>(statusInt);
+  if (status != Hdf5LoadStatus::Success) {
+    return status;
+  }
+
+  // Broadcast header: [nVariables, dims x3, scales x3]
+  int header[7] = {0, 0, 0, 0, 0, 0, 0};
+  if (myRank == root) {
+    header[0] = localTable.nVariables;
+    header[1] = localTable.dimensions[0];
+    header[2] = localTable.dimensions[1];
+    header[3] = localTable.dimensions[2];
+    header[4] = static_cast<int>(localTable.scales[0]);
+    header[5] = static_cast<int>(localTable.scales[1]);
+    header[6] = static_cast<int>(localTable.scales[2]);
+  }
+  amrex::ParallelDescriptor::Bcast(header, 7, root);
+
+  const int nVariables = header[0];
+  std::array<int, 3> dimensions{{header[1], header[2], header[3]}};
+  std::array<AxisScale, 3> scales{{
+      static_cast<AxisScale>(header[4]),
+      static_cast<AxisScale>(header[5]),
+      static_cast<AxisScale>(header[6])
+  }};
+
+  // Broadcast axis counts
+  int axisCounts[3] = {0, 0, 0};
+  if (myRank == root) {
+    for (int dim = 0; dim < 3; ++dim) {
+      axisCounts[dim] = localTable.axes[dim].n;
+    }
+  }
+  amrex::ParallelDescriptor::Bcast(axisCounts, 3, root);
+
+  // Non-root: allocate base structure
+  if (myRank != root) {
+    output = WeakLibEosTable{};
+    output.nVariables = nVariables;
+    output.dimensions = dimensions;
+    output.scales = scales;
+
+    // Allocate axis storage
+    for (int dim = 0; dim < 3; ++dim) {
+      output.axisStorage[dim].resize(axisCounts[dim]);
+      output.axes[dim].grid = output.axisStorage[dim].data();
+      output.axes[dim].n = axisCounts[dim];
+      output.axes[dim].scale = scales[dim];
+    }
+
+    // Allocate variable arrays
+    const amrex::Array<int, 3> lo{{0, 0, 0}};
+    const amrex::Array<int, 3> hi{{dimensions[0] - 1, dimensions[1] - 1, dimensions[2] - 1}};
+    output.variables.resize(nVariables);
+    for (int iVar = 0; iVar < nVariables; ++iVar) {
+      output.variables[iVar].resize(lo, hi, amrex::The_Pinned_Arena());
+    }
+
+    // Allocate repaired mask
+    output.repaired.resize(lo, hi, amrex::The_Pinned_Arena());
+
+    // Allocate offset/string vectors
+    output.offsets.resize(nVariables);
+    output.variableNames.resize(nVariables);
+    output.variableUnits.resize(nVariables);
+
+    // Compute layout
+    std::array<int, 5> extents5{{dimensions[0], dimensions[1], dimensions[2], 1, 1}};
+    output.layout = MakeLayout(extents5.data(), 3);
+  }
+
+  // Get reference to working table
+  WeakLibEosTable& table = (myRank == root) ? localTable : output;
+
+  // Broadcast axis grids
+  for (int dim = 0; dim < 3; ++dim) {
+    if (axisCounts[dim] > 0) {
+      amrex::ParallelDescriptor::Bcast(table.axisStorage[dim].data(), axisCounts[dim], root);
+    }
+  }
+
+  // Broadcast string metadata
+  detail::BcastStringArray(table.axisNames, root);
+  detail::BcastStringArray(table.axisUnits, root);
+  detail::BcastStringVector(table.variableNames, root);
+  detail::BcastStringVector(table.variableUnits, root);
+
+  // Broadcast offsets
+  if (nVariables > 0) {
+    amrex::ParallelDescriptor::Bcast(table.offsets.data(), nVariables, root);
+  }
+
+  // Broadcast each variable's 3D data
+  const std::size_t varSize = static_cast<std::size_t>(dimensions[0]) *
+                              static_cast<std::size_t>(dimensions[1]) *
+                              static_cast<std::size_t>(dimensions[2]);
+  if (varSize > 0) {
+    for (int iVar = 0; iVar < nVariables; ++iVar) {
+      amrex::ParallelDescriptor::Bcast(table.variables[iVar].table().p,
+                                       static_cast<int>(varSize), root);
+    }
+  }
+
+  // Broadcast repaired mask
+  if (varSize > 0) {
+    amrex::ParallelDescriptor::Bcast(table.repaired.table().p,
+                                     static_cast<int>(varSize), root);
+  }
+
+  // Broadcast indices (15 integers as a block)
+  static_assert(sizeof(WeakLibEosIndices) == 15 * sizeof(int),
+                "WeakLibEosIndices must be 15 contiguous ints");
+  amrex::ParallelDescriptor::Bcast(reinterpret_cast<int*>(&table.indices), 15, root);
+
+  // Root moves its local table to output
+  if (myRank == root) {
+    output = std::move(localTable);
+  }
+
+  return status;
+}
+
 } // namespace WeakLibReader

--- a/src/detail/WeakLibReader_Hdf5LoaderDetail.hpp
+++ b/src/detail/WeakLibReader_Hdf5LoaderDetail.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <AMReX_ParallelDescriptor.H>
 #include <AMReX_Vector.H>
 
 #include <array>
@@ -479,6 +480,73 @@ inline Hdf5LoadStatus LoadWeakLibAxis(hid_t thermoGroup,
   table.axes[axisIndex] = axis;
 
   return Hdf5LoadStatus::Success;
+}
+
+/// Broadcast a vector of strings from root to all ranks.
+/// Format: [count][len0][len1]...[lenN-1][chars...]
+inline void BcastStringVector(std::vector<std::string>& strings, int root)
+{
+  const int myRank = amrex::ParallelDescriptor::MyProc();
+
+  // Broadcast count
+  int count = (myRank == root) ? static_cast<int>(strings.size()) : 0;
+  amrex::ParallelDescriptor::Bcast(&count, 1, root);
+
+  if (count == 0) {
+    if (myRank != root) {
+      strings.clear();
+    }
+    return;
+  }
+
+  // Broadcast lengths
+  std::vector<int> lengths(count);
+  if (myRank == root) {
+    for (int i = 0; i < count; ++i) {
+      lengths[i] = static_cast<int>(strings[i].size());
+    }
+  }
+  amrex::ParallelDescriptor::Bcast(lengths.data(), count, root);
+
+  // Compute total chars and broadcast concatenated buffer
+  int totalChars = 0;
+  for (int i = 0; i < count; ++i) {
+    totalChars += lengths[i];
+  }
+
+  std::vector<char> buffer(totalChars);
+  if (myRank == root) {
+    int offset = 0;
+    for (int i = 0; i < count; ++i) {
+      std::memcpy(buffer.data() + offset, strings[i].data(), lengths[i]);
+      offset += lengths[i];
+    }
+  }
+
+  if (totalChars > 0) {
+    amrex::ParallelDescriptor::Bcast(buffer.data(), totalChars, root);
+  }
+
+  // Non-root: reconstruct strings
+  if (myRank != root) {
+    strings.resize(count);
+    int offset = 0;
+    for (int i = 0; i < count; ++i) {
+      strings[i].assign(buffer.data() + offset, lengths[i]);
+      offset += lengths[i];
+    }
+  }
+}
+
+/// Broadcast a fixed-size array of strings from root to all ranks.
+template <std::size_t N>
+inline void BcastStringArray(std::array<std::string, N>& strings, int root)
+{
+  std::vector<std::string> vec(strings.begin(), strings.end());
+  BcastStringVector(vec, root);
+  for (std::size_t i = 0; i < N && i < vec.size(); ++i) {
+    strings[i] = std::move(vec[i]);
+  }
 }
 
 } // namespace detail

--- a/test/test_weaklib_eos_loader.cpp
+++ b/test/test_weaklib_eos_loader.cpp
@@ -569,3 +569,120 @@ TEST_CASE("MakeDeviceCopy works for WeakLibEosTable", "[hdf5][weaklib][gpu]")
 
   std::filesystem::remove(eosPath);
 }
+
+TEST_CASE("LoadWeakLibEosTableParallel loads Pressure", "[weaklib][eos][parallel]")
+{
+  EnsureAmrexInitialized();
+
+  TempWeakLibEosFile tempFile{};
+  const std::string path = tempFile.path.string();
+  Hdf5Table table;
+  const Hdf5LoadStatus status = LoadWeakLibEosTableParallel(path, "Pressure", table);
+
+  REQUIRE(status == Hdf5LoadStatus::Success);
+
+  // Verify dimensions match sequential loader
+  REQUIRE(table.nd == 3);
+  CHECK(table.extents[0] == static_cast<int>(kRhoCount));
+  CHECK(table.extents[1] == static_cast<int>(kTempCount));
+  CHECK(table.extents[2] == static_cast<int>(kYeCount));
+
+  // Verify axis scales
+  CHECK(table.axes[0].scale == AxisScale::Log10);
+  CHECK(table.axes[1].scale == AxisScale::Log10);
+  CHECK(table.axes[2].scale == AxisScale::Linear);
+
+  // Verify data matches sequential loader
+  Hdf5Table seqTable;
+  REQUIRE(LoadWeakLibEosTable(path, "Pressure", seqTable) == Hdf5LoadStatus::Success);
+
+  const double* parData = table.DataPtr();
+  const double* seqData = seqTable.DataPtr();
+  const std::size_t totalSize = kRhoCount * kTempCount * kYeCount;
+  for (std::size_t i = 0; i < totalSize; ++i) {
+    CHECK(parData[i] == seqData[i]);
+  }
+}
+
+TEST_CASE("LoadWeakLibEosTableParallel fails for nonexistent file", "[weaklib][eos][parallel]")
+{
+  EnsureAmrexInitialized();
+  ScopedHdf5ErrorSilencer silencer{};
+
+  Hdf5Table table;
+  const Hdf5LoadStatus status = LoadWeakLibEosTableParallel("/nonexistent/path.h5", "Pressure", table);
+
+  CHECK(status == Hdf5LoadStatus::FileOpenFailed);
+}
+
+TEST_CASE("LoadWeakLibEosTableFullParallel loads complete table", "[weaklib][eos][parallel]")
+{
+  EnsureAmrexInitialized();
+
+  const std::filesystem::path eosPath =
+      std::filesystem::temp_directory_path() / "weaklibreader_eos_parallel_full.h5";
+  CreateWeakLibEosTestFileFull(eosPath);
+
+  WeakLibEosTable table;
+  const auto status = LoadWeakLibEosTableFullParallel(eosPath.string(), table);
+  REQUIRE(status == Hdf5LoadStatus::Success);
+
+  // Load sequential for comparison
+  WeakLibEosTable seqTable;
+  REQUIRE(LoadWeakLibEosTableFull(eosPath.string(), seqTable) == Hdf5LoadStatus::Success);
+
+  // Verify dimensions match
+  CHECK(table.nVariables == seqTable.nVariables);
+  CHECK(table.dimensions == seqTable.dimensions);
+  CHECK(table.scales == seqTable.scales);
+
+  // Verify axis names and units
+  CHECK(table.axisNames == seqTable.axisNames);
+  CHECK(table.axisUnits == seqTable.axisUnits);
+
+  // Verify variable names and units
+  CHECK(table.variableNames == seqTable.variableNames);
+  CHECK(table.variableUnits == seqTable.variableUnits);
+
+  // Verify offsets
+  REQUIRE(table.offsets.size() == seqTable.offsets.size());
+  for (std::size_t i = 0; i < table.offsets.size(); ++i) {
+    CHECK(table.offsets[i] == seqTable.offsets[i]);
+  }
+
+  // Verify indices
+  CHECK(table.indices.iPressure == seqTable.indices.iPressure);
+  CHECK(table.indices.iEntropyPerBaryon == seqTable.indices.iEntropyPerBaryon);
+  CHECK(table.indices.iGamma1 == seqTable.indices.iGamma1);
+
+  // Verify variable data matches
+  const std::size_t varSize = static_cast<std::size_t>(table.dimensions[0]) *
+                              table.dimensions[1] * table.dimensions[2];
+  for (int iVar = 0; iVar < table.nVariables; ++iVar) {
+    const double* parData = table.variables[iVar].const_table().p;
+    const double* seqData = seqTable.variables[iVar].const_table().p;
+    for (std::size_t i = 0; i < varSize; ++i) {
+      CHECK(parData[i] == seqData[i]);
+    }
+  }
+
+  // Verify repaired mask matches
+  const int* parRepaired = table.repaired.const_table().p;
+  const int* seqRepaired = seqTable.repaired.const_table().p;
+  for (std::size_t i = 0; i < varSize; ++i) {
+    CHECK(parRepaired[i] == seqRepaired[i]);
+  }
+
+  std::filesystem::remove(eosPath);
+}
+
+TEST_CASE("LoadWeakLibEosTableFullParallel fails for nonexistent file", "[weaklib][eos][parallel]")
+{
+  EnsureAmrexInitialized();
+  ScopedHdf5ErrorSilencer silencer{};
+
+  WeakLibEosTable table;
+  const Hdf5LoadStatus status = LoadWeakLibEosTableFullParallel("/nonexistent/path.h5", table);
+
+  CHECK(status == Hdf5LoadStatus::FileOpenFailed);
+}


### PR DESCRIPTION
## Summary
- Add `LoadWeakLibEosTableParallel()` for single-variable EOS tables with MPI broadcast
- Add `LoadWeakLibEosTableFullParallel()` for complete EOS tables with MPI broadcast
- Add helper functions `BcastStringVector()` and `BcastStringArray()` for broadcasting string metadata
- Reduces HDF5 I/O contention when multiple MPI ranks need the same table

## Test plan
- [x] Add tests comparing parallel loader output against sequential loaders
- [x] Add tests for error handling (nonexistent files)
- [ ] Run with multiple MPI ranks to verify broadcast correctness