### PR TITLE
Replace TableData with PinnedVector/DeviceVector

### DIFF
--- a/cactus_interface/TestWeakLibReader/src/testweaklibreader.cxx
+++ b/cactus_interface/TestWeakLibReader/src/testweaklibreader.cxx
@@ -135,7 +135,7 @@ extern "C" void TestWeakLibReader_LoadOpacityTable(CCTK_ARGUMENTS) {
 
     nes_aligned.resize(nMom);
     for (int iMom = 0; iMom < nMom; ++iMom) {
-      const double nesOffset = nes.offsets.const_table()(0, iMom);
+      const double nesOffset = nes.OffsetValue(0, iMom);
       const std::size_t alignedSize =
           static_cast<std::size_t>(nE) * nE * nT * nEta;
       amrex::Vector<double> hostBuf(alignedSize);
@@ -171,7 +171,7 @@ extern "C" void TestWeakLibReader_LoadOpacityTable(CCTK_ARGUMENTS) {
 
     pair_aligned.resize(nMom);
     for (int iMom = 0; iMom < nMom; ++iMom) {
-      const double pairOffset = pair.offsets.const_table()(0, iMom);
+      const double pairOffset = pair.OffsetValue(0, iMom);
       const std::size_t alignedSize =
           static_cast<std::size_t>(nE) * nE * nT * nEta;
       amrex::Vector<double> hostBuf(alignedSize);
@@ -207,7 +207,7 @@ extern "C" void TestWeakLibReader_LoadOpacityTable(CCTK_ARGUMENTS) {
 
     brem_aligned.resize(nMom);
     for (int iMom = 0; iMom < nMom; ++iMom) {
-      const double bremOffset = brem.offsets.const_table()(0, iMom);
+      const double bremOffset = brem.OffsetValue(0, iMom);
       const std::size_t alignedSize =
           static_cast<std::size_t>(nE) * nE * nRho * nT;
       amrex::Vector<double> hostBuf(alignedSize);
@@ -296,7 +296,7 @@ extern "C" void TestWeakLibReader_InitIso(CCTK_ARGUMENTS) {
   const double fixedE = fixedEnergyMidpoint;
 
   // Offset for species=0, moment=0 from the 2D offset table
-  const double offset = opacity_table_device.scatIso.offsets.const_table()(0, 0);
+  const double offset = opacity_table_device.scatIso.OffsetValue(0, 0);
   const double* sliceData = iso_slice_device.data();
 
   grid.loop_int_device<0, 0, 0>(
@@ -393,7 +393,7 @@ extern "C" void TestWeakLibReader_InitNES(CCTK_ARGUMENTS) {
     opacity_table_device.etaGrid.MakeAxis(),   // Eta
   };
 
-  const double nesOffset = opacity_table_device.scatNES.offsets.const_table()(0, 0);
+  const double nesOffset = opacity_table_device.scatNES.OffsetValue(0, 0);
 
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
@@ -436,7 +436,7 @@ extern "C" void TestWeakLibReader_InitPair(CCTK_ARGUMENTS) {
     opacity_table_device.etaGrid.MakeAxis(),   // Eta
   };
 
-  const double pairOffset = opacity_table_device.scatPair.offsets.const_table()(0, 0);
+  const double pairOffset = opacity_table_device.scatPair.OffsetValue(0, 0);
 
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
@@ -479,7 +479,7 @@ extern "C" void TestWeakLibReader_InitBrem(CCTK_ARGUMENTS) {
     opacity_table_device.thermoState.axes[1],  // T
   };
 
-  const double bremOffset = opacity_table_device.scatBrem.offsets.const_table()(0, 0);
+  const double bremOffset = opacity_table_device.scatBrem.OffsetValue(0, 0);
 
   // Brem alpha coefficients: [pp, nn, pn]
   constexpr double alpha[3] = {1.0, 1.0, 28.0 / 3.0};

--- a/src/WeakLibReader_Hdf5Loader.hpp
+++ b/src/WeakLibReader_Hdf5Loader.hpp
@@ -61,16 +61,10 @@ inline Hdf5LoadStatus LoadHdf5Table(const std::string& filePath,
     return Hdf5LoadStatus::IncompatibleDatasetExtent;
   }
 
-  const amrex::Array<int, 4> lo{{0, 0, 0, 0}};
-  bool extentOverflow = false;
-  amrex::Array<int, 4> hi = detail::MakeHiArray(rank, extents, extentOverflow);
-  if (extentOverflow) {
-    return Hdf5LoadStatus::IncompatibleDatasetExtent;
-  }
-  result.values.resize(lo, hi, amrex::The_Pinned_Arena());
+  result.values.resize(totalSize);
 
   if (H5Dread(dataset.Get(), H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT,
-              result.values.table().p) < 0) {
+              result.values.data()) < 0) {
     return Hdf5LoadStatus::DatasetReadFailed;
   }
 
@@ -285,13 +279,10 @@ inline TableDevice MakeDeviceCopy(const Hdf5Table& host,
   device.nd = host.nd;
   device.layout = host.layout;
 
-  const amrex::Array<int, 4> lo{{0, 0, 0, 0}};
-  bool overflow = false;
-  const amrex::Array<int, 4> hi = detail::MakeHiArray(host.nd, host.extents, overflow);
-  AMREX_ASSERT(!overflow);
-
-  device.values.resize(lo, hi, arena);
-  device.values.copy(host.values);
+  device.values.resize(host.values.size());
+  amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                   host.values.begin(), host.values.end(),
+                   device.values.begin());
 
   for (int dim = 0; dim < host.nd; ++dim) {
     const auto& hostAxis = host.axisStorage[dim];
@@ -1054,18 +1045,19 @@ inline WeakLibEosTableDevice MakeDeviceCopy(const WeakLibEosTable& host,
   }
 
   // Copy all variable data to device
-  const amrex::Array<int, 3> lo{{0, 0, 0}};
-  const amrex::Array<int, 3> hi{{host.dimensions[0] - 1, host.dimensions[1] - 1, host.dimensions[2] - 1}};
-
   device.variables.resize(host.nVariables);
   for (int iVar = 0; iVar < host.nVariables; ++iVar) {
-    device.variables[iVar].resize(lo, hi, arena);
-    device.variables[iVar].copy(host.variables[iVar]);
+    device.variables[iVar].resize(host.variables[iVar].size());
+    amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                     host.variables[iVar].begin(), host.variables[iVar].end(),
+                     device.variables[iVar].begin());
   }
 
   // Copy Repaired mask to device
-  device.repaired.resize(lo, hi, arena);
-  device.repaired.copy(host.repaired);
+  device.repaired.resize(host.repaired.size());
+  amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                   host.repaired.begin(), host.repaired.end(),
+                   device.repaired.begin());
 
   return device;
 }
@@ -1127,14 +1119,12 @@ inline WeakLibOpacityTableDevice MakeDeviceCopy(const WeakLibOpacityTable& host,
     device.emAb.parameters = host.emAb.parameters;
     device.emAb.layout = host.emAb.layout;
 
-    const amrex::Array<int, 4> lo{{0, 0, 0, 0}};
-    const amrex::Array<int, 4> hi{{host.emAb.dimensions[0] - 1, host.emAb.dimensions[1] - 1,
-                                    host.emAb.dimensions[2] - 1, host.emAb.dimensions[3] - 1}};
-
     for (int i = 0; i < WeakLibEmAbTable::kNumSpecies; ++i) {
       if (host.emAb.opacities[i].size() > 0) {
-        device.emAb.opacities[i].resize(lo, hi, arena);
-        device.emAb.opacities[i].copy(host.emAb.opacities[i]);
+        device.emAb.opacities[i].resize(host.emAb.opacities[i].size());
+        amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                         host.emAb.opacities[i].begin(), host.emAb.opacities[i].end(),
+                         device.emAb.opacities[i].begin());
       }
     }
 
@@ -1168,15 +1158,15 @@ inline WeakLibOpacityTableDevice MakeDeviceCopy(const WeakLibOpacityTable& host,
       amrex::Gpu::copy(amrex::Gpu::hostToDevice, hostEC.yeValues.begin(), hostEC.yeValues.end(), deviceEC.yeValues.begin());
 
       // Copy spectrum and rate
-      const amrex::Array<int, 4> specLo{{0, 0, 0, 0}};
-      const amrex::Array<int, 4> specHi{{hostEC.nRho - 1, hostEC.nT - 1, hostEC.nYe - 1, hostEC.nE - 1}};
-      deviceEC.spectrum.resize(specLo, specHi, arena);
-      deviceEC.spectrum.copy(hostEC.spectrum);
+      deviceEC.spectrum.resize(hostEC.spectrum.size());
+      amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                       hostEC.spectrum.begin(), hostEC.spectrum.end(),
+                       deviceEC.spectrum.begin());
 
-      const amrex::Array<int, 3> rateLo{{0, 0, 0}};
-      const amrex::Array<int, 3> rateHi{{hostEC.nRho - 1, hostEC.nT - 1, hostEC.nYe - 1}};
-      deviceEC.rate.resize(rateLo, rateHi, arena);
-      deviceEC.rate.copy(hostEC.rate);
+      deviceEC.rate.resize(hostEC.rate.size());
+      amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                       hostEC.rate.begin(), hostEC.rate.end(),
+                       deviceEC.rate.begin());
     }
   }
 
@@ -1191,10 +1181,10 @@ inline WeakLibOpacityTableDevice MakeDeviceCopy(const WeakLibOpacityTable& host,
     device.scatIso.ga_strange = host.scatIso.ga_strange;
     device.scatIso.layout = host.scatIso.layout;
 
-    const amrex::Array<int, 2> offLo{{0, 0}};
-    const amrex::Array<int, 2> offHi{{host.scatIso.nOpacities - 1, host.scatIso.nMoments - 1}};
-    device.scatIso.offsets.resize(offLo, offHi, arena);
-    device.scatIso.offsets.copy(host.scatIso.offsets);
+    device.scatIso.offsets.resize(host.scatIso.offsets.size());
+    amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                     host.scatIso.offsets.begin(), host.scatIso.offsets.end(),
+                     device.scatIso.offsets.begin());
 
     // Kernels are stored as flat vectors
     for (int i = 0; i < WeakLibScatIsoTable::kNumSpecies; ++i) {
@@ -1215,10 +1205,10 @@ inline WeakLibOpacityTableDevice MakeDeviceCopy(const WeakLibOpacityTable& host,
     device.scatNES.NPS = host.scatNES.NPS;
     device.scatNES.layout = host.scatNES.layout;
 
-    const amrex::Array<int, 2> offLo{{0, 0}};
-    const amrex::Array<int, 2> offHi{{host.scatNES.nOpacities - 1, host.scatNES.nMoments - 1}};
-    device.scatNES.offsets.resize(offLo, offHi, arena);
-    device.scatNES.offsets.copy(host.scatNES.offsets);
+    device.scatNES.offsets.resize(host.scatNES.offsets.size());
+    amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                     host.scatNES.offsets.begin(), host.scatNES.offsets.end(),
+                     device.scatNES.offsets.begin());
 
     // Kernel is stored as flat vector
     if (!host.scatNES.kernel.empty()) {
@@ -1236,10 +1226,10 @@ inline WeakLibOpacityTableDevice MakeDeviceCopy(const WeakLibOpacityTable& host,
     device.scatPair.dimensions = host.scatPair.dimensions;
     device.scatPair.layout = host.scatPair.layout;
 
-    const amrex::Array<int, 2> offLo{{0, 0}};
-    const amrex::Array<int, 2> offHi{{host.scatPair.nOpacities - 1, host.scatPair.nMoments - 1}};
-    device.scatPair.offsets.resize(offLo, offHi, arena);
-    device.scatPair.offsets.copy(host.scatPair.offsets);
+    device.scatPair.offsets.resize(host.scatPair.offsets.size());
+    amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                     host.scatPair.offsets.begin(), host.scatPair.offsets.end(),
+                     device.scatPair.offsets.begin());
 
     // Kernel is stored as flat vector
     if (!host.scatPair.kernel.empty()) {
@@ -1257,10 +1247,10 @@ inline WeakLibOpacityTableDevice MakeDeviceCopy(const WeakLibOpacityTable& host,
     device.scatBrem.dimensions = host.scatBrem.dimensions;
     device.scatBrem.layout = host.scatBrem.layout;
 
-    const amrex::Array<int, 2> offLo{{0, 0}};
-    const amrex::Array<int, 2> offHi{{host.scatBrem.nOpacities - 1, host.scatBrem.nMoments - 1}};
-    device.scatBrem.offsets.resize(offLo, offHi, arena);
-    device.scatBrem.offsets.copy(host.scatBrem.offsets);
+    device.scatBrem.offsets.resize(host.scatBrem.offsets.size());
+    amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                     host.scatBrem.offsets.begin(), host.scatBrem.offsets.end(),
+                     device.scatBrem.offsets.begin());
 
     // Kernel is stored as flat vector
     if (!host.scatBrem.kernel.empty()) {
@@ -1345,13 +1335,10 @@ inline Hdf5LoadStatus LoadHdf5TableParallel(const std::string& filePath,
     output = Hdf5Table{};
     output.nd = nd;
     output.extents = extents;
-    bool overflow = false;
-    const amrex::Array<int, 4> lo{{0, 0, 0, 0}};
-    const amrex::Array<int, 4> hi = detail::MakeHiArray(nd, output.extents, overflow);
-    if (overflow || totalSize == 0) {
+    if (totalSize == 0) {
       return Hdf5LoadStatus::IncompatibleDatasetExtent;
     }
-    output.values.resize(lo, hi, amrex::The_Pinned_Arena());
+    output.values.resize(totalSize);
     output.layout = MakeLayout(output.extents.data(), output.nd);
     for (int dim = 0; dim < 5; ++dim) {
       amrex::Vector<double>& storage = output.axisStorage[dim];
@@ -1367,8 +1354,8 @@ inline Hdf5LoadStatus LoadHdf5TableParallel(const std::string& filePath,
   }
 
   double* dataPtr = (myRank == root)
-                        ? localTable.values.table().p
-                        : output.values.table().p;
+                        ? localTable.values.data()
+                        : output.values.data();
   if (totalSize > 0) {
     amrex::ParallelDescriptor::Bcast(dataPtr,
                                      static_cast<int>(totalSize),
@@ -1472,15 +1459,16 @@ inline Hdf5LoadStatus LoadWeakLibEosTableFullParallel(
     }
 
     // Allocate variable arrays
-    const amrex::Array<int, 3> lo{{0, 0, 0}};
-    const amrex::Array<int, 3> hi{{dimensions[0] - 1, dimensions[1] - 1, dimensions[2] - 1}};
+    const std::size_t varSize = static_cast<std::size_t>(dimensions[0]) *
+                                static_cast<std::size_t>(dimensions[1]) *
+                                static_cast<std::size_t>(dimensions[2]);
     output.variables.resize(nVariables);
     for (int iVar = 0; iVar < nVariables; ++iVar) {
-      output.variables[iVar].resize(lo, hi, amrex::The_Pinned_Arena());
+      output.variables[iVar].resize(varSize);
     }
 
     // Allocate repaired mask
-    output.repaired.resize(lo, hi, amrex::The_Pinned_Arena());
+    output.repaired.resize(varSize);
 
     // Allocate offset/string vectors
     output.offsets.resize(nVariables);
@@ -1519,14 +1507,14 @@ inline Hdf5LoadStatus LoadWeakLibEosTableFullParallel(
                               static_cast<std::size_t>(dimensions[2]);
   if (varSize > 0) {
     for (int iVar = 0; iVar < nVariables; ++iVar) {
-      amrex::ParallelDescriptor::Bcast(table.variables[iVar].table().p,
+      amrex::ParallelDescriptor::Bcast(table.variables[iVar].data(),
                                        static_cast<int>(varSize), root);
     }
   }
 
   // Broadcast repaired mask
   if (varSize > 0) {
-    amrex::ParallelDescriptor::Bcast(table.repaired.table().p,
+    amrex::ParallelDescriptor::Bcast(table.repaired.data(),
                                      static_cast<int>(varSize), root);
   }
 

--- a/src/WeakLibReader_Hdf5Types.hpp
+++ b/src/WeakLibReader_Hdf5Types.hpp
@@ -2,7 +2,6 @@
 
 #include <AMReX_Array.H>
 #include <AMReX_GpuContainers.H>
-#include <AMReX_TableData.H>
 #include <AMReX_Vector.H>
 
 #include <array>
@@ -46,7 +45,7 @@ struct TableDevice {
   int nd = 0;
   Layout layout{};
   Axis axes[5]{};
-  amrex::TableData<double, 4> values{};
+  amrex::Gpu::DeviceVector<double> values;
   std::array<amrex::Gpu::DeviceVector<double>, 5> axisStorage{};
 
   [[nodiscard]] TableView View() const noexcept
@@ -54,7 +53,7 @@ struct TableDevice {
     TableView view{};
     view.nd = nd;
     view.layout = layout;
-    view.data = values.const_table().p;
+    view.data = values.data();
     for (int dim = 0; dim < 5; ++dim) {
       view.axes[dim] = axes[dim];
     }
@@ -67,7 +66,7 @@ struct Hdf5Table {
   std::array<int, 5> extents{{1, 1, 1, 1, 1}};
   Layout layout{};
   Axis axes[5]{};
-  amrex::TableData<double, 4> values{};
+  amrex::Gpu::PinnedVector<double> values;
   std::array<amrex::Vector<double>, 5> axisStorage{};
 
   Hdf5Table() = default;
@@ -76,15 +75,15 @@ struct Hdf5Table {
   Hdf5Table(const Hdf5Table&) = delete;
   Hdf5Table& operator=(const Hdf5Table&) = delete;
 
-  [[nodiscard]] double* DataPtr() noexcept { return values.table().p; }
-  [[nodiscard]] const double* DataPtr() const noexcept { return values.const_table().p; }
+  [[nodiscard]] double* DataPtr() noexcept { return values.data(); }
+  [[nodiscard]] const double* DataPtr() const noexcept { return values.data(); }
 
   [[nodiscard]] TableView View() const noexcept
   {
     TableView view{};
     view.nd = nd;
     view.layout = layout;
-    view.data = values.const_table().p;
+    view.data = values.data();
     for (int dim = 0; dim < 5; ++dim) {
       view.axes[dim] = axes[dim];
     }
@@ -127,8 +126,8 @@ struct WeakLibEosTable {
   std::vector<std::string> variableNames;
   std::vector<std::string> variableUnits;
   std::vector<double> offsets;
-  std::vector<amrex::TableData<double, 3>> variables;
-  amrex::TableData<int, 3> repaired;
+  std::vector<amrex::Gpu::PinnedVector<double>> variables;
+  amrex::Gpu::PinnedVector<int> repaired;
   WeakLibEosIndices indices;
 
   // Layout for interpolation
@@ -142,7 +141,7 @@ struct WeakLibEosTable {
 
   // Get data pointer for a specific variable
   [[nodiscard]] const double* VariableData(int varIndex) const noexcept {
-    return variables[varIndex].const_table().p;
+    return variables[varIndex].data();
   }
 };
 
@@ -155,13 +154,13 @@ struct WeakLibEosTableDevice {
   Layout layout{};
 
   std::vector<double> offsets;
-  std::vector<amrex::TableData<double, 3>> variables;
-  amrex::TableData<int, 3> repaired;
+  std::vector<amrex::Gpu::DeviceVector<double>> variables;
+  amrex::Gpu::DeviceVector<int> repaired;
   WeakLibEosIndices indices;
 
   // Get device data pointer for a specific variable
   [[nodiscard]] const double* VariableData(int varIndex) const noexcept {
-    return variables[varIndex].const_table().p;
+    return variables[varIndex].data();
   }
 };
 
@@ -218,9 +217,9 @@ struct WeakLibECTable {
   double rateOffset = 0.0;
 
   // Spectrum: 4D [nRho, nT, nYe, nE]
-  amrex::TableData<double, 4> spectrum;
+  amrex::Gpu::PinnedVector<double> spectrum;
   // Rate: 3D [nRho, nT, nYe]
-  amrex::TableData<double, 3> rate;
+  amrex::Gpu::PinnedVector<double> rate;
 
   [[nodiscard]] bool IsPresent() const noexcept { return nE > 0; }
 };
@@ -243,8 +242,8 @@ struct WeakLibECTableDevice {
   double specOffset = 0.0;
   double rateOffset = 0.0;
 
-  amrex::TableData<double, 4> spectrum;
-  amrex::TableData<double, 3> rate;
+  amrex::Gpu::DeviceVector<double> spectrum;
+  amrex::Gpu::DeviceVector<double> rate;
 
   [[nodiscard]] bool IsPresent() const noexcept { return nE > 0; }
 };
@@ -274,7 +273,7 @@ struct WeakLibEmAbTable {
   std::array<double, kNumSpecies> offsets{{0.0, 0.0}};
 
   // Opacity data: 4D [nE, nRho, nT, nYe] per species
-  std::array<amrex::TableData<double, 4>, kNumSpecies> opacities;
+  std::array<amrex::Gpu::PinnedVector<double>, kNumSpecies> opacities;
 
   WeakLibEmAbParameters parameters;
   WeakLibECTable ecTable;
@@ -289,7 +288,7 @@ struct WeakLibEmAbTable {
 
   [[nodiscard]] bool IsLoaded() const noexcept { return nOpacities > 0; }
   [[nodiscard]] const double* OpacityData(int species) const noexcept {
-    return opacities[species].const_table().p;
+    return opacities[species].data();
   }
 };
 
@@ -299,14 +298,14 @@ struct WeakLibEmAbTableDevice {
   int nOpacities = 0;
   std::array<int, 4> dimensions{{0, 0, 0, 0}};
   std::array<double, kNumSpecies> offsets{{0.0, 0.0}};
-  std::array<amrex::TableData<double, 4>, kNumSpecies> opacities;
+  std::array<amrex::Gpu::DeviceVector<double>, kNumSpecies> opacities;
   WeakLibEmAbParameters parameters;
   WeakLibECTableDevice ecTable;
   Layout layout{};
 
   [[nodiscard]] bool IsLoaded() const noexcept { return nOpacities > 0; }
   [[nodiscard]] const double* OpacityData(int species) const noexcept {
-    return opacities[species].const_table().p;
+    return opacities[species].data();
   }
 };
 
@@ -320,8 +319,8 @@ struct WeakLibScatIsoTable {
 
   std::array<std::string, kNumSpecies> names;
   std::array<std::string, kNumSpecies> units;
-  // Offsets: 2D [nOpacities, nMoments]
-  amrex::TableData<double, 2> offsets;
+  // Offsets: 2D [nOpacities, nMoments] — column-major (species stride=1)
+  amrex::Gpu::PinnedVector<double> offsets;
 
   // Kernel data: 5D per species (stored as flat arrays)
   std::array<amrex::Vector<double>, kNumSpecies> kernels;
@@ -344,6 +343,10 @@ struct WeakLibScatIsoTable {
   [[nodiscard]] const double* KernelData(int species) const noexcept {
     return kernels[species].data();
   }
+  [[nodiscard]] double OffsetValue(int species, int moment) const noexcept {
+    return offsets[static_cast<std::size_t>(species)
+                   + static_cast<std::size_t>(moment) * nOpacities];
+  }
 };
 
 struct WeakLibScatIsoTableDevice {
@@ -352,7 +355,7 @@ struct WeakLibScatIsoTableDevice {
   int nOpacities = 0;
   int nMoments = 0;
   std::array<int, 5> dimensions{{0, 0, 0, 0, 0}};
-  amrex::TableData<double, 2> offsets;
+  amrex::Gpu::DeviceVector<double> offsets;
   std::array<amrex::Gpu::DeviceVector<double>, kNumSpecies> kernels;
 
   int weak_magnetism_corrections = -1;
@@ -366,6 +369,10 @@ struct WeakLibScatIsoTableDevice {
   [[nodiscard]] const double* KernelData(int species) const noexcept {
     return kernels[species].data();
   }
+  [[nodiscard]] double OffsetValue(int species, int moment) const noexcept {
+    return offsets[static_cast<std::size_t>(species)
+                   + static_cast<std::size_t>(moment) * nOpacities];
+  }
 };
 
 // NES scattering table (5D: nE_in x nE_out x nMom x nT x nEta)
@@ -376,7 +383,8 @@ struct WeakLibScatNESTable {
 
   std::string name;
   std::string unit;
-  amrex::TableData<double, 2> offsets;  // [nMom, nOpacities]
+  // Offsets: 2D [nOpacities, nMoments] — column-major (species stride=1)
+  amrex::Gpu::PinnedVector<double> offsets;
 
   // Single kernel: "Kernels" (stored as flat array)
   amrex::Vector<double> kernel;
@@ -393,19 +401,27 @@ struct WeakLibScatNESTable {
 
   [[nodiscard]] bool IsLoaded() const noexcept { return nOpacities > 0; }
   [[nodiscard]] const double* KernelData() const noexcept { return kernel.data(); }
+  [[nodiscard]] double OffsetValue(int species, int moment) const noexcept {
+    return offsets[static_cast<std::size_t>(species)
+                   + static_cast<std::size_t>(moment) * nOpacities];
+  }
 };
 
 struct WeakLibScatNESTableDevice {
   int nOpacities = 0;
   int nMoments = 0;
   std::array<int, 5> dimensions{{0, 0, 0, 0, 0}};
-  amrex::TableData<double, 2> offsets;
+  amrex::Gpu::DeviceVector<double> offsets;
   amrex::Gpu::DeviceVector<double> kernel;
   int NPS = -1;
   Layout layout{};
 
   [[nodiscard]] bool IsLoaded() const noexcept { return nOpacities > 0; }
   [[nodiscard]] const double* KernelData() const noexcept { return kernel.data(); }
+  [[nodiscard]] double OffsetValue(int species, int moment) const noexcept {
+    return offsets[static_cast<std::size_t>(species)
+                   + static_cast<std::size_t>(moment) * nOpacities];
+  }
 };
 
 // Pair production table (same structure as NES)
@@ -416,7 +432,8 @@ struct WeakLibScatPairTable {
 
   std::string name;
   std::string unit;
-  amrex::TableData<double, 2> offsets;
+  // Offsets: 2D [nOpacities, nMoments] — column-major (species stride=1)
+  amrex::Gpu::PinnedVector<double> offsets;
   amrex::Vector<double> kernel;  // Stored as flat array
 
   Layout layout{};
@@ -429,18 +446,26 @@ struct WeakLibScatPairTable {
 
   [[nodiscard]] bool IsLoaded() const noexcept { return nOpacities > 0; }
   [[nodiscard]] const double* KernelData() const noexcept { return kernel.data(); }
+  [[nodiscard]] double OffsetValue(int species, int moment) const noexcept {
+    return offsets[static_cast<std::size_t>(species)
+                   + static_cast<std::size_t>(moment) * nOpacities];
+  }
 };
 
 struct WeakLibScatPairTableDevice {
   int nOpacities = 0;
   int nMoments = 0;
   std::array<int, 5> dimensions{{0, 0, 0, 0, 0}};
-  amrex::TableData<double, 2> offsets;
+  amrex::Gpu::DeviceVector<double> offsets;
   amrex::Gpu::DeviceVector<double> kernel;
   Layout layout{};
 
   [[nodiscard]] bool IsLoaded() const noexcept { return nOpacities > 0; }
   [[nodiscard]] const double* KernelData() const noexcept { return kernel.data(); }
+  [[nodiscard]] double OffsetValue(int species, int moment) const noexcept {
+    return offsets[static_cast<std::size_t>(species)
+                   + static_cast<std::size_t>(moment) * nOpacities];
+  }
 };
 
 // Bremsstrahlung table (5D: nE_in x nE_out x nMom x nRho x nT)
@@ -451,7 +476,8 @@ struct WeakLibScatBremTable {
 
   std::string name;
   std::string unit;
-  amrex::TableData<double, 2> offsets;
+  // Offsets: 2D [nOpacities, nMoments] — column-major (species stride=1)
+  amrex::Gpu::PinnedVector<double> offsets;
   amrex::Vector<double> kernel;  // "S_sigma" (stored as flat array)
 
   Layout layout{};
@@ -464,18 +490,26 @@ struct WeakLibScatBremTable {
 
   [[nodiscard]] bool IsLoaded() const noexcept { return nOpacities > 0; }
   [[nodiscard]] const double* KernelData() const noexcept { return kernel.data(); }
+  [[nodiscard]] double OffsetValue(int species, int moment) const noexcept {
+    return offsets[static_cast<std::size_t>(species)
+                   + static_cast<std::size_t>(moment) * nOpacities];
+  }
 };
 
 struct WeakLibScatBremTableDevice {
   int nOpacities = 0;
   int nMoments = 0;
   std::array<int, 5> dimensions{{0, 0, 0, 0, 0}};
-  amrex::TableData<double, 2> offsets;
+  amrex::Gpu::DeviceVector<double> offsets;
   amrex::Gpu::DeviceVector<double> kernel;
   Layout layout{};
 
   [[nodiscard]] bool IsLoaded() const noexcept { return nOpacities > 0; }
   [[nodiscard]] const double* KernelData() const noexcept { return kernel.data(); }
+  [[nodiscard]] double OffsetValue(int species, int moment) const noexcept {
+    return offsets[static_cast<std::size_t>(species)
+                   + static_cast<std::size_t>(moment) * nOpacities];
+  }
 };
 
 // ThermoState for opacity tables (shared across types)

--- a/src/detail/WeakLibReader_Hdf5LoaderDetail.hpp
+++ b/src/detail/WeakLibReader_Hdf5LoaderDetail.hpp
@@ -326,7 +326,7 @@ inline bool ValidateFortranDims(const std::array<hsize_t, Rank>& fileDims,
 
 template <typename T, int Rank>
 bool ReadWeakLibArrayNd(hid_t parent, const char* name,
-                        amrex::TableData<T, Rank>& output,
+                        amrex::Gpu::PinnedVector<T>& output,
                         const std::array<int, Rank>& expectedDims)
 {
   ScopedHandle dataset;
@@ -339,29 +339,26 @@ bool ReadWeakLibArrayNd(hid_t parent, const char* name,
     return false;
   }
 
-  amrex::Array<int, Rank> lo{};
-  amrex::Array<int, Rank> hi{};
+  std::size_t totalSize = 1;
   for (int i = 0; i < Rank; ++i) {
-    lo[i] = 0;
-    hi[i] = expectedDims[i] - 1;
+    totalSize *= static_cast<std::size_t>(expectedDims[i]);
   }
-
-  output.resize(lo, hi, amrex::The_Pinned_Arena());
+  output.resize(totalSize);
 
   hid_t memType = std::is_same_v<T, double> ? H5T_NATIVE_DOUBLE : H5T_NATIVE_INT;
   if (H5Dread(dataset.Get(), memType, H5S_ALL, H5S_ALL, H5P_DEFAULT,
-              output.table().p) < 0) {
+              output.data()) < 0) {
     return false;
   }
 
   return true;
 }
 
-// Read a 3D integer array dataset
+// Read a 3D array dataset
 // Matches Fortran Read3dHDF_integer (wlIOModuleHDF.F90:361-375)
 template <typename T>
 inline bool ReadWeakLibArray3d(hid_t parent, const char* name,
-                               amrex::TableData<T, 3>& out,
+                               amrex::Gpu::PinnedVector<T>& out,
                                const std::array<int, 3>& expectedDims)
 {
   return ReadWeakLibArrayNd<T, 3>(parent, name, out, expectedDims);
@@ -370,14 +367,14 @@ inline bool ReadWeakLibArray3d(hid_t parent, const char* name,
 // Read a 3D integer array dataset
 // Expects Fortran-written (Ye,T,rho) datasets.
 inline bool ReadIntArray3d(hid_t parent, const char* name,
-                           amrex::TableData<int, 3>& out,
+                           amrex::Gpu::PinnedVector<int>& out,
                            const std::array<int, 3>& expectedDims)
 {
   return ReadWeakLibArray3d<int>(parent, name, out, expectedDims);
 }
 
 inline bool ReadDoubleArray3d(hid_t parent, const char* name,
-                              amrex::TableData<double, 3>& out,
+                              amrex::Gpu::PinnedVector<double>& out,
                               const std::array<int, 3>& expectedDims)
 {
   return ReadWeakLibArray3d<double>(parent, name, out, expectedDims);
@@ -387,14 +384,14 @@ inline bool ReadDoubleArray3d(hid_t parent, const char* name,
 // Fortran order: [d1, d0] -> C order: [d0, d1]
 template <typename T>
 bool ReadWeakLibArray2d(hid_t group, const char* name,
-                        amrex::TableData<T, 2>& output,
+                        amrex::Gpu::PinnedVector<T>& output,
                         const std::array<int, 2>& expectedDims)
 {
   return ReadWeakLibArrayNd<T, 2>(group, name, output, expectedDims);
 }
 
 inline bool ReadDoubleArray2d(hid_t group, const char* name,
-                              amrex::TableData<double, 2>& output,
+                              amrex::Gpu::PinnedVector<double>& output,
                               const std::array<int, 2>& expectedDims)
 {
   return ReadWeakLibArray2d<double>(group, name, output, expectedDims);
@@ -403,21 +400,21 @@ inline bool ReadDoubleArray2d(hid_t group, const char* name,
 // Read 4D array in Fortran order [d3, d2, d1, d0] -> C order [d0, d1, d2, d3]
 template <typename T>
 bool ReadWeakLibArray4d(hid_t group, const char* name,
-                        amrex::TableData<T, 4>& output,
+                        amrex::Gpu::PinnedVector<T>& output,
                         const std::array<int, 4>& expectedDims)
 {
   return ReadWeakLibArrayNd<T, 4>(group, name, output, expectedDims);
 }
 
 inline bool ReadDoubleArray4d(hid_t group, const char* name,
-                              amrex::TableData<double, 4>& output,
+                              amrex::Gpu::PinnedVector<double>& output,
                               const std::array<int, 4>& expectedDims)
 {
   return ReadWeakLibArray4d<double>(group, name, output, expectedDims);
 }
 
 // Read 5D array in Fortran order [d4, d3, d2, d1, d0] -> C order [d0, d1, d2, d3, d4]
-// Stores data in a flat amrex::Vector<T> since AMReX TableData only supports up to 4D.
+// Stores data in a flat amrex::Vector<T>.
 template <typename T>
 bool ReadWeakLibArray5d(hid_t group, const char* name,
                         amrex::Vector<T>& output,
@@ -570,33 +567,6 @@ inline Hdf5LoadStatus LoadWeakLibOpacityGrid(hid_t file, const char* groupName,
   }
 
   return Hdf5LoadStatus::Success;
-}
-
-inline amrex::Array<int, 4> MakeHiArray(int nd, const std::array<int, 5>& extents,
-                                        bool& overflow) noexcept
-{
-  amrex::Array<int, 4> hi{{0, 0, 0, 0}};
-  if (nd >= 1) {
-    hi[0] = extents[0] - 1;
-  }
-  if (nd >= 2) {
-    hi[1] = extents[1] - 1;
-  }
-  if (nd >= 3) {
-    hi[2] = extents[2] - 1;
-  }
-  if (nd == 4) {
-    hi[3] = extents[3] - 1;
-  } else if (nd == 5) {
-    const long long product =
-        static_cast<long long>(extents[3]) * static_cast<long long>(extents[4]);
-    if (product > static_cast<long long>(std::numeric_limits<int>::max())) {
-      overflow = true;
-      return hi;
-    }
-    hi[3] = static_cast<int>(product) - 1;
-  }
-  return hi;
 }
 
 inline std::size_t ComputeTotalSize(int nd, const std::array<int, 5>& extents)

--- a/test/test_hdf5_loader.cpp
+++ b/test/test_hdf5_loader.cpp
@@ -4,10 +4,9 @@
 #include "WeakLibReader_Hdf5Loader.hpp"
 
 #include <AMReX.H>
-#include <AMReX_Arena.H>
 #include <AMReX_GpuContainers.H>
 #include <AMReX_GpuDevice.H>
-#include <AMReX_TableData.H>
+
 #include <hdf5.h>
 
 #include <cstring>
@@ -162,22 +161,15 @@ TEST_CASE("HDF5 loader reads table and axes", "[hdf5][loader]")
   CHECK(axis2.n == 4);
   CHECK(axis2.grid[3] == Catch::Approx(4.0));
 
-  CHECK(table.values.arena() == amrex::The_Pinned_Arena());
-
   const auto deviceTable = WeakLibReader::MakeDeviceCopy(table);
-  CHECK(deviceTable.values.arena() == amrex::The_Device_Arena());
 
-  amrex::TableData<double, 4> roundtrip;
-  const amrex::Array<int, 4> lo{{0, 0, 0, 0}};
-  bool overflow = false;
-  const amrex::Array<int, 4> hi =
-      WeakLibReader::detail::MakeHiArray(table.nd, table.extents, overflow);
-  REQUIRE_FALSE(overflow);
-  roundtrip.resize(lo, hi, amrex::The_Pinned_Arena());
-  roundtrip.copy(deviceTable.values);
+  amrex::Gpu::PinnedVector<double> roundtrip(deviceTable.values.size());
+  amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                   deviceTable.values.begin(), deviceTable.values.end(),
+                   roundtrip.begin());
 
   const double* originalPtr = table.DataPtr();
-  const double* roundtripPtr = roundtrip.const_table().p;
+  const double* roundtripPtr = roundtrip.data();
   std::size_t total = 1;
   for (int dim = 0; dim < table.nd; ++dim) {
     total *= static_cast<std::size_t>(table.extents[dim]);
@@ -604,24 +596,20 @@ TEST_CASE("HDF5 loader handles 5D tables correctly", "[hdf5][loader][5d]")
   const double* data = table.DataPtr();
   CHECK(data[offset] == Catch::Approx(54321.0));
 
-  // Test MakeDeviceCopy (exercises MakeHiArray 5D flattening)
+  // Test MakeDeviceCopy for 5D table
   const auto deviceTable = WeakLibReader::MakeDeviceCopy(table);
   CHECK(deviceTable.nd == 5);
   CHECK(deviceTable.layout.nd == 5);
 
   // Round-trip: copy device data back to host and verify
-  amrex::TableData<double, 4> roundtrip;
-  const amrex::Array<int, 4> lo{{0, 0, 0, 0}};
-  bool overflow = false;
-  const amrex::Array<int, 4> hi =
-      WeakLibReader::detail::MakeHiArray(table.nd, table.extents, overflow);
-  REQUIRE_FALSE(overflow);
-  roundtrip.resize(lo, hi, amrex::The_Pinned_Arena());
-  roundtrip.copy(deviceTable.values);
+  amrex::Gpu::PinnedVector<double> roundtrip(deviceTable.values.size());
+  amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                   deviceTable.values.begin(), deviceTable.values.end(),
+                   roundtrip.begin());
 
   // Verify all data matches
   const double* originalPtr = table.DataPtr();
-  const double* roundtripPtr = roundtrip.const_table().p;
+  const double* roundtripPtr = roundtrip.data();
   for (std::size_t i = 0; i < totalSize; ++i) {
     CHECK(roundtripPtr[i] == Catch::Approx(originalPtr[i]).margin(kTol));
   }

--- a/test/test_weaklib_eos_loader.cpp
+++ b/test/test_weaklib_eos_loader.cpp
@@ -466,11 +466,11 @@ TEST_CASE("LoadWeakLibEosTableFull reads complete EOS table", "[hdf5][weaklib]")
   // Variable data has correct size
   for (int iVar = 0; iVar < table.nVariables; ++iVar) {
     const auto& var = table.variables[iVar];
-    CHECK(var.const_table().p != nullptr);
+    CHECK(var.data() != nullptr);
   }
 
   // Repaired mask is loaded
-  CHECK(table.repaired.const_table().p != nullptr);
+  CHECK(table.repaired.data() != nullptr);
 
   // Layout is computed correctly (row-major)
   // stride[0] = 1, stride[1] = n[0], stride[2] = n[0]*n[1]
@@ -549,16 +549,16 @@ TEST_CASE("LoadWeakLibEosTableFullParallel loads complete table", "[weaklib][eos
   const std::size_t varSize = static_cast<std::size_t>(table.dimensions[0]) *
                               table.dimensions[1] * table.dimensions[2];
   for (int iVar = 0; iVar < table.nVariables; ++iVar) {
-    const double* parData = table.variables[iVar].const_table().p;
-    const double* seqData = seqTable.variables[iVar].const_table().p;
+    const double* parData = table.variables[iVar].data();
+    const double* seqData = seqTable.variables[iVar].data();
     for (std::size_t i = 0; i < varSize; ++i) {
       CHECK(parData[i] == seqData[i]);
     }
   }
 
   // Verify repaired mask matches
-  const int* parRepaired = table.repaired.const_table().p;
-  const int* seqRepaired = seqTable.repaired.const_table().p;
+  const int* parRepaired = table.repaired.data();
+  const int* seqRepaired = seqTable.repaired.data();
   for (std::size_t i = 0; i < varSize; ++i) {
     CHECK(parRepaired[i] == seqRepaired[i]);
   }


### PR DESCRIPTION
## Summary

- Replace all `amrex::TableData` usage with flat `amrex::Gpu::PinnedVector` (host) / `amrex::Gpu::DeviceVector` (device) across all table structs, loaders, device copy functions, and tests
- Delete `MakeHiArray` helper and remove `#include <AMReX_TableData.H>`
- Add `OffsetValue()` accessor to scattering table structs for clean 2D offset access

## Test plan

- [x] `grep -r "TableData\|MakeHiArray\|const_table\|\.table()" src/ test/` returns zero matches
- [x] `scripts/check.sh` — build and all tests pass cleanly
- [x] Cactus thorn compiles and runs correctly (manual verification)