### PR TITLE
Rescale TestWeakLibReader coordinates to table axis ranges

### DIFF
--- a/cactus_interface/TestWeakLibReader/src/testweaklibreader_eos.cxx
+++ b/cactus_interface/TestWeakLibReader/src/testweaklibreader_eos.cxx
@@ -11,6 +11,13 @@
 
 namespace TestWeakLibReader {
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+double RescaleUnitCoordinateToAxis(double u, const WeakLibReader::Axis& axis) noexcept {
+  const double lower = axis.grid[0];
+  const double upper = axis.grid[axis.n - 1];
+  return lower + u * (upper - lower);
+}
+
 WeakLibReader::WeakLibEosTableDevice eos_table_device;
 WeakLibReader::EosInversionBounds eos_inversion_bounds;
 
@@ -68,8 +75,11 @@ extern "C" void TestWeakLibReader_Init(CCTK_ARGUMENTS) {
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      const double rho = RescaleUnitCoordinateToAxis(p.x, axes[0]);
+      const double T = RescaleUnitCoordinateToAxis(p.y, axes[1]);
+      const double Ye = RescaleUnitCoordinateToAxis(p.z, axes[2]);
       energy(p.I) = WeakLibReader::LogInterpolateSingleVariable3DCustomPoint(
-          p.x, p.y, p.z,
+          rho, T, Ye,
           axes,
           pressureData, pressureOffset);
       });
@@ -109,10 +119,9 @@ extern "C" void TestWeakLibReader_ComputeEosDerived(CCTK_ARGUMENTS) {
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-      // (p.x, p.y, p.z) = (rho, T, Ye) in raw units
-      const double rho = p.x;
-      const double T   = p.y;
-      const double Ye  = p.z;
+      const double rho = RescaleUnitCoordinateToAxis(p.x, axes[0]);
+      const double T = RescaleUnitCoordinateToAxis(p.y, axes[1]);
+      const double Ye = RescaleUnitCoordinateToAxis(p.z, axes[2]);
 
       // Interpolate mu_e from EOS
       const double muE = WeakLibReader::LogInterpolateSingleVariable3DCustomPoint(
@@ -158,9 +167,9 @@ extern "C" void TestWeakLibReader_InvertEos(CCTK_ARGUMENTS) {
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-      const double rho = p.x;
-      const double T   = p.y;  // known temperature
-      const double Ye  = p.z;
+      const double rho = RescaleUnitCoordinateToAxis(p.x, axes[0]);
+      const double T = RescaleUnitCoordinateToAxis(p.y, axes[1]);
+      const double Ye = RescaleUnitCoordinateToAxis(p.z, axes[2]);
 
       // Forward interpolate energy
       const double E = WeakLibReader::LogInterpolateSingleVariable3DCustomPoint(

--- a/cactus_interface/TestWeakLibReader/src/testweaklibreader_opacity.cxx
+++ b/cactus_interface/TestWeakLibReader/src/testweaklibreader_opacity.cxx
@@ -10,6 +10,13 @@
 
 namespace TestWeakLibReader {
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+double RescaleUnitCoordinateToAxis(double u, const WeakLibReader::Axis& axis) noexcept {
+  const double lower = axis.grid[0];
+  const double upper = axis.grid[axis.n - 1];
+  return lower + u * (upper - lower);
+}
+
 WeakLibReader::WeakLibOpacityTableDevice opacity_table_device;
 
 // Fixed energy value at midpoint of energy grid (set during load)
@@ -218,8 +225,11 @@ extern "C" void TestWeakLibReader_InitEmAb(CCTK_ARGUMENTS) {
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      const double rho = RescaleUnitCoordinateToAxis(p.x, axes[1]);
+      const double T = RescaleUnitCoordinateToAxis(p.y, axes[2]);
+      const double Ye = RescaleUnitCoordinateToAxis(p.z, axes[3]);
       opacity_emab(p.I) = WeakLibReader::LogInterpolateSingleVariable4DCustomPoint(
-          fixedE, p.x, p.y, p.z,
+          fixedE, rho, T, Ye,
           axes,
           opacityData, offset);
       });
@@ -253,8 +263,11 @@ extern "C" void TestWeakLibReader_InitIso(CCTK_ARGUMENTS) {
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+      const double rho = RescaleUnitCoordinateToAxis(p.x, axes[1]);
+      const double T = RescaleUnitCoordinateToAxis(p.y, axes[2]);
+      const double Ye = RescaleUnitCoordinateToAxis(p.z, axes[3]);
       opacity_iso(p.I) = WeakLibReader::LogInterpolateSingleVariable4DCustomPoint(
-          fixedE, p.x, p.y, p.z,
+          fixedE, rho, T, Ye,
           axes,
           sliceData, offset);
       });
@@ -287,7 +300,7 @@ extern "C" void TestWeakLibReader_InitNES(CCTK_ARGUMENTS) {
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-      const double T   = p.y;
+      const double T = RescaleUnitCoordinateToAxis(p.y, axes[0]);
       const double eta = eos_log_eta(p.I);
 
       int idxT = 0, idxEta = 0;
@@ -330,7 +343,7 @@ extern "C" void TestWeakLibReader_InitPair(CCTK_ARGUMENTS) {
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-      const double T   = p.y;
+      const double T = RescaleUnitCoordinateToAxis(p.y, axes[0]);
       const double eta = eos_log_eta(p.I);
 
       int idxT = 0, idxEta = 0;
@@ -376,7 +389,7 @@ extern "C" void TestWeakLibReader_InitBrem(CCTK_ARGUMENTS) {
   grid.loop_int_device<0, 0, 0>(
       grid.nghostzones,
       [=] CCTK_DEVICE(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-      const double T = p.y;
+      const double T = RescaleUnitCoordinateToAxis(p.y, axes[1]);
 
       // Density-weighted terms from EOS-derived GFs
       const double dxVals[3] = {


### PR DESCRIPTION
### Motivation
- Tests in `cactus_interface/TestWeakLibReader/src` use `p.x`, `p.y`, `p.z` from the parameter file which are provided in `[0,1)` and must be mapped to the actual table axis ranges before interpolation.
- Rescale unit-domain coordinates into each table `Axis` range so interpolation and inversion use table-domain values (preserving axis scales and boundary behavior).

### Description
- Added a GPU-safe helper `RescaleUnitCoordinateToAxis(u, axis)` (annotated with `AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE`) to both `testweaklibreader_eos.cxx` and `testweaklibreader_opacity.cxx` to map unit coordinates to axis endpoints using `axis.grid[0]` and `axis.grid[axis.n-1]`.
- Replaced direct uses of `p.x`, `p.y`, `p.z` in EOS test kernels (`TestWeakLibReader_Init`, `TestWeakLibReader_ComputeEosDerived`, `TestWeakLibReader_InvertEos`) with rescaled `(rho, T, Ye)` values before calling `LogInterpolate*` and inversion routines.
- Updated opacity test kernels so EmAb/Iso 4D interpolations use rescaled `rho, T, Ye`, and aligned-table paths (NES, Pair, Brem) rescale the temperature (`p.y`) into the corresponding table temperature axis prior to `IndexAndDelta` and aligned lookups.
- Changes are confined to test sources and are committed on the current branch.

### Testing
- Ran `scripts/check.sh` which immediately failed in this environment because `build/` did not exist; no full test run completed.
- Attempted configure with `cmake -S . -B build` which failed due to missing HDF5 development libraries in the environment, preventing compilation.
- Attempted `scripts/build.sh` (via `mkdir -p build && scripts/build.sh`) which could not complete because the CMake configure/cache step failed; therefore no automated tests were executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e1685d8ac8325a66b56dca54c878d)