### PR TITLE
Add RescaleToAxis helper for proper coordinate mapping in WeakLibReader

### DIFF
--- a/cactus_interface/TestWeakLibReader/src/testweaklibreader_eos.cxx
+++ b/cactus_interface/TestWeakLibReader/src/testweaklibreader_eos.cxx
@@ -14,6 +14,20 @@ namespace TestWeakLibReader {
 WeakLibReader::WeakLibEosTableDevice eos_table_device;
 WeakLibReader::EosInversionBounds eos_inversion_bounds;
 
+// Map a coordinate t in [0,1) to the physical range of the given axis.
+// For Log10 axes the mapping is uniform in log-space.
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+double RescaleToAxis(double t, const WeakLibReader::Axis& axis) noexcept
+{
+  const double lo = axis.grid[0];
+  const double hi = axis.grid[axis.n - 1];
+  if (axis.scale == WeakLibReader::AxisScale::Log10) {
+    return lo * WeakLibReader::math::Pow10(
+        WeakLibReader::math::Log10(hi / lo) * t);
+  }
+  return lo + (hi - lo) * t;
+}
+
 extern "C" void TestWeakLibReader_LoadTable(CCTK_ARGUMENTS) {
   DECLARE_CCTK_PARAMETERS;
 
@@ -68,8 +82,11 @@ extern "C" void TestWeakLibReader_Init(CCTK_ARGUMENTS) {
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      const double rho = RescaleToAxis(p.x, axes[0]);
+      const double T   = RescaleToAxis(p.y, axes[1]);
+      const double Ye  = RescaleToAxis(p.z, axes[2]);
       energy(p.I) = WeakLibReader::LogInterpolateSingleVariable3DCustomPoint(
-          p.x, p.y, p.z,
+          rho, T, Ye,
           axes,
           pressureData, pressureOffset);
       });
@@ -109,10 +126,10 @@ extern "C" void TestWeakLibReader_ComputeEosDerived(CCTK_ARGUMENTS) {
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-      // (p.x, p.y, p.z) = (rho, T, Ye) in raw units
-      const double rho = p.x;
-      const double T   = p.y;
-      const double Ye  = p.z;
+      // Rescale [0,1) grid coordinates to physical axis ranges
+      const double rho = RescaleToAxis(p.x, axes[0]);
+      const double T   = RescaleToAxis(p.y, axes[1]);
+      const double Ye  = RescaleToAxis(p.z, axes[2]);
 
       // Interpolate mu_e from EOS
       const double muE = WeakLibReader::LogInterpolateSingleVariable3DCustomPoint(
@@ -158,9 +175,9 @@ extern "C" void TestWeakLibReader_InvertEos(CCTK_ARGUMENTS) {
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-      const double rho = p.x;
-      const double T   = p.y;  // known temperature
-      const double Ye  = p.z;
+      const double rho = RescaleToAxis(p.x, axes[0]);
+      const double T   = RescaleToAxis(p.y, axes[1]);
+      const double Ye  = RescaleToAxis(p.z, axes[2]);
 
       // Forward interpolate energy
       const double E = WeakLibReader::LogInterpolateSingleVariable3DCustomPoint(

--- a/cactus_interface/TestWeakLibReader/src/testweaklibreader_opacity.cxx
+++ b/cactus_interface/TestWeakLibReader/src/testweaklibreader_opacity.cxx
@@ -31,6 +31,20 @@ std::vector<AlignedKernel> nes_aligned;
 std::vector<AlignedKernel> pair_aligned;
 std::vector<AlignedKernel> brem_aligned;
 
+// Map a coordinate t in [0,1) to the physical range of the given axis.
+// For Log10 axes the mapping is uniform in log-space.
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+double RescaleToAxis(double t, const WeakLibReader::Axis& axis) noexcept
+{
+  const double lo = axis.grid[0];
+  const double hi = axis.grid[axis.n - 1];
+  if (axis.scale == WeakLibReader::AxisScale::Log10) {
+    return lo * WeakLibReader::math::Pow10(
+        WeakLibReader::math::Log10(hi / lo) * t);
+  }
+  return lo + (hi - lo) * t;
+}
+
 extern "C" void TestWeakLibReader_LoadOpacityTable(CCTK_ARGUMENTS) {
   DECLARE_CCTK_PARAMETERS;
 
@@ -218,8 +232,11 @@ extern "C" void TestWeakLibReader_InitEmAb(CCTK_ARGUMENTS) {
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      const double rho = RescaleToAxis(p.x, axes[1]);
+      const double T   = RescaleToAxis(p.y, axes[2]);
+      const double Ye  = RescaleToAxis(p.z, axes[3]);
       opacity_emab(p.I) = WeakLibReader::LogInterpolateSingleVariable4DCustomPoint(
-          fixedE, p.x, p.y, p.z,
+          fixedE, rho, T, Ye,
           axes,
           opacityData, offset);
       });
@@ -253,8 +270,11 @@ extern "C" void TestWeakLibReader_InitIso(CCTK_ARGUMENTS) {
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      const double rho = RescaleToAxis(p.x, axes[1]);
+      const double T   = RescaleToAxis(p.y, axes[2]);
+      const double Ye  = RescaleToAxis(p.z, axes[3]);
       opacity_iso(p.I) = WeakLibReader::LogInterpolateSingleVariable4DCustomPoint(
-          fixedE, p.x, p.y, p.z,
+          fixedE, rho, T, Ye,
           axes,
           sliceData, offset);
       });
@@ -287,7 +307,7 @@ extern "C" void TestWeakLibReader_InitNES(CCTK_ARGUMENTS) {
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-      const double T   = p.y;
+      const double T   = RescaleToAxis(p.y, axes[0]);
       const double eta = eos_log_eta(p.I);
 
       int idxT = 0, idxEta = 0;
@@ -330,7 +350,7 @@ extern "C" void TestWeakLibReader_InitPair(CCTK_ARGUMENTS) {
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-      const double T   = p.y;
+      const double T   = RescaleToAxis(p.y, axes[0]);
       const double eta = eos_log_eta(p.I);
 
       int idxT = 0, idxEta = 0;
@@ -376,7 +396,7 @@ extern "C" void TestWeakLibReader_InitBrem(CCTK_ARGUMENTS) {
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-      const double T = p.y;
+      const double T = RescaleToAxis(p.y, axes[1]);
 
       // Density-weighted terms from EOS-derived GFs
       const double dxVals[3] = {


### PR DESCRIPTION
## Summary
This PR introduces a `RescaleToAxis` helper function to properly map normalized grid coordinates [0,1) to physical axis ranges, with support for both linear and logarithmic (Log10) axis scales. This function is now used consistently across EOS and opacity table initialization routines.

## Key Changes
- **New `RescaleToAxis` function**: Added in both `testweaklibreader_eos.cxx` and `testweaklibreader_opacity.cxx` to handle coordinate transformation with proper handling of logarithmic axes
- **EOS table initialization**: Updated `TestWeakLibReader_Init` to rescale grid coordinates (rho, T, Ye) before interpolation
- **EOS derived quantities**: Updated `TestWeakLibReader_ComputeEosDerived` to use rescaled coordinates with improved comments
- **EOS inversion**: Updated `TestWeakLibReader_InvertEos` to rescale coordinates
- **Opacity initialization**: Updated `TestWeakLibReader_InitEmAb` and `TestWeakLibReader_InitIso` to rescale (rho, T, Ye) coordinates
- **Neutrino opacity**: Updated `TestWeakLibReader_InitNES`, `TestWeakLibReader_InitPair`, and `TestWeakLibReader_InitBrem` to rescale temperature coordinates

## Implementation Details
The `RescaleToAxis` function:
- Maps a normalized coordinate `t` in [0,1) to the physical range [lo, hi] of a given axis
- For Log10 axes, performs uniform mapping in log-space: `lo * 10^(log10(hi/lo) * t)`
- For linear axes, performs standard linear interpolation: `lo + (hi - lo) * t`
- Marked as `AMREX_GPU_HOST_DEVICE` and `AMREX_FORCE_INLINE` for GPU compatibility
- Replaces direct use of grid coordinates with properly scaled physical values

https://claude.ai/code/session_01GdNLF7i42w68VAGgY47Uf1