### PR TITLE
Add opacity interpolation to Cactus test thorn

### DIFF
--- a/cactus_interface/TestWeakLibReader/interface.ccl
+++ b/cactus_interface/TestWeakLibReader/interface.ccl
@@ -5,3 +5,12 @@ IMPLEMENTS: TestWeakLibReader
 USES INCLUDE HEADER: loop_device.hxx
 
 CCTK_REAL energy TYPE=GF CENTERING={VVV} TAGS="checkpoint='yes'" "weaklibreader test"
+CCTK_REAL opacity_emab TYPE=GF CENTERING={VVV} TAGS="checkpoint='yes'" "EmAb opacity test"
+CCTK_REAL opacity_iso TYPE=GF CENTERING={VVV} TAGS="checkpoint='yes'" "Iso opacity test"
+CCTK_REAL eos_log_eta TYPE=GF CENTERING={VVV} TAGS="checkpoint='yes'" "log10(mu_e/(kB*T))"
+CCTK_REAL eos_dxp TYPE=GF CENTERING={VVV} TAGS="checkpoint='yes'" "D*Xp for Brem"
+CCTK_REAL eos_dxn TYPE=GF CENTERING={VVV} TAGS="checkpoint='yes'" "D*Xn for Brem"
+CCTK_REAL eos_dxpn TYPE=GF CENTERING={VVV} TAGS="checkpoint='yes'" "D*sqrt(Xp*Xn) for Brem"
+CCTK_REAL opacity_nes TYPE=GF CENTERING={VVV} TAGS="checkpoint='yes'" "NES kernel test"
+CCTK_REAL opacity_pair TYPE=GF CENTERING={VVV} TAGS="checkpoint='yes'" "Pair kernel test"
+CCTK_REAL opacity_brem TYPE=GF CENTERING={VVV} TAGS="checkpoint='yes'" "Brem kernel test"

--- a/cactus_interface/TestWeakLibReader/param.ccl
+++ b/cactus_interface/TestWeakLibReader/param.ccl
@@ -3,3 +3,8 @@
 SHARES: WeakLibReader
 
 USES STRING eos_table_file
+USES STRING opacity_emab_file
+USES STRING opacity_iso_file
+USES STRING opacity_nes_file
+USES STRING opacity_pair_file
+USES STRING opacity_brem_file

--- a/cactus_interface/TestWeakLibReader/schedule.ccl
+++ b/cactus_interface/TestWeakLibReader/schedule.ccl
@@ -1,6 +1,10 @@
 # Schedule definitions for thorn TestWeakLibReader
 
 STORAGE: energy
+STORAGE: opacity_emab
+STORAGE: opacity_iso
+STORAGE: eos_log_eta eos_dxp eos_dxn eos_dxpn
+STORAGE: opacity_nes opacity_pair opacity_brem
 
 SCHEDULE TestWeakLibReader_LoadTable AT INITIAL
 {
@@ -15,8 +19,65 @@ SCHEDULE TestWeakLibReader_Init AT INITIAL AFTER TestWeakLibReader_LoadTable
   SYNC: energy
 } "Initialize grid function"
 
+SCHEDULE TestWeakLibReader_LoadOpacityTable AT INITIAL AFTER TestWeakLibReader_LoadTable
+{
+  LANG: C
+  OPTIONS: global
+} "Load opacity tables"
+
+SCHEDULE TestWeakLibReader_InitEmAb AT INITIAL AFTER TestWeakLibReader_LoadOpacityTable
+{
+  LANG: C
+  WRITES: opacity_emab(interior)
+  SYNC: opacity_emab
+} "Test EmAb 4D interpolation"
+
+SCHEDULE TestWeakLibReader_InitIso AT INITIAL AFTER TestWeakLibReader_LoadOpacityTable
+{
+  LANG: C
+  WRITES: opacity_iso(interior)
+  SYNC: opacity_iso
+} "Test Iso 4D interpolation"
+
+SCHEDULE TestWeakLibReader_ComputeEosDerived AT INITIAL AFTER TestWeakLibReader_LoadOpacityTable
+{
+  LANG: C
+  WRITES: eos_log_eta(interior) eos_dxp(interior) eos_dxn(interior) eos_dxpn(interior)
+  SYNC: eos_log_eta eos_dxp eos_dxn eos_dxpn
+} "Compute EOS-derived quantities for opacity tests"
+
+SCHEDULE TestWeakLibReader_InitNES AT INITIAL AFTER TestWeakLibReader_ComputeEosDerived
+{
+  LANG: C
+  READS: eos_log_eta(interior)
+  WRITES: opacity_nes(interior)
+  SYNC: opacity_nes
+} "Test NES aligned interpolation"
+
+SCHEDULE TestWeakLibReader_InitPair AT INITIAL AFTER TestWeakLibReader_ComputeEosDerived
+{
+  LANG: C
+  READS: eos_log_eta(interior)
+  WRITES: opacity_pair(interior)
+  SYNC: opacity_pair
+} "Test Pair aligned interpolation"
+
+SCHEDULE TestWeakLibReader_InitBrem AT INITIAL AFTER TestWeakLibReader_ComputeEosDerived
+{
+  LANG: C
+  READS: eos_dxp(interior) eos_dxn(interior) eos_dxpn(interior)
+  WRITES: opacity_brem(interior)
+  SYNC: opacity_brem
+} "Test Brem sum-aligned interpolation"
+
 SCHEDULE TestWeakLibReader_Cleanup AT TERMINATE
 {
   LANG: C
   OPTIONS: global
 } "Clean up EOS table before AMReX finalizes"
+
+SCHEDULE TestWeakLibReader_CleanupOpacity AT TERMINATE
+{
+  LANG: C
+  OPTIONS: global
+} "Clean up opacity tables"

--- a/cactus_interface/TestWeakLibReader/src/testweaklibreader.cxx
+++ b/cactus_interface/TestWeakLibReader/src/testweaklibreader.cxx
@@ -3,12 +3,35 @@
 #include <cctk_Parameters.h>
 #include <loop_device.hxx>
 
+#include <cmath>
+#include <vector>
+
 #include <WeakLibReader_Hdf5Loader.hpp>
 #include <WeakLibReader_LogInterpolate.hpp>
 
 namespace TestWeakLibReader {
 
 WeakLibReader::WeakLibEosTableDevice eos_table_device;
+WeakLibReader::WeakLibOpacityTableDevice opacity_table_device;
+
+// Fixed energy value at midpoint of energy grid (set during load)
+double fixedEnergyMidpoint = 0.0;
+
+// Iso moment=0 slice, species=0, copied to device
+amrex::Gpu::DeviceVector<double> iso_slice_device;
+
+// Pre-aligned scattering kernel tables (host-computed, device-stored)
+struct AlignedKernel {
+  amrex::Gpu::DeviceVector<double> data;
+  int nAlignedE = 0;
+  int nDim3 = 0;   // nT for NES/Pair, nRho for Brem
+  int nDim4 = 0;   // nEta for NES/Pair, nT for Brem
+  WeakLibReader::Layout layout{};
+};
+
+std::vector<AlignedKernel> nes_aligned;
+std::vector<AlignedKernel> pair_aligned;
+std::vector<AlignedKernel> brem_aligned;
 
 extern "C" void TestWeakLibReader_LoadTable(CCTK_ARGUMENTS) {
   DECLARE_CCTK_PARAMETERS;
@@ -55,6 +78,455 @@ extern "C" void TestWeakLibReader_Init(CCTK_ARGUMENTS) {
           axes,
           pressureData, pressureOffset);
       });
+}
+
+extern "C" void TestWeakLibReader_LoadOpacityTable(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_PARAMETERS;
+
+  const std::string emabFile(opacity_emab_file);
+  const std::string isoFile(opacity_iso_file);
+  const std::string nesFile(opacity_nes_file);
+  const std::string pairFile(opacity_pair_file);
+  const std::string bremFile(opacity_brem_file);
+
+  if (emabFile.empty() && isoFile.empty() && nesFile.empty() &&
+      pairFile.empty() && bremFile.empty()) {
+    CCTK_INFO("No opacity table files specified, skipping opacity load");
+    return;
+  }
+
+  CCTK_INFO("Loading opacity tables");
+
+  WeakLibReader::WeakLibOpacityTable opacity_table;
+  const auto status = WeakLibReader::LoadWeakLibOpacityTableFull(
+      opacity_table, emabFile, isoFile, nesFile, pairFile, bremFile);
+
+  if (status != WeakLibReader::Hdf5LoadStatus::Success) {
+    CCTK_ERROR("Failed to load opacity tables");
+  }
+
+  // Store midpoint energy from host-side table before device copy
+  fixedEnergyMidpoint =
+      opacity_table.energyGrid.values[opacity_table.energyGrid.nPoints / 2];
+
+  opacity_table_device = WeakLibReader::MakeDeviceCopy(opacity_table);
+
+  // Extract Iso moment=0 slice as contiguous 4D and copy to device
+  if (opacity_table.scatIso.IsLoaded()) {
+    auto slice = WeakLibReader::ExtractIsoMomentSlice4D(
+        opacity_table.scatIso.KernelData(0),
+        opacity_table.scatIso.dimensions, /*iMom=*/0);
+    iso_slice_device.resize(slice.size());
+    amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                      slice.begin(), slice.end(),
+                      iso_slice_device.begin());
+    CCTK_VINFO("Iso slice extracted: %zu elements", slice.size());
+  }
+
+  // Pre-align NES
+  if (opacity_table.scatNES.IsLoaded()) {
+    const auto& nes = opacity_table.scatNES;
+    const int nE = opacity_table.energyGrid.nPoints;
+    const int nMom = nes.nMoments;
+    const int nT = nes.dimensions[3];
+    const int nEta = nes.dimensions[4];
+    const auto energyAxis = opacity_table.energyGrid.MakeAxis();
+    const auto nesLayout = WeakLibReader::MakeLayout(nes.dimensions.data(), 5);
+
+    nes_aligned.resize(nMom);
+    for (int iMom = 0; iMom < nMom; ++iMom) {
+      const double nesOffset = nes.offsets.const_table()(0, iMom);
+      const std::size_t alignedSize =
+          static_cast<std::size_t>(nE) * nE * nT * nEta;
+      amrex::Vector<double> hostBuf(alignedSize);
+
+      WeakLibReader::PreAlignScatteringKernelMoment(
+          nes.KernelData(), nesLayout, energyAxis,
+          iMom, nT, nEta,
+          opacity_table.energyGrid.values.data(), nE,
+          nesOffset, hostBuf.data());
+
+      nes_aligned[iMom].nAlignedE = nE;
+      nes_aligned[iMom].nDim3 = nT;
+      nes_aligned[iMom].nDim4 = nEta;
+      int ext[4] = {nE, nE, nT, nEta};
+      nes_aligned[iMom].layout = WeakLibReader::MakeLayout(ext, 4);
+      nes_aligned[iMom].data.resize(alignedSize);
+      amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                        hostBuf.begin(), hostBuf.end(),
+                        nes_aligned[iMom].data.begin());
+    }
+    CCTK_VINFO("NES pre-aligned: %d moments, %d energy points", nMom, nE);
+  }
+
+  // Pre-align Pair
+  if (opacity_table.scatPair.IsLoaded()) {
+    const auto& pair = opacity_table.scatPair;
+    const int nE = opacity_table.energyGrid.nPoints;
+    const int nMom = pair.nMoments;
+    const int nT = pair.dimensions[3];
+    const int nEta = pair.dimensions[4];
+    const auto energyAxis = opacity_table.energyGrid.MakeAxis();
+    const auto pairLayout = WeakLibReader::MakeLayout(pair.dimensions.data(), 5);
+
+    pair_aligned.resize(nMom);
+    for (int iMom = 0; iMom < nMom; ++iMom) {
+      const double pairOffset = pair.offsets.const_table()(0, iMom);
+      const std::size_t alignedSize =
+          static_cast<std::size_t>(nE) * nE * nT * nEta;
+      amrex::Vector<double> hostBuf(alignedSize);
+
+      WeakLibReader::PreAlignScatteringKernelMoment(
+          pair.KernelData(), pairLayout, energyAxis,
+          iMom, nT, nEta,
+          opacity_table.energyGrid.values.data(), nE,
+          pairOffset, hostBuf.data());
+
+      pair_aligned[iMom].nAlignedE = nE;
+      pair_aligned[iMom].nDim3 = nT;
+      pair_aligned[iMom].nDim4 = nEta;
+      int ext[4] = {nE, nE, nT, nEta};
+      pair_aligned[iMom].layout = WeakLibReader::MakeLayout(ext, 4);
+      pair_aligned[iMom].data.resize(alignedSize);
+      amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                        hostBuf.begin(), hostBuf.end(),
+                        pair_aligned[iMom].data.begin());
+    }
+    CCTK_VINFO("Pair pre-aligned: %d moments, %d energy points", nMom, nE);
+  }
+
+  // Pre-align Brem (nMom=1, dims[3]=nRho, dims[4]=nT)
+  if (opacity_table.scatBrem.IsLoaded()) {
+    const auto& brem = opacity_table.scatBrem;
+    const int nE = opacity_table.energyGrid.nPoints;
+    const int nMom = brem.nMoments;
+    const int nRho = brem.dimensions[3];
+    const int nT = brem.dimensions[4];
+    const auto energyAxis = opacity_table.energyGrid.MakeAxis();
+    const auto bremLayout = WeakLibReader::MakeLayout(brem.dimensions.data(), 5);
+
+    brem_aligned.resize(nMom);
+    for (int iMom = 0; iMom < nMom; ++iMom) {
+      const double bremOffset = brem.offsets.const_table()(0, iMom);
+      const std::size_t alignedSize =
+          static_cast<std::size_t>(nE) * nE * nRho * nT;
+      amrex::Vector<double> hostBuf(alignedSize);
+
+      WeakLibReader::PreAlignScatteringKernelMoment(
+          brem.KernelData(), bremLayout, energyAxis,
+          iMom, nRho, nT,
+          opacity_table.energyGrid.values.data(), nE,
+          bremOffset, hostBuf.data());
+
+      brem_aligned[iMom].nAlignedE = nE;
+      brem_aligned[iMom].nDim3 = nRho;
+      brem_aligned[iMom].nDim4 = nT;
+      int ext[4] = {nE, nE, nRho, nT};
+      brem_aligned[iMom].layout = WeakLibReader::MakeLayout(ext, 4);
+      brem_aligned[iMom].data.resize(alignedSize);
+      amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                        hostBuf.begin(), hostBuf.end(),
+                        brem_aligned[iMom].data.begin());
+    }
+    CCTK_VINFO("Brem pre-aligned: %d moments, %d energy points", nMom, nE);
+  }
+
+  CCTK_VINFO("Opacity tables loaded: EmAb=%s Iso=%s NES=%s Pair=%s Brem=%s",
+              opacity_table_device.HasEmAb() ? "yes" : "no",
+              opacity_table_device.HasScatIso() ? "yes" : "no",
+              opacity_table_device.HasScatNES() ? "yes" : "no",
+              opacity_table_device.HasScatPair() ? "yes" : "no",
+              opacity_table_device.HasScatBrem() ? "yes" : "no");
+}
+
+extern "C" void TestWeakLibReader_InitEmAb(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_TestWeakLibReader_InitEmAb;
+
+  if (!opacity_table_device.HasEmAb()) {
+    CCTK_INFO("No EmAb table loaded, skipping");
+    return;
+  }
+
+  CCTK_INFO("Testing EmAb 4D interpolation");
+
+  // Build 4D axes: [E, Rho, T, Ye]
+  const WeakLibReader::Axis axes[4] = {
+    opacity_table_device.energyGrid.MakeAxis(),   // E (log10)
+    opacity_table_device.thermoState.axes[0],      // Rho (log10)
+    opacity_table_device.thermoState.axes[1],      // T (log10)
+    opacity_table_device.thermoState.axes[2],      // Ye (linear)
+  };
+
+  // Fixed energy at midpoint of energy grid (set during load from host data)
+  const double fixedE = fixedEnergyMidpoint;
+
+  // Species 0 = electron neutrino
+  const double offset = opacity_table_device.emAb.offsets[0];
+  const double* opacityData = opacity_table_device.emAb.OpacityData(0);
+
+  grid.loop_int_device<0, 0, 0>(
+      grid.nghostzones,
+      [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      opacity_emab(p.I) = WeakLibReader::LogInterpolateSingleVariable4DCustomPoint(
+          fixedE, p.x, p.y, p.z,
+          axes,
+          opacityData, offset);
+      });
+}
+
+extern "C" void TestWeakLibReader_InitIso(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_TestWeakLibReader_InitIso;
+
+  if (!opacity_table_device.HasScatIso() || iso_slice_device.empty()) {
+    CCTK_INFO("No Iso table loaded, skipping");
+    return;
+  }
+
+  CCTK_INFO("Testing Iso 4D interpolation (moment=0, species=0)");
+
+  // 4D axes: [E, Rho, T, Ye] (same as EmAb after moment extraction)
+  const WeakLibReader::Axis axes[4] = {
+    opacity_table_device.energyGrid.MakeAxis(),
+    opacity_table_device.thermoState.axes[0],
+    opacity_table_device.thermoState.axes[1],
+    opacity_table_device.thermoState.axes[2],
+  };
+
+  // Fixed energy at midpoint of energy grid (set during load from host data)
+  const double fixedE = fixedEnergyMidpoint;
+
+  // Offset for species=0, moment=0 from the 2D offset table
+  const double offset = opacity_table_device.scatIso.offsets.const_table()(0, 0);
+  const double* sliceData = iso_slice_device.data();
+
+  grid.loop_int_device<0, 0, 0>(
+      grid.nghostzones,
+      [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      opacity_iso(p.I) = WeakLibReader::LogInterpolateSingleVariable4DCustomPoint(
+          fixedE, p.x, p.y, p.z,
+          axes,
+          sliceData, offset);
+      });
+}
+
+extern "C" void TestWeakLibReader_ComputeEosDerived(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_TestWeakLibReader_ComputeEosDerived;
+
+  if (eos_table_device.nVariables == 0) {
+    CCTK_INFO("No EOS table loaded, skipping EOS-derived computation");
+    return;
+  }
+
+  CCTK_INFO("Computing EOS-derived quantities");
+
+  const WeakLibReader::Axis axes[3] = {
+    eos_table_device.axes[0],  // Rho
+    eos_table_device.axes[1],  // T
+    eos_table_device.axes[2],  // Ye
+  };
+
+  // EOS variable indices
+  const int iMuE = eos_table_device.indices.iElectronChemicalPotential;
+  const int iXp  = eos_table_device.indices.iProtonMassFraction;
+  const int iXn  = eos_table_device.indices.iNeutronMassFraction;
+
+  const double* muEData = eos_table_device.VariableData(iMuE);
+  const double muEOffset = eos_table_device.offsets[iMuE];
+  const double* xpData = eos_table_device.VariableData(iXp);
+  const double xpOffset = eos_table_device.offsets[iXp];
+  const double* xnData = eos_table_device.VariableData(iXn);
+  const double xnOffset = eos_table_device.offsets[iXn];
+
+  // Boltzmann constant in MeV/K (same units as EOS table)
+  constexpr double kB_MeV_per_K = 8.6173303e-11;  // MeV/K
+
+  grid.loop_int_device<0, 0, 0>(
+      grid.nghostzones,
+      [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      // (p.x, p.y, p.z) = (rho, T, Ye) in raw units
+      const double rho = p.x;
+      const double T   = p.y;
+      const double Ye  = p.z;
+
+      // Interpolate mu_e from EOS
+      const double muE = WeakLibReader::LogInterpolateSingleVariable3DCustomPoint(
+          rho, T, Ye, axes, muEData, muEOffset);
+
+      // eta = mu_e / (kB * T) — dimensionless
+      // Note: table T is in Kelvin, mu_e in MeV
+      const double eta = muE / (kB_MeV_per_K * T);
+      eos_log_eta(p.I) = eta;  // raw value; IndexAndDelta handles log
+
+      // Interpolate mass fractions
+      const double Xp = WeakLibReader::LogInterpolateSingleVariable3DCustomPoint(
+          rho, T, Ye, axes, xpData, xpOffset);
+      const double Xn = WeakLibReader::LogInterpolateSingleVariable3DCustomPoint(
+          rho, T, Ye, axes, xnData, xnOffset);
+
+      // Density-weighted terms for Brem (raw values)
+      eos_dxp(p.I)  = rho * Xp;
+      eos_dxn(p.I)  = rho * Xn;
+      const double XpXn = Xp * Xn;
+      eos_dxpn(p.I) = (XpXn > 0.0) ? rho * sqrt(XpXn) : 0.0;
+      });
+}
+
+extern "C" void TestWeakLibReader_InitNES(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_TestWeakLibReader_InitNES;
+
+  if (nes_aligned.empty()) {
+    CCTK_INFO("No NES aligned table, skipping");
+    return;
+  }
+
+  CCTK_INFO("Testing NES aligned interpolation (moment=0)");
+
+  // Aligned table for moment 0 (H_I zeroth moment)
+  const double* nesData = nes_aligned[0].data.data();
+  const WeakLibReader::Layout nesLayout = nes_aligned[0].layout;
+  const int nAlignedE = nes_aligned[0].nAlignedE;
+  const int iE_mid = nAlignedE / 2;
+
+  // Axes for aligned interpolation: [T, Eta]
+  const WeakLibReader::Axis axes[2] = {
+    opacity_table_device.thermoState.axes[1],  // T
+    opacity_table_device.etaGrid.MakeAxis(),   // Eta
+  };
+
+  const double nesOffset = opacity_table_device.scatNES.offsets.const_table()(0, 0);
+
+  grid.loop_int_device<0, 0, 0>(
+      grid.nghostzones,
+      [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      const double T   = p.y;
+      const double eta = eos_log_eta(p.I);
+
+      int idxT = 0, idxEta = 0;
+      double fracT = 0.0, fracEta = 0.0;
+      WeakLibReader::detail::IndexAndDelta(axes[0], T, idxT, fracT);
+      WeakLibReader::detail::IndexAndDelta(axes[1], eta, idxEta, fracEta);
+
+      opacity_nes(p.I) = WeakLibReader::LinearInterp2D4DArray2DAlignedPoint(
+          iE_mid, iE_mid,
+          idxT, idxEta,
+          fracT, fracEta,
+          nesOffset,
+          nesData, nesLayout);
+      });
+}
+
+extern "C" void TestWeakLibReader_InitPair(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_TestWeakLibReader_InitPair;
+
+  if (pair_aligned.empty()) {
+    CCTK_INFO("No Pair aligned table, skipping");
+    return;
+  }
+
+  CCTK_INFO("Testing Pair aligned interpolation (moment=0)");
+
+  const double* pairData = pair_aligned[0].data.data();
+  const WeakLibReader::Layout pairLayout = pair_aligned[0].layout;
+  const int nAlignedE = pair_aligned[0].nAlignedE;
+  const int iE_mid = nAlignedE / 2;
+
+  // Axes for aligned interpolation: [T, Eta]
+  const WeakLibReader::Axis axes[2] = {
+    opacity_table_device.thermoState.axes[1],  // T
+    opacity_table_device.etaGrid.MakeAxis(),   // Eta
+  };
+
+  const double pairOffset = opacity_table_device.scatPair.offsets.const_table()(0, 0);
+
+  grid.loop_int_device<0, 0, 0>(
+      grid.nghostzones,
+      [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      const double T   = p.y;
+      const double eta = eos_log_eta(p.I);
+
+      int idxT = 0, idxEta = 0;
+      double fracT = 0.0, fracEta = 0.0;
+      WeakLibReader::detail::IndexAndDelta(axes[0], T, idxT, fracT);
+      WeakLibReader::detail::IndexAndDelta(axes[1], eta, idxEta, fracEta);
+
+      opacity_pair(p.I) = WeakLibReader::LinearInterp2D4DArray2DAlignedPoint(
+          iE_mid, iE_mid,
+          idxT, idxEta,
+          fracT, fracEta,
+          pairOffset,
+          pairData, pairLayout);
+      });
+}
+
+extern "C" void TestWeakLibReader_InitBrem(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_TestWeakLibReader_InitBrem;
+
+  if (brem_aligned.empty()) {
+    CCTK_INFO("No Brem aligned table, skipping");
+    return;
+  }
+
+  CCTK_INFO("Testing Brem sum-aligned interpolation");
+
+  const double* bremData = brem_aligned[0].data.data();
+  const WeakLibReader::Layout bremLayout = brem_aligned[0].layout;
+  const int nAlignedE = brem_aligned[0].nAlignedE;
+  const int iE_mid = nAlignedE / 2;
+
+  // Axes for aligned interpolation: [Rho, T]
+  const WeakLibReader::Axis axes[2] = {
+    opacity_table_device.thermoState.axes[0],  // Rho
+    opacity_table_device.thermoState.axes[1],  // T
+  };
+
+  const double bremOffset = opacity_table_device.scatBrem.offsets.const_table()(0, 0);
+
+  // Brem alpha coefficients: [pp, nn, pn]
+  constexpr double alpha[3] = {1.0, 1.0, 28.0 / 3.0};
+
+  grid.loop_int_device<0, 0, 0>(
+      grid.nghostzones,
+      [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      const double T = p.y;
+
+      // Density-weighted terms from EOS-derived GFs
+      const double dxVals[3] = {
+        eos_dxp(p.I),
+        eos_dxn(p.I),
+        eos_dxpn(p.I),
+      };
+
+      int idxT = 0;
+      double fracT = 0.0;
+      WeakLibReader::detail::IndexAndDelta(axes[1], T, idxT, fracT);
+
+      // Sum over 3 density terms with alpha weights
+      double sum = 0.0;
+      for (int l = 0; l < 3; ++l) {
+        int idxD = 0;
+        double fracD = 0.0;
+        WeakLibReader::detail::IndexAndDelta(axes[0], dxVals[l], idxD, fracD);
+
+        const double val = WeakLibReader::LinearInterp2D4DArray2DAlignedPoint(
+            iE_mid, iE_mid,
+            idxD, idxT,
+            fracD, fracT,
+            bremOffset,
+            bremData, bremLayout);
+        sum += alpha[l] * val;
+      }
+
+      opacity_brem(p.I) = sum;
+      });
+}
+
+extern "C" void TestWeakLibReader_CleanupOpacity(CCTK_ARGUMENTS) {
+  CCTK_INFO("Cleaning up opacity tables");
+  opacity_table_device = WeakLibReader::WeakLibOpacityTableDevice{};
+  iso_slice_device.clear();
+  nes_aligned.clear();
+  pair_aligned.clear();
+  brem_aligned.clear();
 }
 
 } // namespace TestWeakLibReader

--- a/cactus_interface/WeakLibReader/param.ccl
+++ b/cactus_interface/WeakLibReader/param.ccl
@@ -6,3 +6,28 @@ STRING eos_table_file "eos table name (hdf5)" STEERABLE=RECOVER
 {
   ".*" :: "can be anything"
 } "foo.h5"
+
+STRING opacity_emab_file "EmAb opacity table (hdf5)" STEERABLE=RECOVER
+{
+  ".*" :: "can be anything"
+} ""
+
+STRING opacity_iso_file "Iso scattering opacity table (hdf5)" STEERABLE=RECOVER
+{
+  ".*" :: "can be anything"
+} ""
+
+STRING opacity_nes_file "NES scattering opacity table (hdf5)" STEERABLE=RECOVER
+{
+  ".*" :: "can be anything"
+} ""
+
+STRING opacity_pair_file "Pair production opacity table (hdf5)" STEERABLE=RECOVER
+{
+  ".*" :: "can be anything"
+} ""
+
+STRING opacity_brem_file "Bremsstrahlung opacity table (hdf5)" STEERABLE=RECOVER
+{
+  ".*" :: "can be anything"
+} ""

--- a/src/WeakLibReader_Hdf5Loader.hpp
+++ b/src/WeakLibReader_Hdf5Loader.hpp
@@ -610,6 +610,51 @@ inline Hdf5LoadStatus LoadWeakLibScatIsoTable(hid_t file,
   return Hdf5LoadStatus::Success;
 }
 
+/// Extract a contiguous 4D slice [nE, nRho, nT, nYe] from a 5D Iso kernel
+/// at a fixed moment index.
+///
+/// The 5D kernel has dimensions [nE, nMom, nRho, nT, nYe] with column-major
+/// strides [1, nE, nE*nMom, ...]. A slice at fixed iMom is not contiguous
+/// because nMom interleaves the Rho stride.
+///
+/// @param kernel5d   Flat 5D kernel data (column-major ordered)
+/// @param dims       5D dimensions: [nE, nMom, nRho, nT, nYe]
+/// @param iMom       Moment index to extract (0-based)
+/// @return           Contiguous 4D array [nE, nRho, nT, nYe]
+inline amrex::Vector<double> ExtractIsoMomentSlice4D(
+    const double* kernel5d,
+    const std::array<int, 5>& dims,
+    int iMom)
+{
+  const int nE   = dims[0];
+  const int nMom = dims[1];
+  const int nRho = dims[2];
+  const int nT   = dims[3];
+  const int nYe  = dims[4];
+
+  const Layout layout5d = MakeLayout(dims.data(), 5);
+  const std::size_t size4d =
+      static_cast<std::size_t>(nE) * nRho * nT * nYe;
+  amrex::Vector<double> result(size4d);
+
+  const std::array<int, 4> dims4d{{nE, nRho, nT, nYe}};
+  const Layout layout4d = MakeLayout(dims4d.data(), 4);
+
+  for (int iYe = 0; iYe < nYe; ++iYe) {
+    for (int iT = 0; iT < nT; ++iT) {
+      for (int iRho = 0; iRho < nRho; ++iRho) {
+        for (int iE = 0; iE < nE; ++iE) {
+          const int src[5] = {iE, iMom, iRho, iT, iYe};
+          const int dst[4] = {iE, iRho, iT, iYe};
+          result[layout4d.Offset(dst)] = kernel5d[layout5d.Offset(src)];
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
 inline Hdf5LoadStatus LoadWeakLibScatNESTable(hid_t file,
                                                WeakLibScatNESTable& scatNES,
                                                const WeakLibOpacityGrid& energyGrid,
@@ -651,8 +696,15 @@ inline Hdf5LoadStatus LoadWeakLibScatNESTable(hid_t file,
     return Hdf5LoadStatus::DatasetReadFailed;
   }
 
-  // Read NPS flag (optional)
-  detail::ReadScalarInt(group.Get(), "NPS", scatNES.NPS);
+  // Read NPS flag (optional — suppress HDF5 error if absent)
+  {
+    H5E_auto2_t oldFunc;
+    void* oldClientData;
+    H5Eget_auto2(H5E_DEFAULT, &oldFunc, &oldClientData);
+    H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
+    detail::ReadScalarInt(group.Get(), "NPS", scatNES.NPS);
+    H5Eset_auto2(H5E_DEFAULT, oldFunc, oldClientData);
+  }
 
   // Set kernel name
   scatNES.name = "Kernels";

--- a/src/detail/WeakLibReader_LogInterpolateSweep.hpp
+++ b/src/detail/WeakLibReader_LogInterpolateSweep.hpp
@@ -216,4 +216,60 @@ inline int LogInterpolateSingleVariable2D2DCustomAligned(
   return 0;
 }
 
+/// Pre-align one moment of a scattering kernel onto aligned energy nodes.
+///
+/// Transforms a 5D raw kernel [nE, nE, nMom, nDim3, nDim4] into a 4D aligned
+/// table [nAlignedE, nAlignedE, nDim3, nDim4] stored as log10(value + offset).
+///
+/// Relies on column-major layout: the 2D energy slice [nE_in, nE_out] at any
+/// fixed (iMom, iD3, iD4) is contiguous in memory, so we can pass a pointer
+/// directly to LogInterpolateSingleVariable2DCustomPoint.
+///
+/// @param rawKernel    Flat 5D kernel data
+/// @param rawLayout    Layout of the 5D kernel [nE, nE, nMom, nDim3, nDim4]
+/// @param energyAxis   Energy axis (raw values, same for both E dims)
+/// @param iMom         Which moment to extract (0-based index into dim 2)
+/// @param nDim3        Size of dimension 3 (nT for NES/Pair, nRho for Brem)
+/// @param nDim4        Size of dimension 4 (nEta for NES/Pair, nT for Brem)
+/// @param alignedE     Raw energy values for aligned grid
+/// @param nAlignedE    Number of aligned energy points
+/// @param offset       Opacity offset
+/// @param output       Output: [nAlignedE, nAlignedE, nDim3, nDim4] log10-stored
+inline void PreAlignScatteringKernelMoment(
+    const double* rawKernel,
+    const Layout& rawLayout,
+    const Axis& energyAxis,
+    int iMom, int nDim3, int nDim4,
+    const double* alignedE, int nAlignedE,
+    double offset,
+    double* output) noexcept
+{
+  // Output layout: [nAlignedE, nAlignedE, nDim3, nDim4]
+  const int outExtents[4] = {nAlignedE, nAlignedE, nDim3, nDim4};
+  const Layout outLayout = MakeLayout(outExtents, 4);
+
+  // 2D energy axes for interpolation
+  const Axis energyAxes[2] = {energyAxis, energyAxis};
+
+  for (int iD4 = 0; iD4 < nDim4; ++iD4) {
+    for (int iD3 = 0; iD3 < nDim3; ++iD3) {
+      // Pointer to contiguous 2D energy slice [nE, nE] at (iMom, iD3, iD4)
+      // Column-major: first two dims (E_in, E_out) are fastest-varying
+      const int sliceIdx[5] = {0, 0, iMom, iD3, iD4};
+      const double* slice2d = rawKernel + rawLayout.Offset(sliceIdx);
+
+      for (int iA2 = 0; iA2 < nAlignedE; ++iA2) {
+        for (int iA1 = 0; iA1 < nAlignedE; ++iA1) {
+          const double value = LogInterpolateSingleVariable2DCustomPoint(
+              alignedE[iA1], alignedE[iA2],
+              energyAxes, slice2d, offset);
+
+          const int outIdx[4] = {iA1, iA2, iD3, iD4};
+          output[outLayout.Offset(outIdx)] = math::Log10(value + offset);
+        }
+      }
+    }
+  }
+}
+
 } // namespace WeakLibReader


### PR DESCRIPTION
## Summary
- Add grid functions, parameters, and scheduled functions for all five opacity table types (EmAb, Iso, NES, Pair, Brem) in the `TestWeakLibReader` Cactus thorn
- Add `ExtractIsoMomentSlice4D` helper to produce contiguous 4D data from the 5D Iso kernel at a fixed moment index
- Add `PreAlignScatteringKernelMoment` to transform 5D raw scattering kernels into 4D pre-aligned tables (log10-stored) for efficient device-side 2D interpolation
- Compute EOS-derived quantities (electron chemical potential eta, density-weighted mass fractions) needed by NES/Pair/Brem interpolation
- Suppress spurious HDF5 error output when reading the optional NPS flag

## Test plan
- [ ] Verify `TestWeakLibReader` thorn compiles with CarpetX
- [ ] Run with opacity HDF5 tables and confirm all scheduled functions execute without error
- [ ] Check EmAb and Iso 4D interpolation output against standalone test suite values
- [ ] Verify NES/Pair aligned interpolation produces physically reasonable kernel values
- [ ] Verify Brem sum-aligned interpolation with alpha-weighted density terms