### PR TITLE
hdf5: clean up loaders — eliminate temp tables, use shared helpers, strict errors

### DIFF
--- a/src/hdf5/WeakLibReader_Hdf5LoaderDetail.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5LoaderDetail.hpp
@@ -430,16 +430,9 @@ inline Hdf5LoadStatus LoadWeakLibOpacityGrid(hid_t file, const char* groupName,
     }
   }
 
-  // Validate monotonicity
-  for (int i = 1; i < grid.nPoints; ++i) {
-    if (grid.values[i] <= grid.values[i - 1]) {
-      return Hdf5LoadStatus::AxisNotMonotone;
-    }
-  }
-
-  // Validate Log10 positivity
-  if (grid.scale == AxisScale::Log10 && grid.values[0] <= 0.0) {
-    return Hdf5LoadStatus::AxisInvalidScale;
+  // Validate axis (monotonicity, min size, Log10 positivity)
+  if (!ValidateAxis(grid.values, grid.scale)) {
+    return Hdf5LoadStatus::AxisNotMonotone;
   }
 
   grid.minValue = grid.values[0];
@@ -547,8 +540,8 @@ inline Hdf5LoadStatus LoadWeakLibAxis(hid_t thermoGroup,
                                       const char* datasetName,
                                       int expectedExtent,
                                       AxisScale scale,
-                                      int axisIndex,
-                                      Hdf5Table& table)
+                                      amrex::Vector<double>& storage,
+                                      Axis& outAxis)
 {
   ScopedHandle dataset(H5Dopen(thermoGroup, datasetName, H5P_DEFAULT), H5Dclose);
   if (!dataset.Valid()) {
@@ -574,7 +567,6 @@ inline Hdf5LoadStatus LoadWeakLibAxis(hid_t thermoGroup,
     return Hdf5LoadStatus::AxisExtentMismatch;
   }
 
-  amrex::Vector<double>& storage = table.axisStorage[axisIndex];
   storage.resize(static_cast<std::size_t>(length));
   if (H5Dread(dataset.Get(), H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT,
               storage.data()) < 0) {
@@ -585,11 +577,9 @@ inline Hdf5LoadStatus LoadWeakLibAxis(hid_t thermoGroup,
     return Hdf5LoadStatus::AxisNotMonotone;
   }
 
-  Axis axis{};
-  axis.grid = storage.data();
-  axis.n = static_cast<int>(storage.size());
-  axis.scale = scale;
-  table.axes[axisIndex] = axis;
+  outAxis.grid = storage.data();
+  outAxis.n = static_cast<int>(storage.size());
+  outAxis.scale = scale;
 
   return Hdf5LoadStatus::Success;
 }

--- a/src/hdf5/WeakLibReader_Hdf5LoaderEos.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5LoaderEos.hpp
@@ -54,30 +54,22 @@ inline Hdf5LoadStatus LoadWeakLibEosTableFull(const std::string& filePath,
     result.axisUnits[i] = axisUnitsVec[i];
   }
 
-  // Load axes using existing helper
-  // Axis 0 = Density, Axis 1 = Temperature, Axis 2 = Electron Fraction
-  Hdf5Table tempTable;
-  tempTable.extents = {result.dimensions[0], result.dimensions[1], result.dimensions[2], 1, 1};
-
+  // Load axes directly into result storage
   Hdf5LoadStatus axisStatus;
   axisStatus = detail::LoadWeakLibAxis(thermoGroup.Get(), "Density",
-                                       result.dimensions[0], scales[0], 0, tempTable);
+                                       result.dimensions[0], scales[0],
+                                       result.axisStorage[0], result.axes[0]);
   if (axisStatus != Hdf5LoadStatus::Success) return axisStatus;
 
   axisStatus = detail::LoadWeakLibAxis(thermoGroup.Get(), "Temperature",
-                                       result.dimensions[1], scales[1], 1, tempTable);
+                                       result.dimensions[1], scales[1],
+                                       result.axisStorage[1], result.axes[1]);
   if (axisStatus != Hdf5LoadStatus::Success) return axisStatus;
 
   axisStatus = detail::LoadWeakLibAxis(thermoGroup.Get(), "Electron Fraction",
-                                       result.dimensions[2], scales[2], 2, tempTable);
+                                       result.dimensions[2], scales[2],
+                                       result.axisStorage[2], result.axes[2]);
   if (axisStatus != Hdf5LoadStatus::Success) return axisStatus;
-
-  // Transfer axis data from temp table
-  for (int i = 0; i < 3; ++i) {
-    result.axisStorage[i] = std::move(tempTable.axisStorage[i]);
-    result.axes[i] = tempTable.axes[i];
-    result.axes[i].grid = result.axisStorage[i].data();
-  }
 
   // ========== Read DependentVariables ==========
   detail::ScopedHandle dvGroup(H5Gopen(file.Get(), "DependentVariables", H5P_DEFAULT), H5Gclose);

--- a/src/hdf5/WeakLibReader_Hdf5LoaderOpacityEmAb.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5LoaderOpacityEmAb.hpp
@@ -170,15 +170,11 @@ inline Hdf5LoadStatus LoadWeakLibEmAbTable(hid_t file,
     emAb.units[i] = unitVec[i];
   }
 
-  // Read Offsets
+  // Read Offsets (1D: [nOpacities])
   {
-    detail::ScopedHandle ds(H5Dopen(group.Get(), "Offsets", H5P_DEFAULT), H5Dclose);
-    if (!ds.Valid()) {
-      return Hdf5LoadStatus::DatasetOpenFailed;
-    }
-    std::vector<double> offsetVec(emAb.nOpacities);
-    if (H5Dread(ds.Get(), H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT,
-                offsetVec.data()) < 0) {
+    amrex::Gpu::PinnedVector<double> offsetVec;
+    std::array<int, 1> offsetDims{{emAb.nOpacities}};
+    if (!detail::ReadWeakLibArrayNd<double, 1>(group.Get(), "Offsets", offsetVec, offsetDims)) {
       return Hdf5LoadStatus::DatasetReadFailed;
     }
     for (int i = 0; i < WeakLibEmAbTable::kNumSpecies && i < emAb.nOpacities; ++i) {

--- a/src/hdf5/WeakLibReader_Hdf5LoaderOpacityMain.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5LoaderOpacityMain.hpp
@@ -47,26 +47,22 @@ inline Hdf5LoadStatus LoadWeakLibOpacityThermoState(hid_t file,
     ts.units[i] = unitsVec[i];
   }
 
-  // Load axis data
-  Hdf5Table tempTable;
-  tempTable.extents = {ts.dimensions[0], ts.dimensions[1], ts.dimensions[2], 1, 1};
-
+  // Load axis data directly into thermoState storage
   Hdf5LoadStatus status;
-  status = LoadWeakLibAxis(group.Get(), "Density", ts.dimensions[0], ts.scales[0], 0, tempTable);
+  status = LoadWeakLibAxis(group.Get(), "Density",
+                           ts.dimensions[0], ts.scales[0],
+                           ts.axisStorage[0], ts.axes[0]);
   if (status != Hdf5LoadStatus::Success) return status;
 
-  status = LoadWeakLibAxis(group.Get(), "Temperature", ts.dimensions[1], ts.scales[1], 1, tempTable);
+  status = LoadWeakLibAxis(group.Get(), "Temperature",
+                           ts.dimensions[1], ts.scales[1],
+                           ts.axisStorage[1], ts.axes[1]);
   if (status != Hdf5LoadStatus::Success) return status;
 
-  status = LoadWeakLibAxis(group.Get(), "Electron Fraction", ts.dimensions[2], ts.scales[2], 2, tempTable);
+  status = LoadWeakLibAxis(group.Get(), "Electron Fraction",
+                           ts.dimensions[2], ts.scales[2],
+                           ts.axisStorage[2], ts.axes[2]);
   if (status != Hdf5LoadStatus::Success) return status;
-
-  // Transfer to thermoState
-  for (int i = 0; i < 3; ++i) {
-    ts.axisStorage[i] = std::move(tempTable.axisStorage[i]);
-    ts.axes[i] = tempTable.axes[i];
-    ts.axes[i].grid = ts.axisStorage[i].data();
-  }
 
   return Hdf5LoadStatus::Success;
 }

--- a/src/hdf5/WeakLibReader_Hdf5LoaderOpacityScat.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5LoaderOpacityScat.hpp
@@ -33,10 +33,12 @@ inline Hdf5LoadStatus LoadWeakLibScatIsoTable(hid_t file,
 
   // Read Units
   std::vector<std::string> unitVec;
-  if (detail::ReadStringArray(group.Get(), "Units", unitVec)) {
-    for (int i = 0; i < WeakLibScatIsoTable::kNumSpecies && i < static_cast<int>(unitVec.size()); ++i) {
-      scatIso.units[i] = unitVec[i];
-    }
+  if (!detail::ReadStringArray(group.Get(), "Units", unitVec) ||
+      unitVec.size() < static_cast<size_t>(scatIso.nOpacities)) {
+    return Hdf5LoadStatus::DatasetReadFailed;
+  }
+  for (int i = 0; i < WeakLibScatIsoTable::kNumSpecies && i < scatIso.nOpacities; ++i) {
+    scatIso.units[i] = unitVec[i];
   }
 
   // Read Offsets (2D: [nOpacities, nMoments])
@@ -151,9 +153,10 @@ inline Hdf5LoadStatus LoadScatKernelTable(
 
   // Read Units
   std::vector<std::string> unitVec;
-  if (ReadStringArray(group.Get(), "Units", unitVec) && !unitVec.empty()) {
-    table.unit = unitVec[0];
+  if (!ReadStringArray(group.Get(), "Units", unitVec) || unitVec.empty()) {
+    return Hdf5LoadStatus::DatasetReadFailed;
   }
+  table.unit = unitVec[0];
 
   // Read Offsets (2D: [nOpacities, nMoments] in C order)
   std::array<int, 2> offsetDims{{table.nOpacities, table.nMoments}};


### PR DESCRIPTION
## Summary
- Refactor `LoadWeakLibAxis` to write directly into caller-provided `storage` and `Axis` instead of routing through a temporary `Hdf5Table`, removing the post-load transfer loops in EOS and opacity loaders
- Replace inline monotonicity/positivity validation in `LoadWeakLibOpacityGrid` with the existing `ValidateAxis` helper
- Replace manual HDF5 read of EmAb Offsets with `ReadWeakLibArrayNd`
- Make Units read failures in ScatIso and ScatKernel loaders return errors instead of silently continuing

## Test plan
- [ ] `scripts/check.sh` passes (build + all Catch2 tests)
- [ ] Verify no regressions in EOS, EmAb, ScatIso, and ScatKernel HDF5 loading