### PR TITLE
Simplify HDF5 module by consolidating duplicated patterns

### DIFF
--- a/src/WeakLibReader_Hdf5Loader.hpp
+++ b/src/WeakLibReader_Hdf5Loader.hpp
@@ -583,8 +583,8 @@ inline Hdf5LoadStatus LoadWeakLibScatIsoTable(hid_t file,
 
   // Read kernel data for each species
   for (int iSpecies = 0; iSpecies < WeakLibScatIsoTable::kNumSpecies && iSpecies < scatIso.nOpacities; ++iSpecies) {
-    if (!detail::ReadWeakLibArray5d<double>(group.Get(), scatIso.names[iSpecies].c_str(),
-                                   scatIso.kernels[iSpecies], scatIso.dimensions)) {
+    if (!detail::ReadWeakLibArrayNd<double, 5>(group.Get(), scatIso.names[iSpecies].c_str(),
+                                               scatIso.kernels[iSpecies], scatIso.dimensions)) {
       return Hdf5LoadStatus::DatasetReadFailed;
     }
   }
@@ -681,7 +681,7 @@ inline Hdf5LoadStatus LoadScatKernelTable(
 
   // Set kernel name and read kernel data
   table.name = kernelDatasetName;
-  if (!ReadWeakLibArray5d<double>(group.Get(), kernelDatasetName, table.kernel, table.dimensions)) {
+  if (!ReadWeakLibArrayNd<double, 5>(group.Get(), kernelDatasetName, table.kernel, table.dimensions)) {
     return Hdf5LoadStatus::DatasetReadFailed;
   }
 

--- a/src/WeakLibReader_Hdf5Types.hpp
+++ b/src/WeakLibReader_Hdf5Types.hpp
@@ -323,7 +323,7 @@ struct WeakLibScatIsoTable {
   amrex::Gpu::PinnedVector<double> offsets;
 
   // Kernel data: 5D per species (stored as flat arrays)
-  std::array<amrex::Vector<double>, kNumSpecies> kernels;
+  std::array<amrex::Gpu::PinnedVector<double>, kNumSpecies> kernels;
 
   // Correction flags
   int weak_magnetism_corrections = -1;
@@ -388,7 +388,7 @@ struct WeakLibScatKernelTable {
   std::string unit;
   // Offsets: 2D [nOpacities, nMoments] — column-major (species stride=1)
   amrex::Gpu::PinnedVector<double> offsets;
-  amrex::Vector<double> kernel;  // Stored as flat array
+  amrex::Gpu::PinnedVector<double> kernel;  // Stored as flat array
 
   int NPS = -1;  // Neutrino-positron scattering flag (NES only; -1 = not set)
 

--- a/src/detail/WeakLibReader_Hdf5LoaderDetail.hpp
+++ b/src/detail/WeakLibReader_Hdf5LoaderDetail.hpp
@@ -377,17 +377,6 @@ bool ReadWeakLibArrayNd(hid_t parent, const char* name,
       parent, name, output, expectedDims);
 }
 
-// Read 5D array in Fortran order [d4, d3, d2, d1, d0] -> C order [d0, d1, d2, d3, d4]
-// Stores data in a flat amrex::Vector<T>.
-template <typename T>
-bool ReadWeakLibArray5d(hid_t group, const char* name,
-                        amrex::Vector<T>& output,
-                        const std::array<int, 5>& expectedDims)
-{
-  return ReadWeakLibArrayNdImpl<amrex::Vector<T>, T, 5>(
-      group, name, output, expectedDims);
-}
-
 // Check if HDF5 group exists (suppress errors)
 inline bool GroupExists(hid_t loc, const char* name)
 {


### PR DESCRIPTION
## Summary
- Add `ScopedH5ErrorSuppressor` RAII helper, replacing 4 manual save/suppress/restore error-handling blocks
- Templatize `ReadWeakLibArrayNdImpl` on container type, eliminating the duplicate 48-line 5D array reader and removing all thin wrapper functions (`ReadDoubleArray{2,3,4,5}d`, `ReadIntArray3d`, `ReadWeakLibArray{2,3,4}d`)
- Unify `WeakLibScatNESTable`, `WeakLibScatPairTable`, and `WeakLibScatBremTable` into a single `WeakLibScatKernelTable` struct with type aliases preserving the public API
- Extract `detail::LoadScatKernelTable` and `detail::CopyScatKernelToDevice` helpers, consolidating 3 near-identical loader functions and 3 near-identical device copy blocks

Net result: **-285 lines** (143 added, 428 removed) with no API or numerical behavior changes.

## Test plan
- [x] `scripts/check.sh` passes (build + all tests)
- [x] All existing opacity loader tests pass (NES, Pair, Brem loading)
- [x] All existing HDF5 loader tests pass (generic loading)