### PR TITLE
Streamline docs and fix column-major layout comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,68 +4,24 @@
 
 Translate WeakLib's EOS & opacity **interpolators** from Fortran into **GPU-friendly C++** that integrates with **AMReX**. Target: numerical parity with Fortran (≤1e-12 relative error), CUDA first (HIP later).
 
-## Repository Structure
+## Tech Stack
+
+- **C++17 header-only library** (all code in `src/` headers)
+- **AMReX** for GPU portability (`AMREX_GPU_HOST_DEVICE`, `Gpu::DeviceVector`, `Gpu::PinnedVector`)
+- **HDF5** for table I/O (only supported format)
+- **Catch2** test framework (`test/`)
+- **CMake 3.18+** build system
+
+## Project Structure
 
 ```
-src/                                        # Public API headers
-  WeakLibReader_AxisTypes.hpp               # Axis, AxisScale
-  WeakLibReader_Hdf5Loader.hpp              # HDF5 table loader API
-  WeakLibReader_Hdf5Types.hpp               # HDF5-related types (TableView, Hdf5Table, etc.)
-  WeakLibReader_IndexDelta.hpp              # Linear/log10 indexing helpers
-  WeakLibReader_InterpBasis.hpp             # Linear through penta-linear basis routines
-  WeakLibReader_InterpLogTable.hpp          # Aggregator for log-table interpolation headers
-  WeakLibReader_Layout.hpp                  # Row-major stride helpers
-  WeakLibReader_LogInterpolate.hpp          # Aggregator for high-level interpolation API
-  WeakLibReader_Math.hpp                    # GPU math utilities (Log10, Pow10)
-  detail/                                   # Implementation details (internal)
-    WeakLibReader_Hdf5LoaderDetail.hpp      # HDF5 loading implementation
-    WeakLibReader_InterpLogTableDeriv.hpp   # Point derivative kernels
-    WeakLibReader_InterpLogTablePoint.hpp   # Point interpolation kernels
-    WeakLibReader_InterpLogTableSlice.hpp   # Slice and symmetric plane ops
-    WeakLibReader_LogInterpolateCore.hpp    # Template dispatch by dimension
-    WeakLibReader_LogInterpolateDeriv.hpp   # Derivative API wrappers
-    WeakLibReader_LogInterpolatePoint.hpp   # Single-point API wrappers
-    WeakLibReader_LogInterpolateSum.hpp     # Sum utilities
-    WeakLibReader_LogInterpolateSweep.hpp   # Batch/sweep operations
-test/                                       # Regression tests (Catch2)
-  test_hdf5_loader.cpp                      # HDF5 loader tests
-  test_log_interpolate_2d.cpp               # 2D interpolation tests
-  test_log_interpolate_3d.cpp               # 3D interpolation tests
-  test_log_interpolate_4d5d.cpp             # 4D/5D interpolation tests
-  test_log_interpolate_basis.cpp            # Basis function tests
-  test_log_interpolate_deriv.cpp            # Derivative tests
-  test_log_interpolate_kernel.cpp           # Kernel unit tests
-  test_log_interpolate_sweep.cpp            # Sweep operation tests
-  test_weaklib_eos_loader.cpp               # WeakLib EOS table loader tests
-ref/weaklib/                                # Fortran reference implementation
-  wlInterpolationModule.F90                 # Main interpolation routines
-  wlInterpolationUtilitiesModule.F90        # Utility functions
-  wlIOModuleHDF.F90                         # HDF5 I/O module
-  wlKindModule.f90                          # Kind parameter definitions
-cactus_interface/                           # Cactus thorn integration
-  WeakLibReader/                            # Library thorn
-  TestWeakLibReader/                        # Test thorn with example usage
-scripts/                                    # Build & test automation
-  build.sh                                  # Build only
-  test.sh                                   # Run tests only
-  check.sh                                  # Build and test together
+src/              # Public API headers + detail/ subdirectory for internals
+test/             # Catch2 regression tests (EOS, opacity, interpolation, HDF5)
+ref/weaklib/      # Fortran reference implementation (consult before new interp logic)
+cactus_interface/ # Cactus thorns: WeakLibReader (library) + TestWeakLibReader (example)
+scripts/          # build.sh, test.sh, check.sh
+agent_docs/       # Detailed reference docs (HDF5 formats, opacity tables, Cactus patterns)
 ```
-
-## Naming Conventions
-
-- **Namespace:** `WeakLibReader`
-- **Types/Functions:** `PascalCase` (e.g., `Axis`, `IndexAndDeltaLin`)
-- **Variables:** `lowerCamelCase` (e.g., `fracT`, `rowStride`)
-- **Standard:** C++17+
-
-## Key Design Principles
-
-1. **Row-major layout** with precomputed strides
-2. **No STL containers** in device code; no dynamic allocations in kernels
-3. **Pass by value** for small structs (`Axis`, `Layout`)
-4. **Out-of-range handling:** Extrapolation (matches Fortran behavior)
-5. **Strict monotonicity** for axis grids (validated at load time)
-6. **Device functions** must be `noexcept`, inline, `AMREX_GPU_HOST_DEVICE`
 
 ## Build & Test
 
@@ -77,45 +33,16 @@ scripts/check.sh   # Build and test together
 
 Set `VERBOSE=1` for full test output (e.g., `VERBOSE=1 scripts/test.sh`).
 
-## HDF5 Table Format
+## Architecture
 
-### Simple Format (Generic Tables)
-
-```
-/values              # N-D array (row-major)
-/axis0, /axis1, ...  # 1D arrays with "scale" attribute ("linear" or "log10")
-```
-
-Validation: monotonic ascending, positive values for Log10 axes.
-
-### Native WeakLib EOS Format
-
-```
-/ThermoState/
-  Dimensions[3]                     # Grid dimensions [nRho, nT, nYe]
-  Density[nRho]                     # Density axis (log10 scale)
-  Temperature[nT]                   # Temperature axis (log10 scale)
-  Electron Fraction[nYe]            # Ye axis (linear scale)
-/DependentVariables/
-  nVariables                        # Number of dependent variables
-  Names[], Units[], Offsets[]       # Variable metadata
-  iPressure, iEntropyPerBaryon, ... # Index mappings for each variable
-  {variable_name}[nYe,nT,nRho]      # Variable data arrays
-```
-
-Use `LoadWeakLibEosTableFull()` for complete tables.
-
-## Fortran Reference
-
-Located in `ref/weaklib/`. Key modules: `wlInterpolationModule.F90`, `wlInterpolationUtilitiesModule.F90`. Always consult before implementing new interpolation logic.
-
-## Architectural Decisions (Locked)
-
-1. **Out-of-range behavior:** Natural extrapolation (matches Fortran)
-2. **Precision:** Double throughout
-3. **Table I/O:** HDF5 only
-4. **GPU backend:** CUDA first, HIP/DPCPP later
-5. **Memory layout:** Explicit row-major with precomputed strides
+- **Column-major layout** — `stride[0]=1`, first dimension varies fastest; precomputed strides via `MakeLayout()`
+- **No STL containers in device code** — no dynamic allocations in kernels
+- **Pass by value** for small structs (`Axis`, `Layout`)
+- **Out-of-range:** natural extrapolation (matches Fortran)
+- **Double precision** throughout
+- **Device functions** must be `noexcept`, inline, `AMREX_GPU_HOST_DEVICE`
+- **Strict monotonicity** for axis grids (validated at load time)
+- **GPU backend:** CUDA first, HIP/DPCPP later
 
 ## Do's and Don'ts
 
@@ -131,3 +58,15 @@ Located in `ref/weaklib/`. Key modules: `wlInterpolationModule.F90`, `wlInterpol
 - Use STL containers or dynamic allocations in device code
 - Add OpenACC or non-AMReX GPU pragmas
 - Skip host-side validation (monotonicity, Log10 positivity)
+
+## Fortran Reference
+
+Located in `ref/weaklib/`. Key modules: `wlInterpolationModule.F90`, `wlInterpolationUtilitiesModule.F90`. Always consult before implementing new interpolation logic.
+
+## Agent Docs
+
+Detailed reference material in `agent_docs/` — consult when working on specific subsystems:
+
+- **`hdf5_formats.md`** — HDF5 table schemas (simple, EOS, opacity) and loader function reference
+- **`opacity_tables.md`** — Opacity table types, dimensions, interpolation API, device patterns
+- **`cactus_integration.md`** — Cactus thorn CCL patterns, device loops, parameter sharing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,68 +4,24 @@
 
 Translate WeakLib's EOS & opacity **interpolators** from Fortran into **GPU-friendly C++** that integrates with **AMReX**. Target: numerical parity with Fortran (≤1e-12 relative error), CUDA first (HIP later).
 
-## Repository Structure
+## Tech Stack
+
+- **C++17 header-only library** (all code in `src/` headers)
+- **AMReX** for GPU portability (`AMREX_GPU_HOST_DEVICE`, `Gpu::DeviceVector`, `Gpu::PinnedVector`)
+- **HDF5** for table I/O (only supported format)
+- **Catch2** test framework (`test/`)
+- **CMake 3.18+** build system
+
+## Project Structure
 
 ```
-src/                                        # Public API headers
-  WeakLibReader_AxisTypes.hpp               # Axis, AxisScale
-  WeakLibReader_Hdf5Loader.hpp              # HDF5 table loader API
-  WeakLibReader_Hdf5Types.hpp               # HDF5-related types (TableView, Hdf5Table, etc.)
-  WeakLibReader_IndexDelta.hpp              # Linear/log10 indexing helpers
-  WeakLibReader_InterpBasis.hpp             # Linear through penta-linear basis routines
-  WeakLibReader_InterpLogTable.hpp          # Aggregator for log-table interpolation headers
-  WeakLibReader_Layout.hpp                  # Row-major stride helpers
-  WeakLibReader_LogInterpolate.hpp          # Aggregator for high-level interpolation API
-  WeakLibReader_Math.hpp                    # GPU math utilities (Log10, Pow10)
-  detail/                                   # Implementation details (internal)
-    WeakLibReader_Hdf5LoaderDetail.hpp      # HDF5 loading implementation
-    WeakLibReader_InterpLogTableDeriv.hpp   # Point derivative kernels
-    WeakLibReader_InterpLogTablePoint.hpp   # Point interpolation kernels
-    WeakLibReader_InterpLogTableSlice.hpp   # Slice and symmetric plane ops
-    WeakLibReader_LogInterpolateCore.hpp    # Template dispatch by dimension
-    WeakLibReader_LogInterpolateDeriv.hpp   # Derivative API wrappers
-    WeakLibReader_LogInterpolatePoint.hpp   # Single-point API wrappers
-    WeakLibReader_LogInterpolateSum.hpp     # Sum utilities
-    WeakLibReader_LogInterpolateSweep.hpp   # Batch/sweep operations
-test/                                       # Regression tests (Catch2)
-  test_hdf5_loader.cpp                      # HDF5 loader tests
-  test_log_interpolate_2d.cpp               # 2D interpolation tests
-  test_log_interpolate_3d.cpp               # 3D interpolation tests
-  test_log_interpolate_4d5d.cpp             # 4D/5D interpolation tests
-  test_log_interpolate_basis.cpp            # Basis function tests
-  test_log_interpolate_deriv.cpp            # Derivative tests
-  test_log_interpolate_kernel.cpp           # Kernel unit tests
-  test_log_interpolate_sweep.cpp            # Sweep operation tests
-  test_weaklib_eos_loader.cpp               # WeakLib EOS table loader tests
-ref/weaklib/                                # Fortran reference implementation
-  wlInterpolationModule.F90                 # Main interpolation routines
-  wlInterpolationUtilitiesModule.F90        # Utility functions
-  wlIOModuleHDF.F90                         # HDF5 I/O module
-  wlKindModule.f90                          # Kind parameter definitions
-cactus_interface/                           # Cactus thorn integration
-  WeakLibReader/                            # Library thorn
-  TestWeakLibReader/                        # Test thorn with example usage
-scripts/                                    # Build & test automation
-  build.sh                                  # Build only
-  test.sh                                   # Run tests only
-  check.sh                                  # Build and test together
+src/              # Public API headers + detail/ subdirectory for internals
+test/             # Catch2 regression tests (EOS, opacity, interpolation, HDF5)
+ref/weaklib/      # Fortran reference implementation (consult before new interp logic)
+cactus_interface/ # Cactus thorns: WeakLibReader (library) + TestWeakLibReader (example)
+scripts/          # build.sh, test.sh, check.sh
+agent_docs/       # Detailed reference docs (HDF5 formats, opacity tables, Cactus patterns)
 ```
-
-## Naming Conventions
-
-- **Namespace:** `WeakLibReader`
-- **Types/Functions:** `PascalCase` (e.g., `Axis`, `IndexAndDeltaLin`)
-- **Variables:** `lowerCamelCase` (e.g., `fracT`, `rowStride`)
-- **Standard:** C++17+
-
-## Key Design Principles
-
-1. **Row-major layout** with precomputed strides
-2. **No STL containers** in device code; no dynamic allocations in kernels
-3. **Pass by value** for small structs (`Axis`, `Layout`)
-4. **Out-of-range handling:** Extrapolation (matches Fortran behavior)
-5. **Strict monotonicity** for axis grids (validated at load time)
-6. **Device functions** must be `noexcept`, inline, `AMREX_GPU_HOST_DEVICE`
 
 ## Build & Test
 
@@ -77,45 +33,16 @@ scripts/check.sh   # Build and test together
 
 Set `VERBOSE=1` for full test output (e.g., `VERBOSE=1 scripts/test.sh`).
 
-## HDF5 Table Format
+## Architecture
 
-### Simple Format (Generic Tables)
-
-```
-/values              # N-D array (row-major)
-/axis0, /axis1, ...  # 1D arrays with "scale" attribute ("linear" or "log10")
-```
-
-Validation: monotonic ascending, positive values for Log10 axes.
-
-### Native WeakLib EOS Format
-
-```
-/ThermoState/
-  Dimensions[3]                     # Grid dimensions [nRho, nT, nYe]
-  Density[nRho]                     # Density axis (log10 scale)
-  Temperature[nT]                   # Temperature axis (log10 scale)
-  Electron Fraction[nYe]            # Ye axis (linear scale)
-/DependentVariables/
-  nVariables                        # Number of dependent variables
-  Names[], Units[], Offsets[]       # Variable metadata
-  iPressure, iEntropyPerBaryon, ... # Index mappings for each variable
-  {variable_name}[nYe,nT,nRho]      # Variable data arrays
-```
-
-Use `LoadWeakLibEosTableFull()` for complete tables.
-
-## Fortran Reference
-
-Located in `ref/weaklib/`. Key modules: `wlInterpolationModule.F90`, `wlInterpolationUtilitiesModule.F90`. Always consult before implementing new interpolation logic.
-
-## Architectural Decisions (Locked)
-
-1. **Out-of-range behavior:** Natural extrapolation (matches Fortran)
-2. **Precision:** Double throughout
-3. **Table I/O:** HDF5 only
-4. **GPU backend:** CUDA first, HIP/DPCPP later
-5. **Memory layout:** Explicit row-major with precomputed strides
+- **Column-major layout** — `stride[0]=1`, first dimension varies fastest; precomputed strides via `MakeLayout()`
+- **No STL containers in device code** — no dynamic allocations in kernels
+- **Pass by value** for small structs (`Axis`, `Layout`)
+- **Out-of-range:** natural extrapolation (matches Fortran)
+- **Double precision** throughout
+- **Device functions** must be `noexcept`, inline, `AMREX_GPU_HOST_DEVICE`
+- **Strict monotonicity** for axis grids (validated at load time)
+- **GPU backend:** CUDA first, HIP/DPCPP later
 
 ## Do's and Don'ts
 
@@ -131,3 +58,15 @@ Located in `ref/weaklib/`. Key modules: `wlInterpolationModule.F90`, `wlInterpol
 - Use STL containers or dynamic allocations in device code
 - Add OpenACC or non-AMReX GPU pragmas
 - Skip host-side validation (monotonicity, Log10 positivity)
+
+## Fortran Reference
+
+Located in `ref/weaklib/`. Key modules: `wlInterpolationModule.F90`, `wlInterpolationUtilitiesModule.F90`. Always consult before implementing new interpolation logic.
+
+## Agent Docs
+
+Detailed reference material in `agent_docs/` — consult when working on specific subsystems:
+
+- **`hdf5_formats.md`** — HDF5 table schemas (simple, EOS, opacity) and loader function reference
+- **`opacity_tables.md`** — Opacity table types, dimensions, interpolation API, device patterns
+- **`cactus_integration.md`** — Cactus thorn CCL patterns, device loops, parameter sharing

--- a/agent_docs/cactus_integration.md
+++ b/agent_docs/cactus_integration.md
@@ -1,0 +1,184 @@
+# Cactus Thorn Integration
+
+## Overview
+
+Two thorns in `cactus_interface/`:
+- **WeakLibReader** — Library thorn that provides the WeakLibReader capability and declares table file parameters
+- **TestWeakLibReader** — Consumer thorn demonstrating EOS + opacity loading and GPU interpolation
+
+**Note:** Thorn source files depend on Cactus-generated headers (`cctk.h`, `cctk_Arguments.h`, `cctk_Parameters.h`) and CarpetX/AMReX headers (`loop_device.hxx`). They will **not** pass standalone clangd analysis — this is expected.
+
+## CCL File Patterns
+
+### Grid Function Declarations (`interface.ccl`)
+
+```ccl
+USES INCLUDE HEADER: loop_device.hxx
+
+CCTK_REAL energy TYPE=GF CENTERING={VVV} TAGS="checkpoint='yes'" "description"
+```
+
+- `TYPE=GF` — grid function storage
+- `CENTERING={VVV}` — vertex-centered (all three dimensions)
+- `TAGS="checkpoint='yes'"` — enables checkpoint/restart
+
+### Scheduling (`schedule.ccl`)
+
+```ccl
+# Allocate storage for grid functions
+STORAGE: energy
+STORAGE: opacity_emab
+
+# Global function (runs once, not per patch) — use for I/O and device memory
+SCHEDULE MyThorn_LoadTable AT INITIAL
+{
+  LANG: C
+  OPTIONS: global
+} "Load table"
+
+# Grid loop function (runs per patch) — use for interpolation
+SCHEDULE MyThorn_Init AT INITIAL AFTER MyThorn_LoadTable
+{
+  LANG: C
+  WRITES: energy(interior)
+  SYNC: energy
+} "Initialize grid function"
+
+# Reading another grid function
+SCHEDULE MyThorn_Compute AT INITIAL AFTER MyThorn_Init
+{
+  LANG: C
+  READS: energy(interior)
+  WRITES: opacity(interior)
+  SYNC: opacity
+} "Compute from energy"
+
+# Cleanup at termination
+SCHEDULE MyThorn_Cleanup AT TERMINATE
+{
+  LANG: C
+  OPTIONS: global
+} "Clean up before AMReX finalizes"
+```
+
+Key scheduling points: `AT INITIAL`, `AT TERMINATE`. Use `AFTER` for ordering.
+
+### Parameter Declaration and Sharing (`param.ccl`)
+
+Library thorn declares parameters as `RESTRICTED` for sharing:
+
+```ccl
+# In WeakLibReader/param.ccl
+RESTRICTED:
+STRING eos_table_file "eos table name (hdf5)" STEERABLE=RECOVER
+{
+  ".*" :: "can be anything"
+} "foo.h5"
+```
+
+Consumer thorn imports via `SHARES`:
+
+```ccl
+# In TestWeakLibReader/param.ccl
+SHARES: WeakLibReader
+USES STRING eos_table_file
+USES STRING opacity_emab_file
+```
+
+### Configuration (`configuration.ccl`)
+
+```ccl
+# Library thorn
+REQUIRES Loop HDF5
+PROVIDES WeakLibReader
+{
+  SCRIPT src/detect.sh
+  LANG bash
+  OPTIONS WEAKLIBREADER_DIR WEAKLIBREADER_INC_DIR
+}
+
+# Consumer thorn
+REQUIRES Loop WeakLibReader
+```
+
+## C++ Implementation Patterns
+
+### Function Signatures
+
+```cpp
+// Global function (I/O, device memory management)
+extern "C" void MyThorn_LoadTable(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_PARAMETERS;            // Access parameters (e.g., eos_table_file)
+  // No DECLARE_CCTK_ARGUMENTSX needed for global functions
+}
+
+// Grid loop function
+extern "C" void MyThorn_Init(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_PARAMETERS;
+  DECLARE_CCTK_ARGUMENTSX_MyThorn_Init;  // Access grid functions
+}
+```
+
+- `DECLARE_CCTK_ARGUMENTSX_FunctionName` — name must match scheduled function exactly
+- All scheduled functions use `extern "C"` linkage
+
+### Device Loop Pattern
+
+```cpp
+grid.loop_int_device<0, 0, 0>(
+    grid.nghostzones,
+    [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+    // p.I = flat index into grid function arrays
+    // p.x, p.y, p.z = physical coordinates
+    energy(p.I) = WeakLibReader::LogInterpolateSingleVariable3DCustomPoint(
+        p.x, p.y, p.z, axes, data, offset);
+    });
+```
+
+- Template `<0, 0, 0>` = no staggering
+- Capture `[=]` by value (device-safe — no host pointers)
+- Grid functions accessed as 1D arrays via `p.I`
+
+### Device Memory Management
+
+```cpp
+namespace MyThorn {
+  // Namespace-scope device tables (persist across scheduled functions)
+  WeakLibReader::WeakLibEosTableDevice eos_device;
+  WeakLibReader::WeakLibOpacityTableDevice opacity_device;
+  amrex::Gpu::DeviceVector<double> iso_slice_device;
+}
+
+// Loading: host load → device copy
+extern "C" void MyThorn_LoadTable(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_PARAMETERS;
+  WeakLibReader::WeakLibEosTable host_table;
+  auto status = WeakLibReader::LoadWeakLibEosTableFullParallel(eos_table_file, host_table);
+  if (status != WeakLibReader::Hdf5LoadStatus::Success) CCTK_ERROR("Failed");
+  eos_device = WeakLibReader::MakeDeviceCopy(host_table);
+}
+
+// Cleanup: assign empty structures
+extern "C" void MyThorn_Cleanup(CCTK_ARGUMENTS) {
+  eos_device = WeakLibReader::WeakLibEosTableDevice{};
+  iso_slice_device.clear();
+}
+```
+
+### Extracting Device Pointers for Kernels
+
+```cpp
+// Before loop: extract device-safe values
+const WeakLibReader::Axis axes[3] = {
+  eos_device.axes[0], eos_device.axes[1], eos_device.axes[2]};
+const double* data = eos_device.VariableData(iVariable);
+const double offset = eos_device.offsets[iVariable];
+
+// Then use in device loop via [=] capture
+```
+
+### Logging
+
+- `CCTK_INFO("message")` — informational
+- `CCTK_VINFO("format %d", val)` — formatted info
+- `CCTK_ERROR("message")` — abort execution

--- a/agent_docs/hdf5_formats.md
+++ b/agent_docs/hdf5_formats.md
@@ -1,0 +1,135 @@
+# HDF5 Table Formats
+
+## Simple Format (Generic Tables)
+
+Used by `LoadHdf5Table()` and `LoadHdf5TableParallel()`.
+
+```
+/values              # N-D array (1-5D)
+/axis0               # 1D array with "scale" attribute ("linear" or "log10")
+/axis1               # ...
+...
+```
+
+- Configurable via `Hdf5LoadConfig` (dataset name, axis prefix, scale attribute name)
+- Validation: monotonic ascending, positive values for Log10 axes
+- Axis length must match corresponding dimension extent
+
+## Native WeakLib EOS Format
+
+Used by `LoadWeakLibEosTableFull()` and `LoadWeakLibEosTableFullParallel()`.
+
+```
+/ThermoState/
+  LogInterp[3]                      # Axis scale flags (0=linear, 1=log10)
+  Dimensions[3]                     # Grid dimensions [nRho, nT, nYe]
+  Names[3], Units[3]                # Axis metadata (string arrays)
+  Density[nRho]                     # Density axis (Log10 scale typically)
+  Temperature[nT]                   # Temperature axis (Log10 scale typically)
+  Electron Fraction[nYe]            # Ye axis (Linear scale typically)
+
+/DependentVariables/
+  nVariables                        # Number of dependent variables (scalar int)
+  Names[nVars], Units[nVars]        # Variable metadata
+  Offsets[nVars]                    # Offset values for log-interpolation
+  Repaired[nYe, nT, nRho]          # Repair mask (3D integer array)
+
+  # Variable data arrays — one per variable
+  {variable_name}[nYe, nT, nRho]   # Fortran order in file, reversed to C order on load
+
+  # Index mappings (1-based in file, converted to 0-based)
+  iPressure, iEntropyPerBaryon, iInternalEnergyDensity,
+  iElectronChemicalPotential, iProtonChemicalPotential,
+  iNeutronChemicalPotential, iProtonMassFraction, iNeutronMassFraction,
+  iAlphaMassFraction, iHeavyMassFraction, iHeavyChargeNumber,
+  iHeavyMassNumber, iHeavyBindingEnergy, iThermalEnergy, iGamma1
+```
+
+## WeakLib Opacity Format
+
+Used by `LoadWeakLibOpacityTableFull()` and `LoadWeakLibOpacityTableFullParallel()`.
+
+### Shared Groups
+
+```
+/EnergyGrid/
+  Name[1], Unit[1]                  # Grid metadata
+  nPoints                           # Number of energy points
+  LogInterp                         # Scale flag (0=linear, 1=log10)
+  Values[nPoints]                   # Grid values
+
+/ThermoState/                       # Same structure as EOS ThermoState
+  LogInterp[3], Dimensions[3], Names[3], Units[3]
+  Density[nRho], Temperature[nT], Electron Fraction[nYe]
+
+/EtaGrid/                           # Same structure as EnergyGrid (NES/Pair only)
+  Name[1], Unit[1], nPoints, LogInterp, Values[nPoints]
+```
+
+### EmAb (Emission/Absorption)
+
+```
+/EmAb/                              # or legacy: /EmAb_CorrectedAbsorption/
+  nOpacities, Units[nOp], Offsets[nOp]
+  Electron Neutrino[nE, nRho, nT, nYe]
+  Electron Antineutrino[nE, nRho, nT, nYe]
+
+/EmAb Parameters/                   # Optional process flags
+  np_FK, np_FK_inv_n_decay, np_isoenergetic, ...
+
+/EC_table/                          # Optional electron capture table
+  Spectrum[nRho, nT, nYe, nE], Rate[nRho, nT, nYe]
+```
+
+### Iso (Isoenergetic Scattering)
+
+```
+/Scat_Iso_Kernels/
+  nOpacities, nMoments
+  Offsets[nOpacities, nMoments]     # 2D (Fortran order in file)
+  weak_magnetism_corr, ion_ion_corr, many_body_corr, ga_strange  # Optional
+  Electron Neutrino[nE, nMom, nRho, nT, nYe]
+  Electron Antineutrino[nE, nMom, nRho, nT, nYe]
+```
+
+### NES (Neutrino-Electron Scattering)
+
+```
+/Scat_NES_Kernels/
+  nOpacities, nMoments, NPS         # NPS = optional flag
+  Offsets[nOpacities, nMoments]
+  Kernels[nE_in, nE_out, nMom, nT, nEta]
+```
+
+### Pair (Pair Production)
+
+```
+/Scat_Pair_Kernels/
+  nOpacities, nMoments
+  Offsets[nOpacities, nMoments]
+  Kernels[nE_in, nE_out, nMom, nT, nEta]
+```
+
+### Brem (Bremsstrahlung)
+
+```
+/Scat_Brem_Kernels/
+  nOpacities, nMoments
+  Offsets[nOpacities, nMoments]
+  S_sigma[nE_in, nE_out, nMom, nRho, nT]
+```
+
+**Note:** All multi-dimensional arrays are stored in Fortran order in HDF5 files and reversed to C column-major order on load.
+
+## Key Loader Functions
+
+| Function | Purpose |
+|----------|---------|
+| `LoadHdf5Table()` | Load simple-format generic table |
+| `LoadHdf5TableParallel()` | Parallel broadcast version of above |
+| `LoadWeakLibEosTableFull()` | Load complete EOS table (ThermoState + DependentVariables) |
+| `LoadWeakLibEosTableFullParallel()` | Parallel broadcast version of above |
+| `LoadWeakLibOpacityTableFull()` | Master loader for all opacity subtables |
+| `LoadWeakLibOpacityTableFullParallel()` | Parallel broadcast version of above |
+| `MakeDeviceCopy()` | Copy host table to GPU device memory (overloaded for all table types) |
+| `ExtractIsoMomentSlice4D()` | Extract contiguous 4D slice from 5D Iso kernel at fixed moment |

--- a/agent_docs/opacity_tables.md
+++ b/agent_docs/opacity_tables.md
@@ -1,0 +1,122 @@
+# Opacity Tables
+
+## Overview
+
+Five neutrino opacity table types, loaded from WeakLib HDF5 files and interpolated on GPU. All values stored as log10 with per-variable offsets.
+
+## Table Types and Dimensions
+
+| Type | Dimensions | Axes | Species |
+|------|-----------|------|---------|
+| **EmAb** | 4D `[nE, nRho, nT, nYe]` | Energy, Density, Temperature, Ye | 2 (nue, anue) |
+| **Iso** | 5D `[nE, nMom, nRho, nT, nYe]` | Energy, Moments, Density, Temperature, Ye | 2 (nue, anue) |
+| **NES** | 5D `[nE_in, nE_out, nMom, nT, nEta]` | Energy×2, Moments, Temperature, Eta | 1 kernel |
+| **Pair** | 5D `[nE_in, nE_out, nMom, nT, nEta]` | Energy×2, Moments, Temperature, Eta | 1 kernel |
+| **Brem** | 5D `[nE_in, nE_out, nMom, nRho, nT]` | Energy×2, Moments, Density, Temperature | 1 kernel |
+
+Shared grids: `EnergyGrid`, `ThermoState` (Rho, T, Ye), `EtaGrid` (NES/Pair only).
+
+## Interpolation API by Table Type
+
+### EmAb — Direct 4D interpolation
+
+```cpp
+// 4D log-interpolation: [E, Rho, T, Ye]
+const Axis axes[4] = {energyAxis, rhoAxis, tempAxis, yeAxis};
+double opacity = LogInterpolateSingleVariable4DCustomPoint(
+    E, rho, T, ye, axes, opacityData, offset);
+```
+
+### Iso — Extract moment slice, then 4D interpolation
+
+```cpp
+// Host: extract contiguous 4D slice at fixed moment
+auto slice = ExtractIsoMomentSlice4D(kernel5d, dims, /*iMom=*/0);
+
+// Device: same 4D interpolation as EmAb
+double opacity = LogInterpolateSingleVariable4DCustomPoint(
+    E, rho, T, ye, axes, sliceData, offset);
+```
+
+### NES / Pair — Pre-align energy grid, then 2D aligned interpolation
+
+```cpp
+// Host: pre-align 5D kernel to 4D [nAlignedE, nAlignedE, nT, nEta]
+PreAlignScatteringKernelMoment(rawKernel, rawLayout, energyAxis,
+    iMom, nT, nEta, alignedE, nAlignedE, offset, output);
+
+// Device: compute indices manually, then 2D aligned interp
+detail::IndexAndDelta(tempAxis, T, idxT, fracT);
+detail::IndexAndDelta(etaAxis, eta, idxEta, fracEta);
+double opacity = LinearInterp2D4DArray2DAlignedPoint(
+    iE_in, iE_out, idxT, idxEta, fracT, fracEta,
+    offset, alignedData, alignedLayout);
+```
+
+### Brem — Pre-align + weighted sum over density terms
+
+```cpp
+// Host: same PreAlignScatteringKernelMoment as NES/Pair
+// but with nDim3=nRho, nDim4=nT
+
+// Device: sum over 3 density-weighted terms [rho*Xp, rho*Xn, rho*sqrt(Xp*Xn)]
+const double alpha[3] = {1.0, 1.0, 28.0/3.0};
+double sum = 0.0;
+for (int l = 0; l < 3; ++l) {
+  detail::IndexAndDelta(rhoAxis, dxVals[l], idxD, fracD);
+  sum += alpha[l] * LinearInterp2D4DArray2DAlignedPoint(
+      iE_in, iE_out, idxD, idxT, fracD, fracT,
+      offset, bremData, bremLayout);
+}
+```
+
+## Key API Functions
+
+| Function | Location | Purpose |
+|----------|----------|---------|
+| `LogInterpolateSingleVariable4DCustomPoint()` | `detail/LogInterpolatePoint.hpp` | Full 4D log-interpolation (EmAb, Iso slice) |
+| `LinearInterp2D4DArray2DAlignedPoint()` | `detail/InterpLogTableSlice.hpp` | 2D interp in 4D array with fixed leading dims (NES/Pair/Brem) |
+| `detail::IndexAndDelta()` | `WeakLibReader_IndexDelta.hpp` | Convert raw coordinate to grid index + fraction |
+| `PreAlignScatteringKernelMoment()` | `detail/LogInterpolateSweep.hpp` | Host-side: interpolate 5D kernel to aligned 4D energy grid |
+| `ExtractIsoMomentSlice4D()` | `WeakLibReader_Hdf5Loader.hpp` | Host-side: extract contiguous 4D slice from 5D Iso kernel |
+
+## Device Copy and Pre-alignment Patterns
+
+### Loading and Device Transfer
+
+```cpp
+// 1. Load all opacity tables from HDF5
+WeakLibOpacityTable opacity_table;
+LoadWeakLibOpacityTableFull(opacity_table, fileEmAb, fileIso, fileNES, filePair, fileBrem);
+
+// 2. Copy to device (handles all subtables)
+auto device_table = MakeDeviceCopy(opacity_table);
+```
+
+### Pre-alignment for Scattering Kernels (NES/Pair/Brem)
+
+Scattering kernels are 5D with energy×energy leading dimensions. For device use, pre-align onto a common energy grid to get contiguous 4D arrays:
+
+```cpp
+// Per-moment pre-alignment
+for (int iMom = 0; iMom < nMom; ++iMom) {
+  amrex::Vector<double> hostBuf(alignedSize);
+  PreAlignScatteringKernelMoment(rawKernel, rawLayout, energyAxis,
+      iMom, nDim3, nDim4, alignedEnergyValues, nAlignedE,
+      offset, hostBuf.data());
+
+  // Copy to device
+  deviceVec.resize(alignedSize);
+  amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+      hostBuf.begin(), hostBuf.end(), deviceVec.begin());
+}
+```
+
+### Offset Handling
+
+- **EmAb**: `offsets[species]` — 1D array indexed by species
+- **Iso/NES/Pair/Brem**: `OffsetValue(species, moment)` — 2D column-major table
+
+## Usage Example
+
+See `cactus_interface/TestWeakLibReader/src/testweaklibreader.cxx` for a complete working example showing all five table types loaded, pre-aligned, device-copied, and interpolated in CarpetX device loops.

--- a/src/WeakLibReader_Layout.hpp
+++ b/src/WeakLibReader_Layout.hpp
@@ -8,8 +8,8 @@ namespace WeakLibReader {
 
 struct Layout {
   int nd = 0;                  // number of dimensions, 1..5
-  int n[5] = {1, 1, 1, 1, 1};   // extent along each axis (row-major ordering)
-  std::size_t stride[5] = {0, 0, 0, 0, 0}; // row-major stride for each axis
+  int n[5] = {1, 1, 1, 1, 1};   // extent along each axis (column-major ordering)
+  std::size_t stride[5] = {0, 0, 0, 0, 0}; // column-major stride for each axis
 
   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
   std::size_t Offset(const int idx[5]) const noexcept


### PR DESCRIPTION
## Summary
- Move detailed reference material (HDF5 formats, opacity tables, Cactus integration patterns) out of CLAUDE.md/AGENTS.md into dedicated `agent_docs/` directory
- Condense CLAUDE.md and AGENTS.md to focus on essential project info, tech stack, and architecture
- Fix Layout.hpp comments from "row-major" to "column-major" to match actual `stride[0]=1` convention

## Test plan
- [ ] Verify `scripts/check.sh` still passes (no code logic changes, only comments and docs)
- [ ] Confirm agent_docs/ files contain the detailed reference content moved from CLAUDE.md/AGENTS.md