### PR TITLE
Simplify interpolation API to accept Axis arrays

### DIFF
--- a/cactus_interface/TestWeakLibReader/src/testweaklibreader.cxx
+++ b/cactus_interface/TestWeakLibReader/src/testweaklibreader.cxx
@@ -46,20 +46,12 @@ extern "C" void TestWeakLibReader_Init(CCTK_ARGUMENTS) {
   const auto &ipress = eos_table->indices.iPressure;
   const double pressureOffset = eos_table->offsets[ipress];
   const double* pressureData = eos_table_device.VariableData(ipress);
-  const double* rhoGrid = axes[0].grid;
-  const double* tempGrid = axes[1].grid;
-  const double* yeGrid = axes[2].grid;
-  const int nRho = axes[0].n;
-  const int nTemp = axes[1].n;
-  const int nYe = axes[2].n;
 
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones, [=](const Loop::PointDesc &p) {
       energy(p.I) = WeakLibReader::LogInterpolateSingleVariable3DCustomPoint(
           p.x, p.y, p.z,
-          rhoGrid, nRho,
-          tempGrid, nTemp,
-          yeGrid, nYe,
+          axes,
           pressureData, pressureOffset);
       });
 }

--- a/src/detail/WeakLibReader_LogInterpolateDeriv.hpp
+++ b/src/detail/WeakLibReader_LogInterpolateDeriv.hpp
@@ -10,37 +10,29 @@ namespace WeakLibReader {
 /// GPU-optimized 3D log-interpolation with derivatives (single point)
 inline int LogInterpolateDifferentiateSingleVariable3DCustomPoint(
     double d, double t, double y,
-    const double* gridD, int nD,
-    const double* gridT, int nT,
-    const double* gridY, int nY,
+    const Axis axes[3],
     const double* data,
     double offset,
     double& interpolant,
     double derivatives[3]) noexcept
 {
   if (data == nullptr ||
-      gridD == nullptr || gridT == nullptr || gridY == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr || axes[2].grid == nullptr) {
     return 1;
   }
 
-  Axis axesLocal[3] = {
-      MakeAxis(gridD, nD, AxisScale::Log10),
-      MakeAxis(gridT, nT, AxisScale::Log10),
-      MakeAxis(gridY, nY, AxisScale::Linear)};
-  int extents[3] = {nD, nT, nY};
+  int extents[3] = {axes[0].n, axes[1].n, axes[2].n};
   const Layout layout = MakeLayout(extents, 3);
 
   detail::LogInterpolateDifferentiateSingleVariable3DCustomPointImpl(
-      d, t, y, data, layout, axesLocal, offset, interpolant, derivatives);
+      d, t, y, data, layout, axes, offset, interpolant, derivatives);
   return 0;
 }
 
 /// GPU-optimized 3D log-interpolation with derivatives (batch)
 inline int LogInterpolateDifferentiateSingleVariable3DCustom(
     const double* d, const double* t, const double* y, std::size_t count,
-    const double* gridD, int nD,
-    const double* gridT, int nT,
-    const double* gridY, int nY,
+    const Axis axes[3],
     const double* data,
     double offset,
     double* interpolants,
@@ -48,15 +40,11 @@ inline int LogInterpolateDifferentiateSingleVariable3DCustom(
 {
   if (d == nullptr || t == nullptr || y == nullptr ||
       data == nullptr || interpolants == nullptr || derivatives == nullptr ||
-      gridD == nullptr || gridT == nullptr || gridY == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr || axes[2].grid == nullptr) {
     return 1;
   }
 
-  Axis axesLocal[3] = {
-      MakeAxis(gridD, nD, AxisScale::Log10),
-      MakeAxis(gridT, nT, AxisScale::Log10),
-      MakeAxis(gridY, nY, AxisScale::Linear)};
-  int extents[3] = {nD, nT, nY};
+  int extents[3] = {axes[0].n, axes[1].n, axes[2].n};
   const Layout layout = MakeLayout(extents, 3);
 
   for (std::size_t i = 0; i < count; ++i) {
@@ -64,7 +52,7 @@ inline int LogInterpolateDifferentiateSingleVariable3DCustom(
     double interp = 0.0;
     detail::LogInterpolateDifferentiateSingleVariable3DCustomPointImpl(
         d[i], t[i], y[i],
-        data, layout, axesLocal,
+        data, layout, axes,
         offset, interp, deriv);
     interpolants[i] = interp;
     derivatives[i * 3 + 0] = deriv[0];
@@ -77,9 +65,7 @@ inline int LogInterpolateDifferentiateSingleVariable3DCustom(
 inline int LogInterpolateDifferentiateSingleVariable2D2DCustomPoint(
     const double* logE, std::size_t sizeE,
     double logT, double logX,
-    const double* gridE, int nE,
-    const double* gridT, int nT,
-    const double* gridX, int nX,
+    const Axis axes[4],
     const double* data,
     double offset,
     double* interpolantPlane,
@@ -88,19 +74,15 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustomPoint(
 {
   if (logE == nullptr || data == nullptr ||
       interpolantPlane == nullptr || derivativeTPlane == nullptr || derivativeXPlane == nullptr ||
-      gridE == nullptr || gridT == nullptr || gridX == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr ||
+      axes[2].grid == nullptr || axes[3].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0) {
     return 0;
   }
 
-  Axis axes[4] = {
-      MakeAxis(gridE, nE, AxisScale::Linear),
-      MakeAxis(gridE, nE, AxisScale::Linear),
-      MakeAxis(gridT, nT, AxisScale::Linear),
-      MakeAxis(gridX, nX, AxisScale::Linear)};
-  int extents[4] = {nE, nE, nT, nX};
+  int extents[4] = {axes[0].n, axes[1].n, axes[2].n, axes[3].n};
   const Layout layout = MakeLayout(extents, 4);
 
   int idxT = 0;
@@ -151,9 +133,7 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustomPoint(
 inline int LogInterpolateDifferentiateSingleVariable2D2DCustom(
     const double* logE, std::size_t sizeE,
     const double* logT, const double* logX, std::size_t count,
-    const double* gridE, int nE,
-    const double* gridT, int nT,
-    const double* gridX, int nX,
+    const Axis axes[4],
     const double* data,
     double offset,
     double* interpolant,
@@ -163,7 +143,8 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustom(
   if (logE == nullptr || logT == nullptr || logX == nullptr ||
       data == nullptr || interpolant == nullptr ||
       derivativeT == nullptr || derivativeX == nullptr ||
-      gridE == nullptr || gridT == nullptr || gridX == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr ||
+      axes[2].grid == nullptr || axes[3].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0 || count == 0) {
@@ -178,9 +159,7 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustom(
     const int rc = LogInterpolateDifferentiateSingleVariable2D2DCustomPoint(
         logE, sizeE,
         logT[l], logX[l],
-        gridE, nE,
-        gridT, nT,
-        gridX, nX,
+        axes,
         data, offset,
         planeInterp, planeDerivT, planeDerivX);
     if (rc != 0) {
@@ -194,8 +173,7 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustom(
 inline int LogInterpolateDifferentiateSingleVariable2D2DCustomAlignedPoint(
     std::size_t sizeE,
     double logT, double logX,
-    const double* gridT, int nT,
-    const double* gridX, int nX,
+    const Axis axes[2],
     const double* data,
     double offset,
     double* interpolantPlane,
@@ -204,21 +182,18 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustomAlignedPoint(
 {
   if (data == nullptr || interpolantPlane == nullptr ||
       derivativeTPlane == nullptr || derivativeXPlane == nullptr ||
-      gridT == nullptr || gridX == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0) {
     return 0;
   }
 
-  Axis axes[2] = {
-      MakeAxis(gridT, nT, AxisScale::Linear),
-      MakeAxis(gridX, nX, AxisScale::Linear)};
   int extents[4] = {
       static_cast<int>(sizeE),
       static_cast<int>(sizeE),
-      nT,
-      nX};
+      axes[0].n,
+      axes[1].n};
   const Layout layout = MakeLayout(extents, 4);
 
   int idxT = 0;
@@ -261,8 +236,7 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustomAlignedPoint(
 inline int LogInterpolateDifferentiateSingleVariable2D2DCustomAligned(
     std::size_t sizeE,
     const double* logT, const double* logX, std::size_t count,
-    const double* gridT, int nT,
-    const double* gridX, int nX,
+    const Axis axes[2],
     const double* data,
     double offset,
     double* interpolant,
@@ -272,7 +246,7 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustomAligned(
   if (logT == nullptr || logX == nullptr ||
       data == nullptr || interpolant == nullptr ||
       derivativeT == nullptr || derivativeX == nullptr ||
-      gridT == nullptr || gridX == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0 || count == 0) {
@@ -286,7 +260,7 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustomAligned(
     double* planeDerivX = derivativeX + k * planeSize;
     const int rc = LogInterpolateDifferentiateSingleVariable2D2DCustomAlignedPoint(
         sizeE, logT[k], logX[k],
-        gridT, nT, gridX, nX,
+        axes,
         data, offset,
         planeInterp, planeDerivT, planeDerivX);
     if (rc != 0) {

--- a/src/detail/WeakLibReader_LogInterpolatePoint.hpp
+++ b/src/detail/WeakLibReader_LogInterpolatePoint.hpp
@@ -13,20 +13,16 @@ namespace WeakLibReader {
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 double LogInterpolateSingleVariable2DCustomPoint(
     double x0, double x1,
-    const double* grid0, int n0,
-    const double* grid1, int n1,
+    const Axis axes[2],
     const double* data,
     double offset) noexcept
 {
-  if (data == nullptr || grid0 == nullptr || grid1 == nullptr) {
+  if (data == nullptr || axes[0].grid == nullptr || axes[1].grid == nullptr) {
     return std::numeric_limits<double>::quiet_NaN();
   }
   // Compile-time known dimensionality (eliminates runtime branching!)
   constexpr int ND = 2;
-  Axis axes[ND] = {
-      MakeAxis(grid0, n0, AxisScale::Linear),
-      MakeAxis(grid1, n1, AxisScale::Linear)};
-  int extents[ND] = {n0, n1};
+  int extents[ND] = {axes[0].n, axes[1].n};
   const Layout layout = MakeLayout(extents, ND);
   double coords[ND] = {x0, x1};
   // Template parameter known at compile time - zero branching!
@@ -37,21 +33,17 @@ double LogInterpolateSingleVariable2DCustomPoint(
 /// Uses compile-time dimensionality for zero runtime branching
 inline int LogInterpolateSingleVariable2DCustom(
     const double* x0, const double* x1, std::size_t count,
-    const double* grid0, int n0,
-    const double* grid1, int n1,
+    const Axis axes[2],
     const double* data,
     double offset,
     double* out) noexcept
 {
   if (x0 == nullptr || x1 == nullptr || out == nullptr ||
-      data == nullptr || grid0 == nullptr || grid1 == nullptr) {
+      data == nullptr || axes[0].grid == nullptr || axes[1].grid == nullptr) {
     return 1;
   }
   constexpr int ND = 2;
-  Axis axes[ND] = {
-      MakeAxis(grid0, n0, AxisScale::Linear),
-      MakeAxis(grid1, n1, AxisScale::Linear)};
-  int extents[ND] = {n0, n1};
+  int extents[ND] = {axes[0].n, axes[1].n};
   const Layout layout = MakeLayout(extents, ND);
   for (std::size_t i = 0; i < count; ++i) {
     double coords[ND] = {x0[i], x1[i]};
@@ -65,21 +57,16 @@ inline int LogInterpolateSingleVariable2DCustom(
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 double LogInterpolateSingleVariable3DCustomPoint(
     double x0, double x1, double x2,
-    const double* grid0, int n0,
-    const double* grid1, int n1,
-    const double* grid2, int n2,
+    const Axis axes[3],
     const double* data,
     double offset) noexcept
 {
-  if (data == nullptr || grid0 == nullptr || grid1 == nullptr || grid2 == nullptr) {
+  if (data == nullptr || axes[0].grid == nullptr ||
+      axes[1].grid == nullptr || axes[2].grid == nullptr) {
     return std::numeric_limits<double>::quiet_NaN();
   }
   constexpr int ND = 3;
-  Axis axes[ND] = {
-      MakeAxis(grid0, n0, AxisScale::Log10),
-      MakeAxis(grid1, n1, AxisScale::Log10),
-      MakeAxis(grid2, n2, AxisScale::Linear)};
-  int extents[ND] = {n0, n1, n2};
+  int extents[ND] = {axes[0].n, axes[1].n, axes[2].n};
   const Layout layout = MakeLayout(extents, ND);
   double coords[ND] = {x0, x1, x2};
   return detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
@@ -89,24 +76,18 @@ double LogInterpolateSingleVariable3DCustomPoint(
 /// Uses compile-time dimensionality for zero runtime branching
 inline int LogInterpolateSingleVariable3DCustom(
     const double* x0, const double* x1, const double* x2, std::size_t count,
-    const double* grid0, int n0,
-    const double* grid1, int n1,
-    const double* grid2, int n2,
+    const Axis axes[3],
     const double* data,
     double offset,
     double* out) noexcept
 {
   if (x0 == nullptr || x1 == nullptr || x2 == nullptr ||
       out == nullptr || data == nullptr ||
-      grid0 == nullptr || grid1 == nullptr || grid2 == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr || axes[2].grid == nullptr) {
     return 1;
   }
   constexpr int ND = 3;
-  Axis axes[ND] = {
-      MakeAxis(grid0, n0, AxisScale::Log10),
-      MakeAxis(grid1, n1, AxisScale::Log10),
-      MakeAxis(grid2, n2, AxisScale::Linear)};
-  int extents[ND] = {n0, n1, n2};
+  int extents[ND] = {axes[0].n, axes[1].n, axes[2].n};
   const Layout layout = MakeLayout(extents, ND);
   for (std::size_t i = 0; i < count; ++i) {
     double coords[ND] = {x0[i], x1[i], x2[i]};
@@ -120,24 +101,16 @@ inline int LogInterpolateSingleVariable3DCustom(
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 double LogInterpolateSingleVariable4DCustomPoint(
     double x0, double x1, double x2, double x3,
-    const double* grid0, int n0,
-    const double* grid1, int n1,
-    const double* grid2, int n2,
-    const double* grid3, int n3,
+    const Axis axes[4],
     const double* data,
     double offset) noexcept
 {
-  if (data == nullptr || grid0 == nullptr || grid1 == nullptr ||
-      grid2 == nullptr || grid3 == nullptr) {
+  if (data == nullptr || axes[0].grid == nullptr || axes[1].grid == nullptr ||
+      axes[2].grid == nullptr || axes[3].grid == nullptr) {
     return std::numeric_limits<double>::quiet_NaN();
   }
   constexpr int ND = 4;
-  Axis axes[ND] = {
-      MakeAxis(grid0, n0, AxisScale::Linear),
-      MakeAxis(grid1, n1, AxisScale::Linear),
-      MakeAxis(grid2, n2, AxisScale::Linear),
-      MakeAxis(grid3, n3, AxisScale::Linear)};
-  int extents[ND] = {n0, n1, n2, n3};
+  int extents[ND] = {axes[0].n, axes[1].n, axes[2].n, axes[3].n};
   const Layout layout = MakeLayout(extents, ND);
   double coords[ND] = {x0, x1, x2, x3};
   return detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
@@ -148,26 +121,19 @@ double LogInterpolateSingleVariable4DCustomPoint(
 inline int LogInterpolateSingleVariable4DCustom(
     const double* x0, const double* x1, const double* x2, const double* x3,
     std::size_t count,
-    const double* grid0, int n0,
-    const double* grid1, int n1,
-    const double* grid2, int n2,
-    const double* grid3, int n3,
+    const Axis axes[4],
     const double* data,
     double offset,
     double* out) noexcept
 {
   if (x0 == nullptr || x1 == nullptr || x2 == nullptr || x3 == nullptr ||
       out == nullptr || data == nullptr ||
-      grid0 == nullptr || grid1 == nullptr || grid2 == nullptr || grid3 == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr ||
+      axes[2].grid == nullptr || axes[3].grid == nullptr) {
     return 1;
   }
   constexpr int ND = 4;
-  Axis axes[ND] = {
-      MakeAxis(grid0, n0, AxisScale::Linear),
-      MakeAxis(grid1, n1, AxisScale::Linear),
-      MakeAxis(grid2, n2, AxisScale::Linear),
-      MakeAxis(grid3, n3, AxisScale::Linear)};
-  int extents[ND] = {n0, n1, n2, n3};
+  int extents[ND] = {axes[0].n, axes[1].n, axes[2].n, axes[3].n};
   const Layout layout = MakeLayout(extents, ND);
   for (std::size_t i = 0; i < count; ++i) {
     double coords[ND] = {x0[i], x1[i], x2[i], x3[i]};

--- a/src/detail/WeakLibReader_LogInterpolateSum.hpp
+++ b/src/detail/WeakLibReader_LogInterpolateSum.hpp
@@ -12,8 +12,7 @@ inline int SumLogInterpolateSingleVariable2D2DCustomAligned(
     std::size_t sizeE,
     const double* logD, std::size_t nAlpha,
     const double* logT, std::size_t count,
-    const double* gridD, int nD,
-    const double* gridT, int nT,
+    const Axis axes[2],
     const double* alpha,
     const double* data,
     double offset,
@@ -21,21 +20,18 @@ inline int SumLogInterpolateSingleVariable2D2DCustomAligned(
 {
   if (logD == nullptr || logT == nullptr || data == nullptr ||
       alpha == nullptr || out == nullptr ||
-      gridD == nullptr || gridT == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0 || nAlpha == 0 || count == 0) {
     return 0;
   }
 
-  Axis axes[2] = {
-      MakeAxis(gridD, nD, AxisScale::Linear),
-      MakeAxis(gridT, nT, AxisScale::Linear)};
   int extents[4] = {
       static_cast<int>(sizeE),
       static_cast<int>(sizeE),
-      nD,
-      nT};
+      axes[0].n,
+      axes[1].n};
   const Layout layout = MakeLayout(extents, 4);
 
   const std::size_t planeSize = sizeE * sizeE;

--- a/src/detail/WeakLibReader_LogInterpolateSweep.hpp
+++ b/src/detail/WeakLibReader_LogInterpolateSweep.hpp
@@ -11,16 +11,14 @@ namespace WeakLibReader {
 inline int LogInterpolateSingleVariable1D3DCustomPoint(
     const double* logE, std::size_t sizeE,
     double logD, double logT, double y,
-    const double* gridE, int nE,
-    const double* gridD, int nD,
-    const double* gridT, int nT,
-    const double* gridY, int nY,
+    const Axis axes[4],
     const double* data,
     double offset,
     double* out) noexcept
 {
   if (logE == nullptr || out == nullptr || data == nullptr ||
-      gridE == nullptr || gridD == nullptr || gridT == nullptr || gridY == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr ||
+      axes[2].grid == nullptr || axes[3].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0) {
@@ -28,12 +26,7 @@ inline int LogInterpolateSingleVariable1D3DCustomPoint(
   }
 
   constexpr int ND = 4;
-  Axis axes[ND] = {
-      MakeAxis(gridE, nE, AxisScale::Linear),
-      MakeAxis(gridD, nD, AxisScale::Linear),
-      MakeAxis(gridT, nT, AxisScale::Linear),
-      MakeAxis(gridY, nY, AxisScale::Linear)};
-  int extents[ND] = {nE, nD, nT, nY};
+  int extents[ND] = {axes[0].n, axes[1].n, axes[2].n, axes[3].n};
   const Layout layout = MakeLayout(extents, ND);
 
   for (std::size_t i = 0; i < sizeE; ++i) {
@@ -48,17 +41,15 @@ inline int LogInterpolateSingleVariable1D3DCustomPoint(
 inline int LogInterpolateSingleVariable1D3DCustom(
     const double* logE, std::size_t sizeE,
     const double* logD, const double* logT, const double* y, std::size_t count,
-    const double* gridE, int nE,
-    const double* gridD, int nD,
-    const double* gridT, int nT,
-    const double* gridY, int nY,
+    const Axis axes[4],
     const double* data,
     double offset,
     double* out) noexcept
 {
   if (logE == nullptr || logD == nullptr || logT == nullptr || y == nullptr ||
       out == nullptr || data == nullptr ||
-      gridE == nullptr || gridD == nullptr || gridT == nullptr || gridY == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr ||
+      axes[2].grid == nullptr || axes[3].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0 || count == 0) {
@@ -66,12 +57,7 @@ inline int LogInterpolateSingleVariable1D3DCustom(
   }
 
   constexpr int ND = 4;
-  Axis axes[ND] = {
-      MakeAxis(gridE, nE, AxisScale::Linear),
-      MakeAxis(gridD, nD, AxisScale::Linear),
-      MakeAxis(gridT, nT, AxisScale::Linear),
-      MakeAxis(gridY, nY, AxisScale::Linear)};
-  int extents[ND] = {nE, nD, nT, nY};
+  int extents[ND] = {axes[0].n, axes[1].n, axes[2].n, axes[3].n};
   const Layout layout = MakeLayout(extents, ND);
 
   for (std::size_t j = 0; j < count; ++j) {
@@ -89,15 +75,14 @@ inline int LogInterpolateSingleVariable1D3DCustom(
 inline int LogInterpolateSingleVariable2D2DCustomPoint(
     const double* logE, std::size_t sizeE,
     double logT, double logX,
-    const double* gridE, int nE,
-    const double* gridT, int nT,
-    const double* gridX, int nX,
+    const Axis axes[4],
     const double* data,
     double offset,
     double* out) noexcept
 {
   if (logE == nullptr || data == nullptr || out == nullptr ||
-      gridE == nullptr || gridT == nullptr || gridX == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr ||
+      axes[2].grid == nullptr || axes[3].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0) {
@@ -105,12 +90,7 @@ inline int LogInterpolateSingleVariable2D2DCustomPoint(
   }
 
   constexpr int ND = 4;
-  Axis axes[ND] = {
-      MakeAxis(gridE, nE, AxisScale::Linear),
-      MakeAxis(gridE, nE, AxisScale::Linear),
-      MakeAxis(gridT, nT, AxisScale::Linear),
-      MakeAxis(gridX, nX, AxisScale::Linear)};
-  int extents[ND] = {nE, nE, nT, nX};
+  int extents[ND] = {axes[0].n, axes[1].n, axes[2].n, axes[3].n};
   const Layout layout = MakeLayout(extents, ND);
 
   for (std::size_t j = 0; j < sizeE; ++j) {
@@ -128,16 +108,15 @@ inline int LogInterpolateSingleVariable2D2DCustomPoint(
 inline int LogInterpolateSingleVariable2D2DCustom(
     const double* logE, std::size_t sizeE,
     const double* logT, const double* logX, std::size_t count,
-    const double* gridE, int nE,
-    const double* gridT, int nT,
-    const double* gridX, int nX,
+    const Axis axes[4],
     const double* data,
     double offset,
     double* out) noexcept
 {
   if (logE == nullptr || logT == nullptr || logX == nullptr ||
       out == nullptr || data == nullptr ||
-      gridE == nullptr || gridT == nullptr || gridX == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr ||
+      axes[2].grid == nullptr || axes[3].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0 || count == 0) {
@@ -145,12 +124,7 @@ inline int LogInterpolateSingleVariable2D2DCustom(
   }
 
   constexpr int ND = 4;
-  Axis axes[ND] = {
-      MakeAxis(gridE, nE, AxisScale::Linear),
-      MakeAxis(gridE, nE, AxisScale::Linear),
-      MakeAxis(gridT, nT, AxisScale::Linear),
-      MakeAxis(gridX, nX, AxisScale::Linear)};
-  int extents[ND] = {nE, nE, nT, nX};
+  int extents[ND] = {axes[0].n, axes[1].n, axes[2].n, axes[3].n};
   const Layout layout = MakeLayout(extents, ND);
 
   const std::size_t planeSize = sizeE * sizeE;
@@ -171,27 +145,24 @@ inline int LogInterpolateSingleVariable2D2DCustom(
 inline int LogInterpolateSingleVariable2D2DCustomAlignedPoint(
     std::size_t sizeE,
     double logT, double logX,
-    const double* gridT, int nT,
-    const double* gridX, int nX,
+    const Axis axes[2],
     const double* data,
     double offset,
     double* out) noexcept
 {
-  if (data == nullptr || out == nullptr) {
+  if (data == nullptr || out == nullptr ||
+      axes[0].grid == nullptr || axes[1].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0) {
     return 0;
   }
 
-  Axis axes[2] = {
-      MakeAxis(gridT, nT, AxisScale::Linear),
-      MakeAxis(gridX, nX, AxisScale::Linear)};
   int extents[4] = {
       static_cast<int>(sizeE),
       static_cast<int>(sizeE),
-      nT,
-      nX};
+      axes[0].n,
+      axes[1].n};
   const Layout layout = MakeLayout(extents, 4);
 
   int idxT = 0;
@@ -217,14 +188,13 @@ inline int LogInterpolateSingleVariable2D2DCustomAlignedPoint(
 inline int LogInterpolateSingleVariable2D2DCustomAligned(
     std::size_t sizeE,
     const double* logT, const double* logX, std::size_t count,
-    const double* gridT, int nT,
-    const double* gridX, int nX,
+    const Axis axes[2],
     const double* data,
     double offset,
     double* out) noexcept
 {
   if (logT == nullptr || logX == nullptr || data == nullptr || out == nullptr ||
-      gridT == nullptr || gridX == nullptr) {
+      axes[0].grid == nullptr || axes[1].grid == nullptr) {
     return 1;
   }
   if (sizeE == 0 || count == 0) {
@@ -236,7 +206,7 @@ inline int LogInterpolateSingleVariable2D2DCustomAligned(
     double* plane = out + k * planeSize;
     const int rc = LogInterpolateSingleVariable2D2DCustomAlignedPoint(
         sizeE, logT[k], logX[k],
-        gridT, nT, gridX, nX,
+        axes,
         data, offset, plane);
     if (rc != 0) {
       return rc;

--- a/test/test_log_interpolate_2d.cpp
+++ b/test/test_log_interpolate_2d.cpp
@@ -37,10 +37,7 @@ TEST_CASE("2D log interpolation matches bilinear expectation", "[loginterp][2d]"
   const double x = 1.5;
   const double y = 2.0;
   const double result = LogInterpolateSingleVariable2DCustomPoint(
-      x, y,
-      gridX.data(), 2,
-      gridY.data(), 2,
-      table.data(), 0.0);
+      x, y, axes, table.data(), 0.0);
 
   const double dX = (x - gridX[0]) / (gridX[1] - gridX[0]);
   const double dY = (y - gridY[0]) / (gridY[1] - gridY[0]);
@@ -67,14 +64,17 @@ TEST_CASE("Batch 2D log interpolation matches point wrapper", "[loginterp][2d][b
       std::log10(4.0),
       std::log10(5.0)};
 
+  Axis axes[2] = {
+      MakeAxis(gridX.data(), 2, AxisScale::Linear),
+      MakeAxis(gridY.data(), 2, AxisScale::Linear)};
+
   std::array<double, 3> x0{1.0, 1.5, 2.0};
   std::array<double, 3> x1{1.0, 2.0, 3.0};
   std::array<double, 3> out{};
 
   const int rc = LogInterpolateSingleVariable2DCustom(
       x0.data(), x1.data(), x0.size(),
-      gridX.data(), 2,
-      gridY.data(), 2,
+      axes,
       table.data(),
       0.0,
       out.data());
@@ -82,11 +82,7 @@ TEST_CASE("Batch 2D log interpolation matches point wrapper", "[loginterp][2d][b
 
   for (std::size_t i = 0; i < x0.size(); ++i) {
     const double point = LogInterpolateSingleVariable2DCustomPoint(
-        x0[i], x1[i],
-        gridX.data(), 2,
-        gridY.data(), 2,
-        table.data(),
-        0.0);
+        x0[i], x1[i], axes, table.data(), 0.0);
     CHECK(out[i] == Catch::Approx(point).margin(kTol));
   }
 }

--- a/test/test_log_interpolate_3d.cpp
+++ b/test/test_log_interpolate_3d.cpp
@@ -39,15 +39,16 @@ TEST_CASE("3D log interpolation matches trilinear expectation", "[loginterp][3d]
     }
   }
 
+  Axis axes[3] = {
+      MakeAxis(gridX.data(), 2, AxisScale::Log10),
+      MakeAxis(gridY.data(), 2, AxisScale::Log10),
+      MakeAxis(gridZ.data(), 2, AxisScale::Linear)};
+
   const double x = 1.5;
   const double y = 2.0;
   const double z = 0.4;
   const double result = LogInterpolateSingleVariable3DCustomPoint(
-      x, y, z,
-      gridX.data(), 2,
-      gridY.data(), 2,
-      gridZ.data(), 2,
-      table.data(), 0.0);
+      x, y, z, axes, table.data(), 0.0);
 
   // Compute expected via trilinear interpolation in log space
   // X and Y axes use Log10 scale, Z axis uses Linear scale
@@ -98,6 +99,11 @@ TEST_CASE("Batch 3D log interpolation matches point wrapper", "[loginterp][3d][b
     }
   }
 
+  Axis axes[3] = {
+      MakeAxis(gridX.data(), 2, AxisScale::Log10),
+      MakeAxis(gridY.data(), 2, AxisScale::Log10),
+      MakeAxis(gridZ.data(), 2, AxisScale::Linear)};
+
   std::array<double, 3> x0{1.0, 1.5, 2.0};
   std::array<double, 3> x1{1.0, 2.0, 3.0};
   std::array<double, 3> x2{0.0, 0.5, 1.0};
@@ -105,9 +111,7 @@ TEST_CASE("Batch 3D log interpolation matches point wrapper", "[loginterp][3d][b
 
   const int rc = LogInterpolateSingleVariable3DCustom(
       x0.data(), x1.data(), x2.data(), x0.size(),
-      gridX.data(), 2,
-      gridY.data(), 2,
-      gridZ.data(), 2,
+      axes,
       table.data(),
       0.0,
       out.data());
@@ -115,12 +119,61 @@ TEST_CASE("Batch 3D log interpolation matches point wrapper", "[loginterp][3d][b
 
   for (std::size_t i = 0; i < x0.size(); ++i) {
     const double point = LogInterpolateSingleVariable3DCustomPoint(
-        x0[i], x1[i], x2[i],
-        gridX.data(), 2,
-        gridY.data(), 2,
-        gridZ.data(), 2,
-        table.data(),
-        0.0);
+        x0[i], x1[i], x2[i], axes, table.data(), 0.0);
     CHECK(out[i] == Catch::Approx(point).margin(kTol));
   }
+}
+
+TEST_CASE("3D interpolation respects axis scales", "[loginterp][3d][scales]")
+{
+  using namespace WeakLibReader;
+
+  // Create a simple 2x2x2 grid with values that will produce
+  // different results depending on Linear vs Log10 interpolation
+  const std::array<double, 2> gridX{1.0, 10.0};  // Log10 range
+  const std::array<double, 2> gridY{1.0, 10.0};  // Log10 range
+  const std::array<double, 2> gridZ{0.0, 1.0};
+
+  const int extents[3] = {2, 2, 2};
+  const Layout layout = MakeLayout(extents, 3);
+  std::array<double, 8> table{};
+
+  // Fill with log10 of a simple function
+  for (int ix = 0; ix < 2; ++ix) {
+    for (int iy = 0; iy < 2; ++iy) {
+      for (int iz = 0; iz < 2; ++iz) {
+        table[layout.Offset(ix, iy, iz)] =
+            std::log10(1.0 + gridX[ix] + gridY[iy] + gridZ[iz]);
+      }
+    }
+  }
+
+  // Test point at geometric midpoint (for Log10) vs arithmetic midpoint (for Linear)
+  const double x = std::sqrt(1.0 * 10.0);  // Geometric mean = 3.162...
+  const double y = std::sqrt(1.0 * 10.0);
+  const double z = 0.5;
+
+  // With Log10 scales on X and Y
+  Axis axesLog[3] = {
+      MakeAxis(gridX.data(), 2, AxisScale::Log10),
+      MakeAxis(gridY.data(), 2, AxisScale::Log10),
+      MakeAxis(gridZ.data(), 2, AxisScale::Linear)};
+  const double resultLog = LogInterpolateSingleVariable3DCustomPoint(
+      x, y, z, axesLog, table.data(), 0.0);
+
+  // With Linear scales on X and Y
+  Axis axesLin[3] = {
+      MakeAxis(gridX.data(), 2, AxisScale::Linear),
+      MakeAxis(gridY.data(), 2, AxisScale::Linear),
+      MakeAxis(gridZ.data(), 2, AxisScale::Linear)};
+  const double resultLin = LogInterpolateSingleVariable3DCustomPoint(
+      x, y, z, axesLin, table.data(), 0.0);
+
+  // The results should be different because the interpolation
+  // fractions are computed differently for Log10 vs Linear
+  CHECK(resultLog != Catch::Approx(resultLin).margin(1e-6));
+
+  // For Log10 scale at geometric midpoint, fraction should be 0.5
+  // For Linear scale at x=3.162..., fraction should be (3.162-1)/(10-1) = 0.24
+  // So the Log10 result should be closer to the center of the interpolation range
 }

--- a/test/test_log_interpolate_4d5d.cpp
+++ b/test/test_log_interpolate_4d5d.cpp
@@ -43,24 +43,20 @@ TEST_CASE("4D log interpolation matches quadrilinear expectation", "[loginterp][
     }
   }
 
-  const double a = 1.5;
-  const double b = 2.0;
-  const double c = 0.4;
-  const double d = 7.0;
-  const double result = LogInterpolateSingleVariable4DCustomPoint(
-      a, b, c, d,
-      gridA.data(), 2,
-      gridB.data(), 2,
-      gridC.data(), 2,
-      gridD.data(), 2,
-      table.data(), 0.0);
-
-  // Verify by computing via 4D wrapper
   Axis axes[4] = {
       MakeAxis(gridA.data(), 2, AxisScale::Linear),
       MakeAxis(gridB.data(), 2, AxisScale::Linear),
       MakeAxis(gridC.data(), 2, AxisScale::Linear),
       MakeAxis(gridD.data(), 2, AxisScale::Linear)};
+
+  const double a = 1.5;
+  const double b = 2.0;
+  const double c = 0.4;
+  const double d = 7.0;
+  const double result = LogInterpolateSingleVariable4DCustomPoint(
+      a, b, c, d, axes, table.data(), 0.0);
+
+  // Verify by computing via 4D wrapper
   double coords[4] = {a, b, c, d};
   const double expected = detail::LogInterpolatedValueDirect<4>(
       table.data(), layout, axes, coords, 0.0);
@@ -92,6 +88,12 @@ TEST_CASE("Batch 4D log interpolation matches point wrapper", "[loginterp][4d][b
     }
   }
 
+  Axis axes[4] = {
+      MakeAxis(gridA.data(), 2, AxisScale::Linear),
+      MakeAxis(gridB.data(), 2, AxisScale::Linear),
+      MakeAxis(gridC.data(), 2, AxisScale::Linear),
+      MakeAxis(gridD.data(), 2, AxisScale::Linear)};
+
   std::array<double, 3> x0{1.0, 1.5, 2.0};
   std::array<double, 3> x1{1.0, 2.0, 3.0};
   std::array<double, 3> x2{0.0, 0.5, 1.0};
@@ -100,10 +102,7 @@ TEST_CASE("Batch 4D log interpolation matches point wrapper", "[loginterp][4d][b
 
   const int rc = LogInterpolateSingleVariable4DCustom(
       x0.data(), x1.data(), x2.data(), x3.data(), x0.size(),
-      gridA.data(), 2,
-      gridB.data(), 2,
-      gridC.data(), 2,
-      gridD.data(), 2,
+      axes,
       table.data(),
       0.0,
       out.data());
@@ -111,13 +110,7 @@ TEST_CASE("Batch 4D log interpolation matches point wrapper", "[loginterp][4d][b
 
   for (std::size_t i = 0; i < x0.size(); ++i) {
     const double point = LogInterpolateSingleVariable4DCustomPoint(
-        x0[i], x1[i], x2[i], x3[i],
-        gridA.data(), 2,
-        gridB.data(), 2,
-        gridC.data(), 2,
-        gridD.data(), 2,
-        table.data(),
-        0.0);
+        x0[i], x1[i], x2[i], x3[i], axes, table.data(), 0.0);
     CHECK(out[i] == Catch::Approx(point).margin(kTol));
   }
 }
@@ -438,23 +431,20 @@ TEST_CASE("1D3D sweep batch matches direct interpolation", "[loginterp][4d][batc
   std::array<double, count> y{0.25, 0.75};
   std::array<double, sizeE * count> out{};
 
-  const int rc = LogInterpolateSingleVariable1D3DCustom(
-      logE.data(), sizeE,
-      logD.data(), logT.data(), y.data(), count,
-      gridE.data(), 2,
-      gridD.data(), 2,
-      gridT.data(), 2,
-      gridY.data(), 2,
-      table.data(),
-      0.0,
-      out.data());
-  REQUIRE(rc == 0);
-
   Axis axes[4] = {
       MakeAxis(gridE.data(), 2, AxisScale::Linear),
       MakeAxis(gridD.data(), 2, AxisScale::Linear),
       MakeAxis(gridT.data(), 2, AxisScale::Linear),
       MakeAxis(gridY.data(), 2, AxisScale::Linear)};
+
+  const int rc = LogInterpolateSingleVariable1D3DCustom(
+      logE.data(), sizeE,
+      logD.data(), logT.data(), y.data(), count,
+      axes,
+      table.data(),
+      0.0,
+      out.data());
+  REQUIRE(rc == 0);
 
   for (std::size_t j = 0; j < count; ++j) {
     for (std::size_t i = 0; i < sizeE; ++i) {
@@ -497,6 +487,12 @@ TEST_CASE("1D3D single point matches batch with count=1", "[loginterp][4d][1d3d]
     }
   }
 
+  Axis axes[4] = {
+      MakeAxis(gridE.data(), 2, AxisScale::Linear),
+      MakeAxis(gridD.data(), 2, AxisScale::Linear),
+      MakeAxis(gridT.data(), 2, AxisScale::Linear),
+      MakeAxis(gridY.data(), 2, AxisScale::Linear)};
+
   std::array<double, sizeE> logE{1.0, 1.5, 2.0};
   const double logD = 2.0;
   const double logT = 15.0;
@@ -506,10 +502,7 @@ TEST_CASE("1D3D single point matches batch with count=1", "[loginterp][4d][1d3d]
   const int rcPoint = LogInterpolateSingleVariable1D3DCustomPoint(
       logE.data(), sizeE,
       logD, logT, y,
-      gridE.data(), 2,
-      gridD.data(), 2,
-      gridT.data(), 2,
-      gridY.data(), 2,
+      axes,
       table.data(),
       0.0,
       outPoint.data());
@@ -524,10 +517,7 @@ TEST_CASE("1D3D single point matches batch with count=1", "[loginterp][4d][1d3d]
   const int rcBatch = LogInterpolateSingleVariable1D3DCustom(
       logE.data(), sizeE,
       logDArr.data(), logTArr.data(), yArr.data(), 1,
-      gridE.data(), 2,
-      gridD.data(), 2,
-      gridT.data(), 2,
-      gridY.data(), 2,
+      axes,
       table.data(),
       0.0,
       outBatch.data());

--- a/test/test_log_interpolate_deriv.cpp
+++ b/test/test_log_interpolate_deriv.cpp
@@ -82,9 +82,7 @@ TEST_CASE("Log derivative wrapper matches direct kernel for 3D tables", "[logint
   double deriv[3] = {0.0, 0.0, 0.0};
   const int rc = LogInterpolateDifferentiateSingleVariable3DCustomPoint(
       dCoord, tCoord, yCoord,
-      gridD.data(), 2,
-      gridT.data(), 2,
-      gridY.data(), 2,
+      axes,
       table.data(),
       0.0, interpolated, deriv);
   REQUIRE(rc == 0);
@@ -150,8 +148,7 @@ TEST_CASE("Aligned derivative wrapper mirrors kernel output", "[loginterp][deriv
 
   const int rc = LogInterpolateDifferentiateSingleVariable2D2DCustomAlignedPoint(
       sizeE, logTCoord, logXCoord,
-      gridT.data(), 2,
-      gridX.data(), 2,
+      axes,
       table.data(),
       0.0,
       planeInterp.data(),
@@ -212,6 +209,11 @@ TEST_CASE("Batch 3D derivative matches point version", "[loginterp][3d][derivati
     }
   }
 
+  Axis axes[3] = {
+      MakeAxis(gridD.data(), 2, AxisScale::Log10),
+      MakeAxis(gridT.data(), 2, AxisScale::Log10),
+      MakeAxis(gridY.data(), 2, AxisScale::Linear)};
+
   std::array<double, count> dCoord{2.0, 5.0, 8.0};
   std::array<double, count> tCoord{10.0, 50.0, 80.0};
   std::array<double, count> yCoord{0.2, 0.5, 0.8};
@@ -221,9 +223,7 @@ TEST_CASE("Batch 3D derivative matches point version", "[loginterp][3d][derivati
 
   const int rcBatch = LogInterpolateDifferentiateSingleVariable3DCustom(
       dCoord.data(), tCoord.data(), yCoord.data(), count,
-      gridD.data(), 2,
-      gridT.data(), 2,
-      gridY.data(), 2,
+      axes,
       table.data(),
       0.0,
       interpBatch.data(),
@@ -236,9 +236,7 @@ TEST_CASE("Batch 3D derivative matches point version", "[loginterp][3d][derivati
 
     const int rcPoint = LogInterpolateDifferentiateSingleVariable3DCustomPoint(
         dCoord[i], tCoord[i], yCoord[i],
-        gridD.data(), 2,
-        gridT.data(), 2,
-        gridY.data(), 2,
+        axes,
         table.data(),
         0.0,
         interpPoint, derivPoint);
@@ -279,6 +277,12 @@ TEST_CASE("Batch 2D2D derivative matches point version", "[loginterp][2d2d][deri
     }
   }
 
+  Axis axes[4] = {
+      MakeAxis(gridE.data(), static_cast<int>(sizeE), AxisScale::Linear),
+      MakeAxis(gridE.data(), static_cast<int>(sizeE), AxisScale::Linear),
+      MakeAxis(gridT.data(), 2, AxisScale::Linear),
+      MakeAxis(gridX.data(), 2, AxisScale::Linear)};
+
   const std::array<double, count> logT{1.3, 1.7};
   const std::array<double, count> logX{1.5, 2.5};
   const std::size_t planeSize = sizeE * sizeE;
@@ -290,9 +294,7 @@ TEST_CASE("Batch 2D2D derivative matches point version", "[loginterp][2d2d][deri
   const int rcBatch = LogInterpolateDifferentiateSingleVariable2D2DCustom(
       gridE.data(), sizeE,
       logT.data(), logX.data(), count,
-      gridE.data(), static_cast<int>(sizeE),
-      gridT.data(), 2,
-      gridX.data(), 2,
+      axes,
       table.data(),
       0.0,
       interpBatch.data(),
@@ -308,9 +310,7 @@ TEST_CASE("Batch 2D2D derivative matches point version", "[loginterp][2d2d][deri
     const int rcPoint = LogInterpolateDifferentiateSingleVariable2D2DCustomPoint(
         gridE.data(), sizeE,
         logT[k], logX[k],
-        gridE.data(), static_cast<int>(sizeE),
-        gridT.data(), 2,
-        gridX.data(), 2,
+        axes,
         table.data(),
         0.0,
         interpPoint.data(),
@@ -358,6 +358,10 @@ TEST_CASE("Batch aligned 2D2D derivative matches point version", "[loginterp][2d
     }
   }
 
+  Axis axes[2] = {
+      MakeAxis(gridT.data(), 2, AxisScale::Linear),
+      MakeAxis(gridX.data(), 2, AxisScale::Linear)};
+
   const std::array<double, count> logT{1.3, 1.7};
   const std::array<double, count> logX{1.5, 2.5};
   const std::size_t planeSize = sizeE * sizeE;
@@ -369,8 +373,7 @@ TEST_CASE("Batch aligned 2D2D derivative matches point version", "[loginterp][2d
   const int rcBatch = LogInterpolateDifferentiateSingleVariable2D2DCustomAligned(
       sizeE,
       logT.data(), logX.data(), count,
-      gridT.data(), 2,
-      gridX.data(), 2,
+      axes,
       table.data(),
       0.0,
       interpBatch.data(),
@@ -386,8 +389,7 @@ TEST_CASE("Batch aligned 2D2D derivative matches point version", "[loginterp][2d
     const int rcPoint = LogInterpolateDifferentiateSingleVariable2D2DCustomAlignedPoint(
         sizeE,
         logT[k], logX[k],
-        gridT.data(), 2,
-        gridX.data(), 2,
+        axes,
         table.data(),
         0.0,
         interpPoint.data(),

--- a/test/test_log_interpolate_sweep.cpp
+++ b/test/test_log_interpolate_sweep.cpp
@@ -53,8 +53,7 @@ TEST_CASE("Aligned 2D plane interpolation mirrors underlying kernel", "[loginter
 
   const int rc = LogInterpolateSingleVariable2D2DCustomAlignedPoint(
       sizeE, logT, logX,
-      gridT.data(), 2,
-      gridX.data(), 2,
+      axes,
       table.data(), 0.0, plane.data());
   REQUIRE(rc == 0);
 
@@ -125,8 +124,7 @@ TEST_CASE("Weighted sum aligned helper reproduces manual accumulation", "[logint
       sizeE,
       logD.data(), nAlpha,
       logT.data(), count,
-      gridD.data(), 2,
-      gridT.data(), 2,
+      axes,
       alpha.data(),
       table.data(),
       0.0,
@@ -188,28 +186,27 @@ TEST_CASE("Non-aligned 2D2D single point interpolation", "[loginterp][2d2d][nona
   const double logX = 2.0;
   std::array<double, sizeE * sizeE> out{};
 
+  Axis axes4[4] = {
+      MakeAxis(gridE.data(), static_cast<int>(sizeE), AxisScale::Linear),
+      MakeAxis(gridE.data(), static_cast<int>(sizeE), AxisScale::Linear),
+      MakeAxis(gridT.data(), 2, AxisScale::Linear),
+      MakeAxis(gridX.data(), 2, AxisScale::Linear)};
+
   const int rc = LogInterpolateSingleVariable2D2DCustomPoint(
       gridE.data(), sizeE, logT, logX,
-      gridE.data(), static_cast<int>(sizeE),
-      gridT.data(), 2,
-      gridX.data(), 2,
+      axes4,
       table.data(), 0.0, out.data());
   REQUIRE(rc == 0);
 
   // Verify output against direct 4D interpolation
   // The function uses symmetric storage: out[i,j] = out[j,i] = interp(E[i], E[j], T, X)
-  Axis axes[4] = {
-      MakeAxis(gridE.data(), static_cast<int>(sizeE), AxisScale::Linear),
-      MakeAxis(gridE.data(), static_cast<int>(sizeE), AxisScale::Linear),
-      MakeAxis(gridT.data(), 2, AxisScale::Linear),
-      MakeAxis(gridX.data(), 2, AxisScale::Linear)};
 
   for (std::size_t j = 0; j < sizeE; ++j) {
     for (std::size_t i = 0; i <= j; ++i) {
       // For i <= j, coords are (E[i], E[j], T, X)
       double coords[4] = {gridE[i], gridE[j], logT, logX};
       const double expected = detail::LogInterpolatedValueDirect<4>(
-          table.data(), layout, axes, coords, 0.0);
+          table.data(), layout, axes4, coords, 0.0);
       // Check both symmetric positions
       const std::size_t lower = j * sizeE + i;
       const std::size_t upper = i * sizeE + j;
@@ -249,12 +246,16 @@ TEST_CASE("Non-aligned 2D2D batch interpolation", "[loginterp][2d2d][nonaligned]
   const std::array<double, count> logX{1.5, 2.5};
   std::array<double, sizeE * sizeE * count> out{};
 
+  Axis axes4[4] = {
+      MakeAxis(gridE.data(), static_cast<int>(sizeE), AxisScale::Linear),
+      MakeAxis(gridE.data(), static_cast<int>(sizeE), AxisScale::Linear),
+      MakeAxis(gridT.data(), 2, AxisScale::Linear),
+      MakeAxis(gridX.data(), 2, AxisScale::Linear)};
+
   const int rc = LogInterpolateSingleVariable2D2DCustom(
       gridE.data(), sizeE,
       logT.data(), logX.data(), count,
-      gridE.data(), static_cast<int>(sizeE),
-      gridT.data(), 2,
-      gridX.data(), 2,
+      axes4,
       table.data(), 0.0, out.data());
   REQUIRE(rc == 0);
 
@@ -263,9 +264,7 @@ TEST_CASE("Non-aligned 2D2D batch interpolation", "[loginterp][2d2d][nonaligned]
     std::array<double, sizeE * sizeE> plane{};
     const int rcPoint = LogInterpolateSingleVariable2D2DCustomPoint(
         gridE.data(), sizeE, logT[l], logX[l],
-        gridE.data(), static_cast<int>(sizeE),
-        gridT.data(), 2,
-        gridX.data(), 2,
+        axes4,
         table.data(), 0.0, plane.data());
     REQUIRE(rcPoint == 0);
 
@@ -301,6 +300,10 @@ TEST_CASE("Batch aligned 2D2D matches point version", "[loginterp][2d2d][aligned
     }
   }
 
+  Axis axes[2] = {
+      MakeAxis(gridT.data(), 2, AxisScale::Linear),
+      MakeAxis(gridX.data(), 2, AxisScale::Linear)};
+
   const std::array<double, count> logT{1.3, 1.7};
   const std::array<double, count> logX{1.5, 2.5};
   const std::size_t planeSize = sizeE * sizeE;
@@ -309,8 +312,7 @@ TEST_CASE("Batch aligned 2D2D matches point version", "[loginterp][2d2d][aligned
   const int rcBatch = LogInterpolateSingleVariable2D2DCustomAligned(
       sizeE,
       logT.data(), logX.data(), count,
-      gridT.data(), 2,
-      gridX.data(), 2,
+      axes,
       table.data(),
       0.0,
       outBatch.data());
@@ -320,8 +322,7 @@ TEST_CASE("Batch aligned 2D2D matches point version", "[loginterp][2d2d][aligned
     std::array<double, planeSize> outPoint{};
     const int rcPoint = LogInterpolateSingleVariable2D2DCustomAlignedPoint(
         sizeE, logT[k], logX[k],
-        gridT.data(), 2,
-        gridX.data(), 2,
+        axes,
         table.data(),
         0.0,
         outPoint.data());


### PR DESCRIPTION
## Summary
- Refactor all `LogInterpolate*Custom*` functions to accept `const Axis axes[N]` instead of separate `(grid, n)` pairs for each dimension
- Reduces parameter counts significantly (e.g., 3D functions drop from 9 to 5 parameters)
- Preserves axis metadata (scale type) from caller instead of hardcoding within functions
- Add test verifying axis scale sensitivity in 3D interpolation

## Test plan
- [ ] Run `scripts/check.sh` to verify all tests pass
- [ ] Verify Cactus test thorn compiles with simplified API