### PR TITLE
refactor: unify test infrastructure, constant naming, and GPU annotations

### DIFF
--- a/src/hdf5/WeakLibReader_Hdf5LoaderOpacityDevice.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5LoaderOpacityDevice.hpp
@@ -80,7 +80,7 @@ inline WeakLibOpacityTableDevice MakeDeviceCopy(const WeakLibOpacityTable& host)
     device.emAb.parameters = host.emAb.parameters;
     device.emAb.layout = host.emAb.layout;
 
-    for (int i = 0; i < WeakLibEmAbTable::kNumSpecies; ++i) {
+    for (int i = 0; i < WeakLibEmAbTable::NumSpecies; ++i) {
       if (host.emAb.opacities[i].size() > 0) {
         device.emAb.opacities[i].resize(host.emAb.opacities[i].size());
         amrex::Gpu::copy(amrex::Gpu::hostToDevice,
@@ -148,7 +148,7 @@ inline WeakLibOpacityTableDevice MakeDeviceCopy(const WeakLibOpacityTable& host)
                      device.scatIso.offsets.begin());
 
     // Kernels are stored as flat vectors
-    for (int i = 0; i < WeakLibScatIsoTable::kNumSpecies; ++i) {
+    for (int i = 0; i < WeakLibScatIsoTable::NumSpecies; ++i) {
       if (!host.scatIso.kernels[i].empty()) {
         device.scatIso.kernels[i].resize(host.scatIso.kernels[i].size());
         amrex::Gpu::copy(amrex::Gpu::hostToDevice,

--- a/src/hdf5/WeakLibReader_Hdf5LoaderOpacityEmAb.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5LoaderOpacityEmAb.hpp
@@ -166,7 +166,7 @@ inline Hdf5LoadStatus LoadWeakLibEmAbTable(hid_t file,
       unitVec.size() < static_cast<size_t>(emAb.nOpacities)) {
     return Hdf5LoadStatus::DatasetReadFailed;
   }
-  for (int i = 0; i < WeakLibEmAbTable::kNumSpecies && i < emAb.nOpacities; ++i) {
+  for (int i = 0; i < WeakLibEmAbTable::NumSpecies && i < emAb.nOpacities; ++i) {
     emAb.units[i] = unitVec[i];
   }
 
@@ -177,7 +177,7 @@ inline Hdf5LoadStatus LoadWeakLibEmAbTable(hid_t file,
     if (!detail::ReadWeakLibArrayNd<double, 1>(group.Get(), "Offsets", offsetVec, offsetDims)) {
       return Hdf5LoadStatus::DatasetReadFailed;
     }
-    for (int i = 0; i < WeakLibEmAbTable::kNumSpecies && i < emAb.nOpacities; ++i) {
+    for (int i = 0; i < WeakLibEmAbTable::NumSpecies && i < emAb.nOpacities; ++i) {
       emAb.offsets[i] = offsetVec[i];
     }
   }
@@ -187,7 +187,7 @@ inline Hdf5LoadStatus LoadWeakLibEmAbTable(hid_t file,
   emAb.names[1] = "Electron Antineutrino";
 
   // Read opacity data for each species
-  for (int iSpecies = 0; iSpecies < WeakLibEmAbTable::kNumSpecies && iSpecies < emAb.nOpacities; ++iSpecies) {
+  for (int iSpecies = 0; iSpecies < WeakLibEmAbTable::NumSpecies && iSpecies < emAb.nOpacities; ++iSpecies) {
     if (!detail::ReadWeakLibArrayNd<double, 4>(group.Get(), emAb.names[iSpecies].c_str(),
                                    emAb.opacities[iSpecies], emAb.dimensions)) {
       return Hdf5LoadStatus::DatasetReadFailed;

--- a/src/hdf5/WeakLibReader_Hdf5LoaderOpacityScat.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5LoaderOpacityScat.hpp
@@ -37,7 +37,7 @@ inline Hdf5LoadStatus LoadWeakLibScatIsoTable(hid_t file,
       unitVec.size() < static_cast<size_t>(scatIso.nOpacities)) {
     return Hdf5LoadStatus::DatasetReadFailed;
   }
-  for (int i = 0; i < WeakLibScatIsoTable::kNumSpecies && i < scatIso.nOpacities; ++i) {
+  for (int i = 0; i < WeakLibScatIsoTable::NumSpecies && i < scatIso.nOpacities; ++i) {
     scatIso.units[i] = unitVec[i];
   }
 
@@ -66,7 +66,7 @@ inline Hdf5LoadStatus LoadWeakLibScatIsoTable(hid_t file,
   scatIso.names[1] = "Electron Antineutrino";
 
   // Read kernel data for each species
-  for (int iSpecies = 0; iSpecies < WeakLibScatIsoTable::kNumSpecies && iSpecies < scatIso.nOpacities; ++iSpecies) {
+  for (int iSpecies = 0; iSpecies < WeakLibScatIsoTable::NumSpecies && iSpecies < scatIso.nOpacities; ++iSpecies) {
     if (!detail::ReadWeakLibArrayNd<double, 5>(group.Get(), scatIso.names[iSpecies].c_str(),
                                                scatIso.kernels[iSpecies], scatIso.dimensions)) {
       return Hdf5LoadStatus::DatasetReadFailed;

--- a/src/hdf5/WeakLibReader_Hdf5Types.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5Types.hpp
@@ -263,17 +263,17 @@ struct WeakLibEmAbParameters {
 
 // EmAb opacity table (4D: nE x nRho x nT x nYe)
 struct WeakLibEmAbTable {
-  static constexpr int kNumSpecies = 2;  // nu_e, nu_e_bar
+  static constexpr int NumSpecies = 2;  // nu_e, nu_e_bar
 
   int nOpacities = 0;
   std::array<int, 4> dimensions{{0, 0, 0, 0}};  // [nE, nRho, nT, nYe]
 
-  std::array<std::string, kNumSpecies> names;
-  std::array<std::string, kNumSpecies> units;
-  std::array<double, kNumSpecies> offsets{{0.0, 0.0}};
+  std::array<std::string, NumSpecies> names;
+  std::array<std::string, NumSpecies> units;
+  std::array<double, NumSpecies> offsets{{0.0, 0.0}};
 
   // Opacity data: 4D [nE, nRho, nT, nYe] per species
-  std::array<amrex::Gpu::PinnedVector<double>, kNumSpecies> opacities;
+  std::array<amrex::Gpu::PinnedVector<double>, NumSpecies> opacities;
 
   WeakLibEmAbParameters parameters;
   WeakLibECTable ecTable;
@@ -293,12 +293,12 @@ struct WeakLibEmAbTable {
 };
 
 struct WeakLibEmAbTableDevice {
-  static constexpr int kNumSpecies = 2;
+  static constexpr int NumSpecies = 2;
 
   int nOpacities = 0;
   std::array<int, 4> dimensions{{0, 0, 0, 0}};
-  std::array<double, kNumSpecies> offsets{{0.0, 0.0}};
-  std::array<amrex::Gpu::DeviceVector<double>, kNumSpecies> opacities;
+  std::array<double, NumSpecies> offsets{{0.0, 0.0}};
+  std::array<amrex::Gpu::DeviceVector<double>, NumSpecies> opacities;
   WeakLibEmAbParameters parameters;
   WeakLibECTableDevice ecTable;
   Layout layout{};
@@ -311,19 +311,19 @@ struct WeakLibEmAbTableDevice {
 
 // Iso scattering table (5D: nE x nMom x nRho x nT x nYe)
 struct WeakLibScatIsoTable {
-  static constexpr int kNumSpecies = 2;
+  static constexpr int NumSpecies = 2;
 
   int nOpacities = 0;
   int nMoments = 0;
   std::array<int, 5> dimensions{{0, 0, 0, 0, 0}};  // [nE, nMom, nRho, nT, nYe]
 
-  std::array<std::string, kNumSpecies> names;
-  std::array<std::string, kNumSpecies> units;
+  std::array<std::string, NumSpecies> names;
+  std::array<std::string, NumSpecies> units;
   // Offsets: 2D [nOpacities, nMoments] — column-major (species stride=1)
   amrex::Gpu::PinnedVector<double> offsets;
 
   // Kernel data: 5D per species (stored as flat arrays)
-  std::array<amrex::Gpu::PinnedVector<double>, kNumSpecies> kernels;
+  std::array<amrex::Gpu::PinnedVector<double>, NumSpecies> kernels;
 
   // Correction flags
   int weak_magnetism_corrections = -1;
@@ -350,13 +350,13 @@ struct WeakLibScatIsoTable {
 };
 
 struct WeakLibScatIsoTableDevice {
-  static constexpr int kNumSpecies = 2;
+  static constexpr int NumSpecies = 2;
 
   int nOpacities = 0;
   int nMoments = 0;
   std::array<int, 5> dimensions{{0, 0, 0, 0, 0}};
   amrex::Gpu::DeviceVector<double> offsets;
-  std::array<amrex::Gpu::DeviceVector<double>, kNumSpecies> kernels;
+  std::array<amrex::Gpu::DeviceVector<double>, NumSpecies> kernels;
 
   int weak_magnetism_corrections = -1;
   int ion_ion_corrections = -1;

--- a/src/interp/WeakLibReader_LogInterpolateCore.hpp
+++ b/src/interp/WeakLibReader_LogInterpolateCore.hpp
@@ -37,9 +37,10 @@ double LogInterpolatedValueDirect(const double* data,
   return LinearInterpPointDirect<ND>(indices, fractions, offset, data, layout);
 }
 
-inline void StoreSymmetric(double* plane, std::size_t size,
-                           std::size_t i, std::size_t j,
-                           double value) noexcept
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void StoreSymmetric(double* plane, std::size_t size,
+                    std::size_t i, std::size_t j,
+                    double value) noexcept
 {
   const std::size_t idxLower = j * size + i;
   plane[idxLower] = value;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 # All test files compiled into a single executable
 set(TEST_SOURCES
+  test_main.cpp
   test_log_interpolate_2d.cpp
   test_log_interpolate_3d.cpp
   test_log_interpolate_4d5d.cpp

--- a/test/include/test_amrex_guard.hpp
+++ b/test/include/test_amrex_guard.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <AMReX.H>
+
+namespace test_detail {
+
+/// Global AMReX guard that initializes once and finalizes at program exit.
+/// This avoids the MPI re-initialization error that occurs when each test
+/// creates its own AmrexGuard (MPI cannot be re-initialized after finalization).
+struct GlobalAmrexGuard {
+  GlobalAmrexGuard()
+  {
+    int argc = 0;
+    char** argv = nullptr;
+    amrex::Initialize(argc, argv);
+  }
+  ~GlobalAmrexGuard() { amrex::Finalize(); }
+};
+
+inline GlobalAmrexGuard& GetGlobalAmrexGuard()
+{
+  static GlobalAmrexGuard guard;
+  return guard;
+}
+
+/// Per-test helper that ensures AMReX is initialized (via the global guard)
+struct AmrexGuard {
+  AmrexGuard() { (void)GetGlobalAmrexGuard(); }
+};
+
+} // namespace test_detail
+
+using test_detail::AmrexGuard;

--- a/test/test_eos_inversion.cpp
+++ b/test/test_eos_inversion.cpp
@@ -31,7 +31,7 @@ const double gridD[nD] = {1e6, 1e7, 1e8, 1e9, 1e10};
 const double gridT[nT] = {1e9, 3e9, 1e10, 3e10, 1e11};
 const double gridY[nY] = {0.1, 0.2, 0.3, 0.4, 0.5};
 
-constexpr double kOffset = 1.0;
+constexpr double Offset = 1.0;
 
 // Build the synthetic table and axes. Returns the data vector and populates
 // axes and layout.
@@ -54,14 +54,14 @@ std::vector<double> BuildSyntheticTable(
       for (int iYe = 0; iYe < nY; ++iYe) {
         const double E = EnergyFunc(gridD[iRho], gridT[iTemp], gridY[iYe]);
         data[layout.Offset(iRho, iTemp, iYe)] =
-            std::log10(E + kOffset);
+            std::log10(E + Offset);
       }
     }
   }
   return data;
 }
 
-constexpr double kTol = 1.0e-10;
+constexpr double Tol = 1.0e-10;
 
 } // namespace
 
@@ -182,11 +182,11 @@ TEST_CASE("EvalAtFixedTIndex matches full 3D interp at grid T", "[eosinversion]"
 
         // EvalAtFixedTIndex
         const double valFixed = detail::EvalAtFixedTIndex(
-            iD, iY, dD, dY, iTemp, kOffset, data.data(), layout);
+            iD, iY, dD, dY, iTemp, Offset, data.data(), layout);
 
         // Full 3D interpolation at the same point
         const double valFull = LogInterpolateSingleVariable3DCustomPoint(
-            D, T, Y, axes, data.data(), kOffset);
+            D, T, Y, axes, data.data(), Offset);
 
         CHECK(std::abs(valFixed - valFull)
               / (std::abs(valFull) + 1e-30) < 1e-12);
@@ -205,7 +205,7 @@ TEST_CASE("Round-trip inversion recovers T without guess", "[eosinversion]")
 
   const auto bounds = InitializeEosInversionBounds(
       axes, totalSize,
-      data.data(), kOffset,
+      data.data(), Offset,
       nullptr, 0.0,
       nullptr, 0.0);
 
@@ -219,17 +219,17 @@ TEST_CASE("Round-trip inversion recovers T without guess", "[eosinversion]")
       for (double Y : testY) {
         // Forward interpolate
         const double E = LogInterpolateSingleVariable3DCustomPoint(
-            D, T_known, Y, axes, data.data(), kOffset);
+            D, T_known, Y, axes, data.data(), Offset);
 
         // Invert
         double T_recovered = 0.0;
         const int error = ComputeTemperatureFromEnergy(
-            D, E, Y, axes, data.data(), layout, kOffset, bounds,
+            D, E, Y, axes, data.data(), layout, Offset, bounds,
             T_recovered);
 
         CHECK(error == 0);
         const double relErr = std::abs(T_recovered - T_known) / T_known;
-        CHECK(relErr < kTol);
+        CHECK(relErr < Tol);
       }
     }
   }
@@ -245,7 +245,7 @@ TEST_CASE("Round-trip inversion recovers T with good guess", "[eosinversion]")
 
   const auto bounds = InitializeEosInversionBounds(
       axes, totalSize,
-      data.data(), kOffset,
+      data.data(), Offset,
       nullptr, 0.0,
       nullptr, 0.0);
 
@@ -254,17 +254,17 @@ TEST_CASE("Round-trip inversion recovers T with good guess", "[eosinversion]")
   const double Y = 0.3;
 
   const double E = LogInterpolateSingleVariable3DCustomPoint(
-      D, T_known, Y, axes, data.data(), kOffset);
+      D, T_known, Y, axes, data.data(), Offset);
 
   const double tGuess = 1.2e10; // close to T_known
   double T_recovered = 0.0;
   const int error = ComputeTemperatureFromEnergy(
-      D, E, Y, axes, data.data(), layout, kOffset, bounds,
+      D, E, Y, axes, data.data(), layout, Offset, bounds,
       tGuess, T_recovered);
 
   CHECK(error == 0);
   const double relErr = std::abs(T_recovered - T_known) / T_known;
-  CHECK(relErr < kTol);
+  CHECK(relErr < Tol);
 }
 
 TEST_CASE("Round-trip inversion recovers T with bad guess", "[eosinversion]")
@@ -277,7 +277,7 @@ TEST_CASE("Round-trip inversion recovers T with bad guess", "[eosinversion]")
 
   const auto bounds = InitializeEosInversionBounds(
       axes, totalSize,
-      data.data(), kOffset,
+      data.data(), Offset,
       nullptr, 0.0,
       nullptr, 0.0);
 
@@ -286,17 +286,17 @@ TEST_CASE("Round-trip inversion recovers T with bad guess", "[eosinversion]")
   const double Y = 0.3;
 
   const double E = LogInterpolateSingleVariable3DCustomPoint(
-      D, T_known, Y, axes, data.data(), kOffset);
+      D, T_known, Y, axes, data.data(), Offset);
 
   const double tGuess = 1e9; // far from T_known=1.5e10
   double T_recovered = 0.0;
   const int error = ComputeTemperatureFromEnergy(
-      D, E, Y, axes, data.data(), layout, kOffset, bounds,
+      D, E, Y, axes, data.data(), layout, Offset, bounds,
       tGuess, T_recovered);
 
   CHECK(error == 0);
   const double relErr = std::abs(T_recovered - T_known) / T_known;
-  CHECK(relErr < kTol);
+  CHECK(relErr < Tol);
 }
 
 TEST_CASE("Round-trip inversion recovers T with upper boundary guess", "[eosinversion]")
@@ -309,7 +309,7 @@ TEST_CASE("Round-trip inversion recovers T with upper boundary guess", "[eosinve
 
   const auto bounds = InitializeEosInversionBounds(
       axes, totalSize,
-      data.data(), kOffset,
+      data.data(), Offset,
       nullptr, 0.0,
       nullptr, 0.0);
 
@@ -318,17 +318,17 @@ TEST_CASE("Round-trip inversion recovers T with upper boundary guess", "[eosinve
   const double Y = 0.3;
 
   const double E = LogInterpolateSingleVariable3DCustomPoint(
-      D, T_known, Y, axes, data.data(), kOffset);
+      D, T_known, Y, axes, data.data(), Offset);
 
   const double tGuess = 9e10; // near upper T boundary
   double T_recovered = 0.0;
   const int error = ComputeTemperatureFromEnergy(
-      D, E, Y, axes, data.data(), layout, kOffset, bounds,
+      D, E, Y, axes, data.data(), layout, Offset, bounds,
       tGuess, T_recovered);
 
   CHECK(error == 0);
   const double relErr = std::abs(T_recovered - T_known) / T_known;
-  CHECK(relErr < kTol);
+  CHECK(relErr < Tol);
 }
 
 TEST_CASE("Inversion at grid boundary points", "[eosinversion]")
@@ -341,7 +341,7 @@ TEST_CASE("Inversion at grid boundary points", "[eosinversion]")
 
   const auto bounds = InitializeEosInversionBounds(
       axes, totalSize,
-      data.data(), kOffset,
+      data.data(), Offset,
       nullptr, 0.0,
       nullptr, 0.0);
 
@@ -365,17 +365,17 @@ TEST_CASE("Inversion at grid boundary points", "[eosinversion]")
   for (const auto& pt : points) {
     // Forward interpolate
     const double E = LogInterpolateSingleVariable3DCustomPoint(
-        pt.D, pt.T, pt.Y, axes, data.data(), kOffset);
+        pt.D, pt.T, pt.Y, axes, data.data(), Offset);
 
     // Invert (no guess)
     double T_recovered = 0.0;
     const int error = ComputeTemperatureFromEnergy(
-        pt.D, E, pt.Y, axes, data.data(), layout, kOffset, bounds,
+        pt.D, E, pt.Y, axes, data.data(), layout, Offset, bounds,
         T_recovered);
 
     CHECK(error == 0);
     const double relErr = std::abs(T_recovered - pt.T) / pt.T;
-    CHECK(relErr < kTol);
+    CHECK(relErr < Tol);
   }
 }
 
@@ -389,7 +389,7 @@ TEST_CASE("InitializeEosInversionBounds computes correct bounds", "[eosinversion
 
   const auto bounds = InitializeEosInversionBounds(
       axes, totalSize,
-      data.data(), kOffset,
+      data.data(), Offset,
       nullptr, 0.0,
       nullptr, 0.0);
 

--- a/test/test_hdf5_loader.cpp
+++ b/test/test_hdf5_loader.cpp
@@ -2,8 +2,8 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "hdf5/WeakLibReader_Hdf5Loader.hpp"
+#include "test_amrex_guard.hpp"
 
-#include <AMReX.H>
 #include <AMReX_GpuContainers.H>
 #include <AMReX_GpuDevice.H>
 
@@ -16,49 +16,7 @@
 
 namespace {
 
-constexpr double kTol = 1.0e-12;
-
-/// Global AMReX guard that initializes once and finalizes at program exit.
-/// This avoids the MPI re-initialization error that occurs when each test
-/// creates its own AmrexGuard (MPI cannot be re-initialized after finalization).
-struct GlobalAmrexGuard {
-  GlobalAmrexGuard()
-  {
-    int argc = 0;
-    char** argv = nullptr;
-    amrex::Initialize(argc, argv);
-  }
-  ~GlobalAmrexGuard() { amrex::Finalize(); }
-
-  static GlobalAmrexGuard& Instance()
-  {
-    static GlobalAmrexGuard guard;
-    return guard;
-  }
-};
-
-/// Per-test helper that ensures AMReX is initialized (via the global guard)
-struct AmrexGuard {
-  AmrexGuard() { (void)GlobalAmrexGuard::Instance(); }
-};
-
-/// RAII helper that temporarily silences HDF5 automatic error printing.
-/// Used in tests that intentionally trigger HDF5 errors.
-struct ScopedHdf5ErrorSilencer {
-  H5E_auto2_t oldFunc = nullptr;
-  void* oldClientData = nullptr;
-
-  ScopedHdf5ErrorSilencer()
-  {
-    H5Eget_auto2(H5E_DEFAULT, &oldFunc, &oldClientData);
-    H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
-  }
-
-  ~ScopedHdf5ErrorSilencer()
-  {
-    H5Eset_auto2(H5E_DEFAULT, oldFunc, oldClientData);
-  }
-};
+constexpr double Tol = 1.0e-12;
 
 void WriteStringAttribute(hid_t parent, const std::string& name, const char* value)
 {
@@ -93,6 +51,7 @@ void CreateAxisDataset(hid_t file,
 
 TEST_CASE("HDF5 loader reads table and axes", "[hdf5][loader]")
 {
+  using namespace WeakLibReader;
   AmrexGuard amrex{};
 
   const std::filesystem::path filePath =
@@ -128,17 +87,17 @@ TEST_CASE("HDF5 loader reads table and axes", "[hdf5][loader]")
 
   H5Fclose(file);
 
-  WeakLibReader::Hdf5Table table;
-  const auto status = WeakLibReader::LoadHdf5Table(filePath.string(), table);
+  Hdf5Table table;
+  const auto status = LoadHdf5Table(filePath.string(), table);
 
-  REQUIRE(status == WeakLibReader::Hdf5LoadStatus::Success);
+  REQUIRE(status == Hdf5LoadStatus::Success);
   REQUIRE(table.nd == 3);
 
   CHECK(table.extents[0] == 2);
   CHECK(table.extents[1] == 3);
   CHECK(table.extents[2] == 4);
 
-  const WeakLibReader::Layout& layout = table.layout;
+  const Layout& layout = table.layout;
   CHECK(layout.nd == 3);
   CHECK(layout.n[0] == 2);
   CHECK(layout.n[1] == 3);
@@ -152,16 +111,16 @@ TEST_CASE("HDF5 loader reads table and axes", "[hdf5][loader]")
   CHECK(data[idx] == Catch::Approx(100.0 * 3.0 + 10.0 * 2.0 + 1.0));
 
   const auto& axis0 = table.axes[0];
-  CHECK(axis0.scale == WeakLibReader::AxisScale::Linear);
+  CHECK(axis0.scale == AxisScale::Linear);
   CHECK(axis0.n == 2);
   CHECK(axis0.grid[1] == Catch::Approx(1.0));
 
   const auto& axis2 = table.axes[2];
-  CHECK(axis2.scale == WeakLibReader::AxisScale::Log10);
+  CHECK(axis2.scale == AxisScale::Log10);
   CHECK(axis2.n == 4);
   CHECK(axis2.grid[3] == Catch::Approx(4.0));
 
-  const auto deviceTable = WeakLibReader::MakeDeviceCopy(table);
+  const auto deviceTable = MakeDeviceCopy(table);
 
   amrex::Gpu::PinnedVector<double> roundtrip(deviceTable.values.size());
   amrex::Gpu::copy(amrex::Gpu::deviceToHost,
@@ -175,7 +134,7 @@ TEST_CASE("HDF5 loader reads table and axes", "[hdf5][loader]")
     total *= static_cast<std::size_t>(table.extents[dim]);
   }
   for (std::size_t i = 0; i < total; ++i) {
-    CHECK(roundtripPtr[i] == Catch::Approx(originalPtr[i]).margin(kTol));
+    CHECK(roundtripPtr[i] == Catch::Approx(originalPtr[i]).margin(Tol));
   }
 
   for (int dim = 0; dim < table.nd; ++dim) {
@@ -186,25 +145,26 @@ TEST_CASE("HDF5 loader reads table and axes", "[hdf5][loader]")
                      hostAxis.begin());
     REQUIRE(hostAxis.size() == table.axisStorage[dim].size());
     for (std::size_t i = 0; i < hostAxis.size(); ++i) {
-      CHECK(hostAxis[i] == Catch::Approx(table.axisStorage[dim][i]).margin(kTol));
+      CHECK(hostAxis[i] == Catch::Approx(table.axisStorage[dim][i]).margin(Tol));
     }
   }
 
-  WeakLibReader::Hdf5Table parallelTable;
+  Hdf5Table parallelTable;
   const auto parallelStatus =
-      WeakLibReader::LoadHdf5TableParallel(filePath.string(), parallelTable);
-  REQUIRE(parallelStatus == WeakLibReader::Hdf5LoadStatus::Success);
+      LoadHdf5TableParallel(filePath.string(), parallelTable);
+  REQUIRE(parallelStatus == Hdf5LoadStatus::Success);
   CHECK(parallelTable.nd == table.nd);
   CHECK(parallelTable.layout.n[0] == table.layout.n[0]);
   CHECK(parallelTable.axes[2].scale == table.axes[2].scale);
   const double* parallelData = parallelTable.DataPtr();
-  CHECK(parallelData[idx] == Catch::Approx(data[idx]).margin(kTol));
+  CHECK(parallelData[idx] == Catch::Approx(data[idx]).margin(Tol));
 
   std::filesystem::remove(filePath);
 }
 
 TEST_CASE("HDF5 loader rejects single-point axes", "[hdf5][loader][validation]")
 {
+  using namespace WeakLibReader;
   AmrexGuard amrex{};
 
   const std::filesystem::path filePath =
@@ -228,29 +188,31 @@ TEST_CASE("HDF5 loader rejects single-point axes", "[hdf5][loader][validation]")
 
   H5Fclose(file);
 
-  WeakLibReader::Hdf5Table table;
-  const auto status = WeakLibReader::LoadHdf5Table(filePath.string(), table);
+  Hdf5Table table;
+  const auto status = LoadHdf5Table(filePath.string(), table);
 
-  CHECK(status == WeakLibReader::Hdf5LoadStatus::AxisNotMonotone);
+  CHECK(status == Hdf5LoadStatus::AxisNotMonotone);
 
   std::filesystem::remove(filePath);
 }
 
 TEST_CASE("HDF5 loader returns FileOpenFailed for non-existent file", "[hdf5][loader][error]")
 {
+  using namespace WeakLibReader;
   AmrexGuard amrex{};
-  ScopedHdf5ErrorSilencer silencer{};
+  detail::ScopedH5ErrorSuppressor silencer{};
 
-  WeakLibReader::Hdf5Table table;
-  const auto status = WeakLibReader::LoadHdf5Table("/nonexistent/path/to/file.h5", table);
+  Hdf5Table table;
+  const auto status = LoadHdf5Table("/nonexistent/path/to/file.h5", table);
 
-  CHECK(status == WeakLibReader::Hdf5LoadStatus::FileOpenFailed);
+  CHECK(status == Hdf5LoadStatus::FileOpenFailed);
 }
 
 TEST_CASE("HDF5 loader returns DatasetOpenFailed for missing values dataset", "[hdf5][loader][error]")
 {
+  using namespace WeakLibReader;
   AmrexGuard amrex{};
-  ScopedHdf5ErrorSilencer silencer{};
+  detail::ScopedH5ErrorSuppressor silencer{};
 
   const std::filesystem::path filePath =
       std::filesystem::temp_directory_path() / "weaklibreader_hdf5_no_values.h5";
@@ -264,18 +226,19 @@ TEST_CASE("HDF5 loader returns DatasetOpenFailed for missing values dataset", "[
 
   H5Fclose(file);
 
-  WeakLibReader::Hdf5Table table;
-  const auto status = WeakLibReader::LoadHdf5Table(filePath.string(), table);
+  Hdf5Table table;
+  const auto status = LoadHdf5Table(filePath.string(), table);
 
-  CHECK(status == WeakLibReader::Hdf5LoadStatus::DatasetOpenFailed);
+  CHECK(status == Hdf5LoadStatus::DatasetOpenFailed);
 
   std::filesystem::remove(filePath);
 }
 
 TEST_CASE("HDF5 loader returns AxisDatasetOpenFailed for missing axis", "[hdf5][loader][error]")
 {
+  using namespace WeakLibReader;
   AmrexGuard amrex{};
-  ScopedHdf5ErrorSilencer silencer{};
+  detail::ScopedH5ErrorSuppressor silencer{};
 
   const std::filesystem::path filePath =
       std::filesystem::temp_directory_path() / "weaklibreader_hdf5_missing_axis.h5";
@@ -299,18 +262,19 @@ TEST_CASE("HDF5 loader returns AxisDatasetOpenFailed for missing axis", "[hdf5][
 
   H5Fclose(file);
 
-  WeakLibReader::Hdf5Table table;
-  const auto status = WeakLibReader::LoadHdf5Table(filePath.string(), table);
+  Hdf5Table table;
+  const auto status = LoadHdf5Table(filePath.string(), table);
 
-  CHECK(status == WeakLibReader::Hdf5LoadStatus::AxisDatasetOpenFailed);
+  CHECK(status == Hdf5LoadStatus::AxisDatasetOpenFailed);
 
   std::filesystem::remove(filePath);
 }
 
 TEST_CASE("HDF5 loader returns AxisExtentMismatch when axis size differs from values", "[hdf5][loader][error]")
 {
+  using namespace WeakLibReader;
   AmrexGuard amrex{};
-  ScopedHdf5ErrorSilencer silencer{};
+  detail::ScopedH5ErrorSuppressor silencer{};
 
   const std::filesystem::path filePath =
       std::filesystem::temp_directory_path() / "weaklibreader_hdf5_extent_mismatch.h5";
@@ -334,18 +298,19 @@ TEST_CASE("HDF5 loader returns AxisExtentMismatch when axis size differs from va
 
   H5Fclose(file);
 
-  WeakLibReader::Hdf5Table table;
-  const auto status = WeakLibReader::LoadHdf5Table(filePath.string(), table);
+  Hdf5Table table;
+  const auto status = LoadHdf5Table(filePath.string(), table);
 
-  CHECK(status == WeakLibReader::Hdf5LoadStatus::AxisExtentMismatch);
+  CHECK(status == Hdf5LoadStatus::AxisExtentMismatch);
 
   std::filesystem::remove(filePath);
 }
 
 TEST_CASE("HDF5 loader returns AxisInvalidScale for unknown scale attribute", "[hdf5][loader][error]")
 {
+  using namespace WeakLibReader;
   AmrexGuard amrex{};
-  ScopedHdf5ErrorSilencer silencer{};
+  detail::ScopedH5ErrorSuppressor silencer{};
 
   const std::filesystem::path filePath =
       std::filesystem::temp_directory_path() / "weaklibreader_hdf5_invalid_scale.h5";
@@ -368,18 +333,19 @@ TEST_CASE("HDF5 loader returns AxisInvalidScale for unknown scale attribute", "[
 
   H5Fclose(file);
 
-  WeakLibReader::Hdf5Table table;
-  const auto status = WeakLibReader::LoadHdf5Table(filePath.string(), table);
+  Hdf5Table table;
+  const auto status = LoadHdf5Table(filePath.string(), table);
 
-  CHECK(status == WeakLibReader::Hdf5LoadStatus::AxisInvalidScale);
+  CHECK(status == Hdf5LoadStatus::AxisInvalidScale);
 
   std::filesystem::remove(filePath);
 }
 
 TEST_CASE("HDF5 loader returns AxisNotMonotone for non-monotonic axis", "[hdf5][loader][error]")
 {
+  using namespace WeakLibReader;
   AmrexGuard amrex{};
-  ScopedHdf5ErrorSilencer silencer{};
+  detail::ScopedH5ErrorSuppressor silencer{};
 
   const std::filesystem::path filePath =
       std::filesystem::temp_directory_path() / "weaklibreader_hdf5_nonmonotonic.h5";
@@ -402,18 +368,19 @@ TEST_CASE("HDF5 loader returns AxisNotMonotone for non-monotonic axis", "[hdf5][
 
   H5Fclose(file);
 
-  WeakLibReader::Hdf5Table table;
-  const auto status = WeakLibReader::LoadHdf5Table(filePath.string(), table);
+  Hdf5Table table;
+  const auto status = LoadHdf5Table(filePath.string(), table);
 
-  CHECK(status == WeakLibReader::Hdf5LoadStatus::AxisNotMonotone);
+  CHECK(status == Hdf5LoadStatus::AxisNotMonotone);
 
   std::filesystem::remove(filePath);
 }
 
 TEST_CASE("HDF5 loader returns AxisNotMonotone for descending axis", "[hdf5][loader][error]")
 {
+  using namespace WeakLibReader;
   AmrexGuard amrex{};
-  ScopedHdf5ErrorSilencer silencer{};
+  detail::ScopedH5ErrorSuppressor silencer{};
 
   const std::filesystem::path filePath =
       std::filesystem::temp_directory_path() / "weaklibreader_hdf5_descending.h5";
@@ -436,18 +403,19 @@ TEST_CASE("HDF5 loader returns AxisNotMonotone for descending axis", "[hdf5][loa
 
   H5Fclose(file);
 
-  WeakLibReader::Hdf5Table table;
-  const auto status = WeakLibReader::LoadHdf5Table(filePath.string(), table);
+  Hdf5Table table;
+  const auto status = LoadHdf5Table(filePath.string(), table);
 
-  CHECK(status == WeakLibReader::Hdf5LoadStatus::AxisNotMonotone);
+  CHECK(status == Hdf5LoadStatus::AxisNotMonotone);
 
   std::filesystem::remove(filePath);
 }
 
 TEST_CASE("HDF5 loader returns AxisNotMonotone for Log10 axis with non-positive values", "[hdf5][loader][error]")
 {
+  using namespace WeakLibReader;
   AmrexGuard amrex{};
-  ScopedHdf5ErrorSilencer silencer{};
+  detail::ScopedH5ErrorSuppressor silencer{};
 
   const std::filesystem::path filePath =
       std::filesystem::temp_directory_path() / "weaklibreader_hdf5_log_nonpositive.h5";
@@ -470,18 +438,19 @@ TEST_CASE("HDF5 loader returns AxisNotMonotone for Log10 axis with non-positive 
 
   H5Fclose(file);
 
-  WeakLibReader::Hdf5Table table;
-  const auto status = WeakLibReader::LoadHdf5Table(filePath.string(), table);
+  Hdf5Table table;
+  const auto status = LoadHdf5Table(filePath.string(), table);
 
-  CHECK(status == WeakLibReader::Hdf5LoadStatus::AxisNotMonotone);
+  CHECK(status == Hdf5LoadStatus::AxisNotMonotone);
 
   std::filesystem::remove(filePath);
 }
 
 TEST_CASE("HDF5 loader returns DatasetRankInvalid for 0D dataset", "[hdf5][loader][error]")
 {
+  using namespace WeakLibReader;
   AmrexGuard amrex{};
-  ScopedHdf5ErrorSilencer silencer{};
+  detail::ScopedH5ErrorSuppressor silencer{};
 
   const std::filesystem::path filePath =
       std::filesystem::temp_directory_path() / "weaklibreader_hdf5_0d.h5";
@@ -500,16 +469,17 @@ TEST_CASE("HDF5 loader returns DatasetRankInvalid for 0D dataset", "[hdf5][loade
 
   H5Fclose(file);
 
-  WeakLibReader::Hdf5Table table;
-  const auto status = WeakLibReader::LoadHdf5Table(filePath.string(), table);
+  Hdf5Table table;
+  const auto status = LoadHdf5Table(filePath.string(), table);
 
-  CHECK(status == WeakLibReader::Hdf5LoadStatus::DatasetRankInvalid);
+  CHECK(status == Hdf5LoadStatus::DatasetRankInvalid);
 
   std::filesystem::remove(filePath);
 }
 
 TEST_CASE("HDF5 loader handles 5D tables correctly", "[hdf5][loader][5d]")
 {
+  using namespace WeakLibReader;
   AmrexGuard amrex{};
 
   const std::filesystem::path filePath =
@@ -561,10 +531,10 @@ TEST_CASE("HDF5 loader handles 5D tables correctly", "[hdf5][loader][5d]")
   H5Fclose(file);
 
   // Load the table
-  WeakLibReader::Hdf5Table table;
-  const auto status = WeakLibReader::LoadHdf5Table(filePath.string(), table);
+  Hdf5Table table;
+  const auto status = LoadHdf5Table(filePath.string(), table);
 
-  REQUIRE(status == WeakLibReader::Hdf5LoadStatus::Success);
+  REQUIRE(status == Hdf5LoadStatus::Success);
   REQUIRE(table.nd == 5);
 
   // Verify extents (C-order)
@@ -583,11 +553,11 @@ TEST_CASE("HDF5 loader handles 5D tables correctly", "[hdf5][loader][5d]")
   CHECK(table.layout.n[4] == 6);
 
   // Verify axes
-  CHECK(table.axes[0].scale == WeakLibReader::AxisScale::Linear);
+  CHECK(table.axes[0].scale == AxisScale::Linear);
   CHECK(table.axes[0].n == 2);
-  CHECK(table.axes[2].scale == WeakLibReader::AxisScale::Log10);
+  CHECK(table.axes[2].scale == AxisScale::Log10);
   CHECK(table.axes[2].n == 4);
-  CHECK(table.axes[4].scale == WeakLibReader::AxisScale::Log10);
+  CHECK(table.axes[4].scale == AxisScale::Log10);
   CHECK(table.axes[4].n == 6);
 
   // Verify a specific data point using Layout::Offset
@@ -597,7 +567,7 @@ TEST_CASE("HDF5 loader handles 5D tables correctly", "[hdf5][loader][5d]")
   CHECK(data[offset] == Catch::Approx(54321.0));
 
   // Test MakeDeviceCopy for 5D table
-  const auto deviceTable = WeakLibReader::MakeDeviceCopy(table);
+  const auto deviceTable = MakeDeviceCopy(table);
   CHECK(deviceTable.nd == 5);
   CHECK(deviceTable.layout.nd == 5);
 
@@ -611,7 +581,7 @@ TEST_CASE("HDF5 loader handles 5D tables correctly", "[hdf5][loader][5d]")
   const double* originalPtr = table.DataPtr();
   const double* roundtripPtr = roundtrip.data();
   for (std::size_t i = 0; i < totalSize; ++i) {
-    CHECK(roundtripPtr[i] == Catch::Approx(originalPtr[i]).margin(kTol));
+    CHECK(roundtripPtr[i] == Catch::Approx(originalPtr[i]).margin(Tol));
   }
 
   // Verify device axis data
@@ -623,7 +593,7 @@ TEST_CASE("HDF5 loader handles 5D tables correctly", "[hdf5][loader][5d]")
                      hostAxis.begin());
     REQUIRE(hostAxis.size() == table.axisStorage[dim].size());
     for (std::size_t i = 0; i < hostAxis.size(); ++i) {
-      CHECK(hostAxis[i] == Catch::Approx(table.axisStorage[dim][i]).margin(kTol));
+      CHECK(hostAxis[i] == Catch::Approx(table.axisStorage[dim][i]).margin(Tol));
     }
   }
 

--- a/test/test_log_interpolate_2d.cpp
+++ b/test/test_log_interpolate_2d.cpp
@@ -1,3 +1,4 @@
+#define SIMPLE_CATCH_NO_MAIN
 #include <catch2/catch_test_macros.hpp>
 
 #include "interp/WeakLibReader_LogInterpolate.hpp"
@@ -11,7 +12,7 @@
 
 namespace {
 
-constexpr double kTol = 1.0e-12;
+constexpr double Tol = 1.0e-12;
 
 } // namespace
 
@@ -49,7 +50,7 @@ TEST_CASE("2D log interpolation matches bilinear expectation", "[loginterp][2d]"
                              dY * ((1.0 - dX) * p01 + dX * p11);
   const double expected = std::pow(10.0, logExpected);
 
-  CHECK(result == Catch::Approx(expected).margin(kTol));
+  CHECK(result == Catch::Approx(expected).margin(Tol));
 }
 
 TEST_CASE("Batch 2D log interpolation matches point wrapper", "[loginterp][2d][batch]")
@@ -83,7 +84,7 @@ TEST_CASE("Batch 2D log interpolation matches point wrapper", "[loginterp][2d][b
   for (std::size_t i = 0; i < x0.size(); ++i) {
     const double point = LogInterpolateSingleVariable2DCustomPoint(
         x0[i], x1[i], axes, table.data(), 0.0);
-    CHECK(out[i] == Catch::Approx(point).margin(kTol));
+    CHECK(out[i] == Catch::Approx(point).margin(Tol));
   }
 }
 
@@ -138,9 +139,9 @@ TEST_CASE("Out-of-range on mixed axes extrapolates correctly", "[loginterp][poli
   detail::LogInterpolatedDerivativeDirect<2>(
       table.data(), layout, axes, coords, offset, interpolant, deriv);
 
-  CHECK(interpolant == Catch::Approx(expectedInterp).margin(kTol));
-  CHECK(deriv[0] == Catch::Approx(expectedDLog).margin(kTol));
-  CHECK(deriv[1] == Catch::Approx(expectedDLin).margin(kTol));
+  CHECK(interpolant == Catch::Approx(expectedInterp).margin(Tol));
+  CHECK(deriv[0] == Catch::Approx(expectedDLog).margin(Tol));
+  CHECK(deriv[1] == Catch::Approx(expectedDLin).margin(Tol));
 }
 
 TEST_CASE("Template instantiation compiles for all dimensions", "[compile-time]")

--- a/test/test_log_interpolate_3d.cpp
+++ b/test/test_log_interpolate_3d.cpp
@@ -11,7 +11,7 @@
 
 namespace {
 
-constexpr double kTol = 1.0e-12;
+constexpr double Tol = 1.0e-12;
 
 } // namespace
 
@@ -76,7 +76,7 @@ TEST_CASE("3D log interpolation matches trilinear expectation", "[loginterp][3d]
   const double logExpected = (1 - dZ) * c0 + dZ * c1;
   const double expected = std::pow(10.0, logExpected);
 
-  CHECK(result == Catch::Approx(expected).margin(kTol));
+  CHECK(result == Catch::Approx(expected).margin(Tol));
 }
 
 TEST_CASE("Batch 3D log interpolation matches point wrapper", "[loginterp][3d][batch]")
@@ -120,7 +120,7 @@ TEST_CASE("Batch 3D log interpolation matches point wrapper", "[loginterp][3d][b
   for (std::size_t i = 0; i < x0.size(); ++i) {
     const double point = LogInterpolateSingleVariable3DCustomPoint(
         x0[i], x1[i], x2[i], axes, table.data(), 0.0);
-    CHECK(out[i] == Catch::Approx(point).margin(kTol));
+    CHECK(out[i] == Catch::Approx(point).margin(Tol));
   }
 }
 

--- a/test/test_log_interpolate_4d5d.cpp
+++ b/test/test_log_interpolate_4d5d.cpp
@@ -13,7 +13,7 @@
 
 namespace {
 
-constexpr double kTol = 1.0e-12;
+constexpr double Tol = 1.0e-12;
 
 } // namespace
 
@@ -61,7 +61,7 @@ TEST_CASE("4D log interpolation matches quadrilinear expectation", "[loginterp][
   const double expected = detail::LogInterpolatedValueDirect<4>(
       table.data(), layout, axes, coords, 0.0);
 
-  CHECK(result == Catch::Approx(expected).margin(kTol));
+  CHECK(result == Catch::Approx(expected).margin(Tol));
 }
 
 TEST_CASE("Batch 4D log interpolation matches point wrapper", "[loginterp][4d][batch]")
@@ -111,7 +111,7 @@ TEST_CASE("Batch 4D log interpolation matches point wrapper", "[loginterp][4d][b
   for (std::size_t i = 0; i < x0.size(); ++i) {
     const double point = LogInterpolateSingleVariable4DCustomPoint(
         x0[i], x1[i], x2[i], x3[i], axes, table.data(), 0.0);
-    CHECK(out[i] == Catch::Approx(point).margin(kTol));
+    CHECK(out[i] == Catch::Approx(point).margin(Tol));
   }
 }
 
@@ -163,7 +163,7 @@ TEST_CASE("4D mixed axes log interpolation respects offset", "[loginterp][4d][of
   const double result = detail::LogInterpolatedValueDirect<4>(
       table.data(), layout, axes, coords, offset);
 
-  CHECK(result == Catch::Approx(expected).margin(kTol));
+  CHECK(result == Catch::Approx(expected).margin(Tol));
 }
 
 TEST_CASE("4D mixed axes derivative matches kernel", "[loginterp][4d][derivative]")
@@ -228,11 +228,11 @@ TEST_CASE("4D mixed axes derivative matches kernel", "[loginterp][4d][derivative
   detail::LogInterpolatedDerivativeDirect<4>(
       table.data(), layout, axes, coords, offset, interpolant, deriv);
 
-  CHECK(interpolant == Catch::Approx(expectedInterp).margin(kTol));
-  CHECK(deriv[0] == Catch::Approx(expectedDA).margin(kTol));
-  CHECK(deriv[1] == Catch::Approx(expectedDB).margin(kTol));
-  CHECK(deriv[2] == Catch::Approx(expectedDC).margin(kTol));
-  CHECK(deriv[3] == Catch::Approx(expectedDD).margin(kTol));
+  CHECK(interpolant == Catch::Approx(expectedInterp).margin(Tol));
+  CHECK(deriv[0] == Catch::Approx(expectedDA).margin(Tol));
+  CHECK(deriv[1] == Catch::Approx(expectedDB).margin(Tol));
+  CHECK(deriv[2] == Catch::Approx(expectedDC).margin(Tol));
+  CHECK(deriv[3] == Catch::Approx(expectedDD).margin(Tol));
 }
 
 TEST_CASE("5D log interpolation via LinearInterp5DPoint", "[loginterp][5d]")
@@ -332,7 +332,7 @@ TEST_CASE("5D log interpolation via LinearInterp5DPoint", "[loginterp][5d]")
       d0, d1, d2, d3, d4);
   const double expected = std::pow(10.0, logExpected);
 
-  CHECK(result == Catch::Approx(expected).margin(kTol));
+  CHECK(result == Catch::Approx(expected).margin(Tol));
 }
 
 TEST_CASE("PentaLinear reduces to TetraLinear at boundaries", "[loginterp][5d][pentalinear]")
@@ -370,7 +370,7 @@ TEST_CASE("PentaLinear reduces to TetraLinear at boundaries", "[loginterp][5d][p
       p00110, p10110, p01110, p11110,
       dX1, dX2, dX3, dX4);
 
-  CHECK(penta0 == Catch::Approx(tetraLo).margin(kTol));
+  CHECK(penta0 == Catch::Approx(tetraLo).margin(Tol));
 
   // dX5 = 1 should give the "hi" tetralinear result
   const double penta1 = PentaLinear(
@@ -391,7 +391,7 @@ TEST_CASE("PentaLinear reduces to TetraLinear at boundaries", "[loginterp][5d][p
       p00111, p10111, p01111, p11111,
       dX1, dX2, dX3, dX4);
 
-  CHECK(penta1 == Catch::Approx(tetraHi).margin(kTol));
+  CHECK(penta1 == Catch::Approx(tetraHi).margin(Tol));
 }
 
 TEST_CASE("1D3D sweep batch matches direct interpolation", "[loginterp][4d][batch]")
@@ -452,7 +452,7 @@ TEST_CASE("1D3D sweep batch matches direct interpolation", "[loginterp][4d][batc
       const double expected = detail::LogInterpolatedValueDirect<4>(
           table.data(), layout, axes, coords, 0.0);
       const std::size_t idx = j * sizeE + i;
-      CHECK(out[idx] == Catch::Approx(expected).margin(kTol));
+      CHECK(out[idx] == Catch::Approx(expected).margin(Tol));
     }
   }
 }
@@ -524,6 +524,6 @@ TEST_CASE("1D3D single point matches batch with count=1", "[loginterp][4d][1d3d]
   REQUIRE(rcBatch == 0);
 
   for (std::size_t i = 0; i < sizeE; ++i) {
-    CHECK(outPoint[i] == Catch::Approx(outBatch[i]).margin(kTol));
+    CHECK(outPoint[i] == Catch::Approx(outBatch[i]).margin(Tol));
   }
 }

--- a/test/test_log_interpolate_basis.cpp
+++ b/test/test_log_interpolate_basis.cpp
@@ -7,7 +7,7 @@
 
 namespace {
 
-constexpr double kTol = 1.0e-12;
+constexpr double Tol = 1.0e-12;
 
 } // namespace
 
@@ -27,7 +27,7 @@ TEST_CASE("BiLinearDerivativeX1 matches analytical formula", "[basis][deriv][2d]
     const double result = BiLinearDerivativeX1(p00, p10, p01, p11, dX2);
     // Analytical: d/dX1[BiLinear] = Linear(p10, p11, dX2) - Linear(p00, p01, dX2)
     const double expected = Linear(p10, p11, dX2) - Linear(p00, p01, dX2);
-    CHECK(result == Catch::Approx(expected).margin(kTol));
+    CHECK(result == Catch::Approx(expected).margin(Tol));
   }
 }
 
@@ -59,7 +59,7 @@ TEST_CASE("BiLinearDerivativeX2 matches analytical formula", "[basis][deriv][2d]
     const double result = BiLinearDerivativeX2(p00, p10, p01, p11, dX1);
     // Analytical: d/dX2[BiLinear] = Linear(p01, p11, dX1) - Linear(p00, p10, dX1)
     const double expected = Linear(p01, p11, dX1) - Linear(p00, p10, dX1);
-    CHECK(result == Catch::Approx(expected).margin(kTol));
+    CHECK(result == Catch::Approx(expected).margin(Tol));
   }
 }
 
@@ -95,7 +95,7 @@ TEST_CASE("TriLinearDerivativeX1 matches analytical formula", "[basis][deriv][3d
       // Analytical: BiLinear(p100,p110,p101,p111) - BiLinear(p000,p010,p001,p011)
       const double expected = BiLinear(p100, p110, p101, p111, dX2, dX3) -
                               BiLinear(p000, p010, p001, p011, dX2, dX3);
-      CHECK(result == Catch::Approx(expected).margin(kTol));
+      CHECK(result == Catch::Approx(expected).margin(Tol));
     }
   }
 }
@@ -136,7 +136,7 @@ TEST_CASE("TriLinearDerivativeX2 matches analytical formula", "[basis][deriv][3d
                                                    dX1, dX3);
       const double expected = BiLinear(p010, p110, p011, p111, dX1, dX3) -
                               BiLinear(p000, p100, p001, p101, dX1, dX3);
-      CHECK(result == Catch::Approx(expected).margin(kTol));
+      CHECK(result == Catch::Approx(expected).margin(Tol));
     }
   }
 }
@@ -177,7 +177,7 @@ TEST_CASE("TriLinearDerivativeX3 matches analytical formula", "[basis][deriv][3d
                                                    dX1, dX2);
       const double expected = BiLinear(p001, p101, p011, p111, dX1, dX2) -
                               BiLinear(p000, p100, p010, p110, dX1, dX2);
-      CHECK(result == Catch::Approx(expected).margin(kTol));
+      CHECK(result == Catch::Approx(expected).margin(Tol));
     }
   }
 }

--- a/test/test_log_interpolate_deriv.cpp
+++ b/test/test_log_interpolate_deriv.cpp
@@ -12,7 +12,7 @@
 
 namespace {
 
-constexpr double kTol = 1.0e-12;
+constexpr double Tol = 1.0e-12;
 
 } // namespace
 
@@ -87,10 +87,10 @@ TEST_CASE("Log derivative wrapper matches direct kernel for 3D tables", "[logint
       0.0, interpolated, deriv);
   REQUIRE(rc == 0);
 
-  CHECK(interpolated == Catch::Approx(expectedInterp).margin(kTol));
-  CHECK(deriv[0] == Catch::Approx(expectedDD).margin(kTol));
-  CHECK(deriv[1] == Catch::Approx(expectedDT).margin(kTol));
-  CHECK(deriv[2] == Catch::Approx(expectedDY).margin(kTol));
+  CHECK(interpolated == Catch::Approx(expectedInterp).margin(Tol));
+  CHECK(deriv[0] == Catch::Approx(expectedDD).margin(Tol));
+  CHECK(deriv[1] == Catch::Approx(expectedDT).margin(Tol));
+  CHECK(deriv[2] == Catch::Approx(expectedDY).margin(Tol));
 }
 
 TEST_CASE("Aligned derivative wrapper mirrors kernel output", "[loginterp][derivative][2d2d]")
@@ -172,12 +172,12 @@ TEST_CASE("Aligned derivative wrapper mirrors kernel output", "[loginterp][deriv
 
       const std::size_t lower = j * sizeE + i;
       const std::size_t upper = i * sizeE + j;
-      CHECK(planeInterp[lower] == Catch::Approx(interpExpected).margin(kTol));
-      CHECK(planeDerivT[lower] == Catch::Approx(dTExpected).margin(kTol));
-      CHECK(planeDerivX[lower] == Catch::Approx(dXExpected).margin(kTol));
-      CHECK(planeInterp[upper] == Catch::Approx(interpExpected).margin(kTol));
-      CHECK(planeDerivT[upper] == Catch::Approx(dTExpected).margin(kTol));
-      CHECK(planeDerivX[upper] == Catch::Approx(dXExpected).margin(kTol));
+      CHECK(planeInterp[lower] == Catch::Approx(interpExpected).margin(Tol));
+      CHECK(planeDerivT[lower] == Catch::Approx(dTExpected).margin(Tol));
+      CHECK(planeDerivX[lower] == Catch::Approx(dXExpected).margin(Tol));
+      CHECK(planeInterp[upper] == Catch::Approx(interpExpected).margin(Tol));
+      CHECK(planeDerivT[upper] == Catch::Approx(dTExpected).margin(Tol));
+      CHECK(planeDerivX[upper] == Catch::Approx(dXExpected).margin(Tol));
     }
   }
 }
@@ -242,10 +242,10 @@ TEST_CASE("Batch 3D derivative matches point version", "[loginterp][3d][derivati
         interpPoint, derivPoint);
     REQUIRE(rcPoint == 0);
 
-    CHECK(interpBatch[i] == Catch::Approx(interpPoint).margin(kTol));
-    CHECK(derivBatch[i * 3 + 0] == Catch::Approx(derivPoint[0]).margin(kTol));
-    CHECK(derivBatch[i * 3 + 1] == Catch::Approx(derivPoint[1]).margin(kTol));
-    CHECK(derivBatch[i * 3 + 2] == Catch::Approx(derivPoint[2]).margin(kTol));
+    CHECK(interpBatch[i] == Catch::Approx(interpPoint).margin(Tol));
+    CHECK(derivBatch[i * 3 + 0] == Catch::Approx(derivPoint[0]).margin(Tol));
+    CHECK(derivBatch[i * 3 + 1] == Catch::Approx(derivPoint[1]).margin(Tol));
+    CHECK(derivBatch[i * 3 + 2] == Catch::Approx(derivPoint[2]).margin(Tol));
   }
 }
 
@@ -319,9 +319,9 @@ TEST_CASE("Batch 2D2D derivative matches point version", "[loginterp][2d2d][deri
     REQUIRE(rcPoint == 0);
 
     for (std::size_t i = 0; i < planeSize; ++i) {
-      CHECK(interpBatch[k * planeSize + i] == Catch::Approx(interpPoint[i]).margin(kTol));
-      CHECK(derivTBatch[k * planeSize + i] == Catch::Approx(derivTPoint[i]).margin(kTol));
-      CHECK(derivXBatch[k * planeSize + i] == Catch::Approx(derivXPoint[i]).margin(kTol));
+      CHECK(interpBatch[k * planeSize + i] == Catch::Approx(interpPoint[i]).margin(Tol));
+      CHECK(derivTBatch[k * planeSize + i] == Catch::Approx(derivTPoint[i]).margin(Tol));
+      CHECK(derivXBatch[k * planeSize + i] == Catch::Approx(derivXPoint[i]).margin(Tol));
     }
   }
 }
@@ -398,9 +398,9 @@ TEST_CASE("Batch aligned 2D2D derivative matches point version", "[loginterp][2d
     REQUIRE(rcPoint == 0);
 
     for (std::size_t i = 0; i < planeSize; ++i) {
-      CHECK(interpBatch[k * planeSize + i] == Catch::Approx(interpPoint[i]).margin(kTol));
-      CHECK(derivTBatch[k * planeSize + i] == Catch::Approx(derivTPoint[i]).margin(kTol));
-      CHECK(derivXBatch[k * planeSize + i] == Catch::Approx(derivXPoint[i]).margin(kTol));
+      CHECK(interpBatch[k * planeSize + i] == Catch::Approx(interpPoint[i]).margin(Tol));
+      CHECK(derivTBatch[k * planeSize + i] == Catch::Approx(derivTPoint[i]).margin(Tol));
+      CHECK(derivXBatch[k * planeSize + i] == Catch::Approx(derivXPoint[i]).margin(Tol));
     }
   }
 }

--- a/test/test_log_interpolate_kernel.cpp
+++ b/test/test_log_interpolate_kernel.cpp
@@ -12,7 +12,7 @@
 
 namespace {
 
-constexpr double kTol = 1.0e-12;
+constexpr double Tol = 1.0e-12;
 
 } // namespace
 
@@ -40,7 +40,7 @@ TEST_CASE("LinearInterp1DPoint matches linear expectation", "[interp][1d]")
   const double logExpected = Linear(table[0], table[1], d0);
   const double expected = std::pow(10.0, logExpected);
 
-  CHECK(result == Catch::Approx(expected).margin(kTol));
+  CHECK(result == Catch::Approx(expected).margin(Tol));
 }
 
 TEST_CASE("LinearInterp1DPoint with offset", "[interp][1d]")
@@ -59,7 +59,7 @@ TEST_CASE("LinearInterp1DPoint with offset", "[interp][1d]")
   const double logExpected = Linear(table[0], table[1], d0);
   const double expected = std::pow(10.0, logExpected) - os;
 
-  CHECK(result == Catch::Approx(expected).margin(kTol));
+  CHECK(result == Catch::Approx(expected).margin(Tol));
 }
 
 TEST_CASE("LinearInterp1DPoint at boundaries", "[interp][1d]")
@@ -72,11 +72,11 @@ TEST_CASE("LinearInterp1DPoint at boundaries", "[interp][1d]")
 
   // At d0=0, should return first value
   CHECK(LinearInterp1DPoint(0, 0.0, 0.0, table.data(), layout) ==
-        Catch::Approx(3.0).margin(kTol));
+        Catch::Approx(3.0).margin(Tol));
 
   // At d0=1, should return second value
   CHECK(LinearInterp1DPoint(0, 1.0, 0.0, table.data(), layout) ==
-        Catch::Approx(6.0).margin(kTol));
+        Catch::Approx(6.0).margin(Tol));
 }
 
 TEST_CASE("LinearInterpDeriv2DPoint returns correct interpolant", "[interp][deriv][2d]")
@@ -100,7 +100,7 @@ TEST_CASE("LinearInterpDeriv2DPoint returns correct interpolant", "[interp][deri
 
   // Verify interpolant matches LinearInterp2DPoint
   const double expected = LinearInterp2DPoint(i0, i1, d0, d1, os, table.data(), layout);
-  CHECK(interpolant == Catch::Approx(expected).margin(kTol));
+  CHECK(interpolant == Catch::Approx(expected).margin(Tol));
 }
 
 TEST_CASE("LinearInterpDeriv2DPoint derivatives match numerical", "[interp][deriv][2d][numerical]")
@@ -160,7 +160,7 @@ TEST_CASE("LinearInterpDeriv2DPoint with offset", "[interp][deriv][2d]")
 
   // Interpolant should match with offset
   const double expectedInterp = LinearInterp2DPoint(0, 0, d0, d1, os, table.data(), layout);
-  CHECK(interpolant == Catch::Approx(expectedInterp).margin(kTol));
+  CHECK(interpolant == Catch::Approx(expectedInterp).margin(Tol));
 
   // Compute numerical derivatives (w.r.t. fractional coordinates)
   const double h = 1.0e-7;
@@ -211,7 +211,7 @@ TEST_CASE("LinearInterp2D3DArray1DAlignedPoint matches slice extraction", "[inte
     const Layout sliceLayout = SliceLeading(layout, 1);
     const double expected = LinearInterp2DPoint(i0, i1, d0, d1, os, slice, sliceLayout);
 
-    CHECK(result == Catch::Approx(expected).margin(kTol));
+    CHECK(result == Catch::Approx(expected).margin(Tol));
   }
 
   // Test at iFixed = 1
@@ -225,7 +225,7 @@ TEST_CASE("LinearInterp2D3DArray1DAlignedPoint matches slice extraction", "[inte
     const Layout sliceLayout = SliceLeading(layout, 1);
     const double expected = LinearInterp2DPoint(i0, i1, d0, d1, os, slice, sliceLayout);
 
-    CHECK(result == Catch::Approx(expected).margin(kTol));
+    CHECK(result == Catch::Approx(expected).margin(Tol));
   }
 }
 
@@ -255,7 +255,7 @@ TEST_CASE("LinearInterp3D4DArray1DAlignedPoint matches slice extraction", "[inte
     const Layout sliceLayout = SliceLeading(layout, 1);
     const double expected = LinearInterp3DPoint(i0, i1, i2, d0, d1, d2, os, slice, sliceLayout);
 
-    CHECK(result == Catch::Approx(expected).margin(kTol));
+    CHECK(result == Catch::Approx(expected).margin(Tol));
   }
 }
 
@@ -287,7 +287,7 @@ TEST_CASE("LinearInterp3D5DArray2DAlignedPoint matches slice extraction", "[inte
       const Layout sliceLayout = SliceLeading(layout, 2);
       const double expected = LinearInterp3DPoint(i0, i1, i2, d0, d1, d2, os, slice, sliceLayout);
 
-      CHECK(result == Catch::Approx(expected).margin(kTol));
+      CHECK(result == Catch::Approx(expected).margin(Tol));
     }
   }
 }
@@ -318,6 +318,6 @@ TEST_CASE("LinearInterp4D5DArray1DAlignedPoint matches slice extraction", "[inte
     const Layout sliceLayout = SliceLeading(layout, 1);
     const double expected = LinearInterp4DPoint(i0, i1, i2, i3, d0, d1, d2, d3, os, slice, sliceLayout);
 
-    CHECK(result == Catch::Approx(expected).margin(kTol));
+    CHECK(result == Catch::Approx(expected).margin(Tol));
   }
 }

--- a/test/test_log_interpolate_sweep.cpp
+++ b/test/test_log_interpolate_sweep.cpp
@@ -12,7 +12,7 @@
 
 namespace {
 
-constexpr double kTol = 1.0e-12;
+constexpr double Tol = 1.0e-12;
 
 } // namespace
 
@@ -72,8 +72,8 @@ TEST_CASE("Aligned 2D plane interpolation mirrors underlying kernel", "[loginter
           table.data(), layout);
       const std::size_t lower = j * sizeE + i;
       const std::size_t upper = i * sizeE + j;
-      CHECK(plane[lower] == Catch::Approx(expected).margin(kTol));
-      CHECK(plane[upper] == Catch::Approx(expected).margin(kTol));
+      CHECK(plane[lower] == Catch::Approx(expected).margin(Tol));
+      CHECK(plane[upper] == Catch::Approx(expected).margin(Tol));
     }
   }
 }
@@ -151,8 +151,8 @@ TEST_CASE("Weighted sum aligned helper reproduces manual accumulation", "[logint
       }
       const std::size_t lower = j * sizeE + i;
       const std::size_t upper = i * sizeE + j;
-      CHECK(out[lower] == Catch::Approx(expected).margin(kTol));
-      CHECK(out[upper] == Catch::Approx(expected).margin(kTol));
+      CHECK(out[lower] == Catch::Approx(expected).margin(Tol));
+      CHECK(out[upper] == Catch::Approx(expected).margin(Tol));
     }
   }
 }
@@ -210,8 +210,8 @@ TEST_CASE("Non-aligned 2D2D single point interpolation", "[loginterp][2d2d][nona
       // Check both symmetric positions
       const std::size_t lower = j * sizeE + i;
       const std::size_t upper = i * sizeE + j;
-      CHECK(out[lower] == Catch::Approx(expected).margin(kTol));
-      CHECK(out[upper] == Catch::Approx(expected).margin(kTol));
+      CHECK(out[lower] == Catch::Approx(expected).margin(Tol));
+      CHECK(out[upper] == Catch::Approx(expected).margin(Tol));
     }
   }
 }
@@ -269,7 +269,7 @@ TEST_CASE("Non-aligned 2D2D batch interpolation", "[loginterp][2d2d][nonaligned]
     REQUIRE(rcPoint == 0);
 
     for (std::size_t k = 0; k < sizeE * sizeE; ++k) {
-      CHECK(out[l * sizeE * sizeE + k] == Catch::Approx(plane[k]).margin(kTol));
+      CHECK(out[l * sizeE * sizeE + k] == Catch::Approx(plane[k]).margin(Tol));
     }
   }
 }
@@ -329,7 +329,7 @@ TEST_CASE("Batch aligned 2D2D matches point version", "[loginterp][2d2d][aligned
     REQUIRE(rcPoint == 0);
 
     for (std::size_t i = 0; i < planeSize; ++i) {
-      CHECK(outBatch[k * planeSize + i] == Catch::Approx(outPoint[i]).margin(kTol));
+      CHECK(outBatch[k * planeSize + i] == Catch::Approx(outPoint[i]).margin(Tol));
     }
   }
 }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,0 +1,3 @@
+// Provides main() for the test executable.
+// All other test files define SIMPLE_CATCH_NO_MAIN to avoid duplicate main.
+#include <catch2/catch_test_macros.hpp>

--- a/test/test_weaklib_eos_loader.cpp
+++ b/test/test_weaklib_eos_loader.cpp
@@ -2,47 +2,27 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "hdf5/WeakLibReader_Hdf5Loader.hpp"
+#include "test_amrex_guard.hpp"
 
-#include <AMReX.H>
 #include <AMReX_GpuContainers.H>
 #include <hdf5.h>
 
 #include <algorithm>
 #include <array>
-#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <string>
 #include <vector>
 
-using namespace WeakLibReader;
-
 namespace {
 
-constexpr std::size_t kRhoCount = 3;
-constexpr std::size_t kTempCount = 2;
-constexpr std::size_t kYeCount = 2;
+constexpr std::size_t RhoCount = 3;
+constexpr std::size_t TempCount = 2;
+constexpr std::size_t YeCount = 2;
 
-const double kDensityAxis[kRhoCount] = {1.0e3, 1.0e6, 1.0e9};
-const double kTemperatureAxis[kTempCount] = {0.1, 1.0};
-const double kYeAxis[kYeCount] = {0.1, 0.3};
-
-/// RAII helper that temporarily silences HDF5 automatic error printing.
-struct ScopedHdf5ErrorSilencer {
-  H5E_auto2_t oldFunc = nullptr;
-  void* oldClientData = nullptr;
-
-  ScopedHdf5ErrorSilencer()
-  {
-    H5Eget_auto2(H5E_DEFAULT, &oldFunc, &oldClientData);
-    H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
-  }
-
-  ~ScopedHdf5ErrorSilencer()
-  {
-    H5Eset_auto2(H5E_DEFAULT, oldFunc, oldClientData);
-  }
-};
+const double DensityAxis[RhoCount] = {1.0e3, 1.0e6, 1.0e9};
+const double TemperatureAxis[TempCount] = {0.1, 1.0};
+const double YeAxis[YeCount] = {0.1, 0.3};
 
 void CreateAxisDataset(hid_t parent, const char* name, const double* values, std::size_t count)
 {
@@ -329,10 +309,10 @@ void CreateWeakLibEosTestFileFullCOrder(const std::filesystem::path& filePath)
 std::vector<double> MakeDependentValues(double offset)
 {
   std::vector<double> values;
-  values.reserve(kRhoCount * kTempCount * kYeCount);
-  for (std::size_t ye = 0; ye < kYeCount; ++ye) {
-    for (std::size_t temp = 0; temp < kTempCount; ++temp) {
-      for (std::size_t rho = 0; rho < kRhoCount; ++rho) {
+  values.reserve(RhoCount * TempCount * YeCount);
+  for (std::size_t ye = 0; ye < YeCount; ++ye) {
+    for (std::size_t temp = 0; temp < TempCount; ++temp) {
+      for (std::size_t rho = 0; rho < RhoCount; ++rho) {
         values.push_back(offset +
                          1.0 +
                          100.0 * static_cast<double>(ye) +
@@ -347,9 +327,9 @@ std::vector<double> MakeDependentValues(double offset)
 void CreateDependentVariable(hid_t parent, const char* name, const std::vector<double>& values)
 {
   const hsize_t dims[3] = {
-      static_cast<hsize_t>(kYeCount),
-      static_cast<hsize_t>(kTempCount),
-      static_cast<hsize_t>(kRhoCount)};
+      static_cast<hsize_t>(YeCount),
+      static_cast<hsize_t>(TempCount),
+      static_cast<hsize_t>(RhoCount)};
   hid_t space = H5Screate_simple(3, dims, nullptr);
   REQUIRE(space >= 0);
 
@@ -374,9 +354,9 @@ void CreateWeakLibEosTestFile(const std::filesystem::path& path)
   const int logInterp[3] = {1, 1, 0};
   CreateIntDataset(thermoGroup, "LogInterp", logInterp, 3);
 
-  CreateAxisDataset(thermoGroup, "Density", kDensityAxis, kRhoCount);
-  CreateAxisDataset(thermoGroup, "Temperature", kTemperatureAxis, kTempCount);
-  CreateAxisDataset(thermoGroup, "Electron Fraction", kYeAxis, kYeCount);
+  CreateAxisDataset(thermoGroup, "Density", DensityAxis, RhoCount);
+  CreateAxisDataset(thermoGroup, "Temperature", TemperatureAxis, TempCount);
+  CreateAxisDataset(thermoGroup, "Electron Fraction", YeAxis, YeCount);
 
   H5Gclose(thermoGroup);
 
@@ -403,28 +383,12 @@ struct TempWeakLibEosFile {
   ~TempWeakLibEosFile() { std::filesystem::remove(path); }
 };
 
-/// Initialize AMReX if not already initialized.
-/// This relies on AMReX's internal tracking to avoid double-initialization.
-void EnsureAmrexInitialized()
-{
-  if (!amrex::Initialized()) {
-    int argc = 0;
-    char** argv = nullptr;
-    amrex::Initialize(argc, argv);
-    // Register finalize at exit - but only if we initialized
-    std::atexit([]() {
-      if (amrex::Initialized()) {
-        amrex::Finalize();
-      }
-    });
-  }
-}
-
 } // namespace
 
 TEST_CASE("LoadWeakLibEosTableFull reads complete EOS table", "[hdf5][weaklib]")
 {
-  EnsureAmrexInitialized();
+  using namespace WeakLibReader;
+  AmrexGuard amrex{};
 
   const std::filesystem::path eosPath =
       std::filesystem::temp_directory_path() / "weaklibreader_eos_small_full.h5";
@@ -483,7 +447,8 @@ TEST_CASE("LoadWeakLibEosTableFull reads complete EOS table", "[hdf5][weaklib]")
 
 TEST_CASE("MakeDeviceCopy works for WeakLibEosTable", "[hdf5][weaklib][gpu]")
 {
-  EnsureAmrexInitialized();
+  using namespace WeakLibReader;
+  AmrexGuard amrex{};
 
   const std::filesystem::path eosPath =
       std::filesystem::temp_directory_path() / "weaklibreader_eos_small_device.h5";
@@ -505,7 +470,8 @@ TEST_CASE("MakeDeviceCopy works for WeakLibEosTable", "[hdf5][weaklib][gpu]")
 
 TEST_CASE("LoadWeakLibEosTableFullParallel loads complete table", "[weaklib][eos][parallel]")
 {
-  EnsureAmrexInitialized();
+  using namespace WeakLibReader;
+  AmrexGuard amrex{};
 
   const std::filesystem::path eosPath =
       std::filesystem::temp_directory_path() / "weaklibreader_eos_parallel_full.h5";
@@ -568,8 +534,9 @@ TEST_CASE("LoadWeakLibEosTableFullParallel loads complete table", "[weaklib][eos
 
 TEST_CASE("LoadWeakLibEosTableFullParallel fails for nonexistent file", "[weaklib][eos][parallel]")
 {
-  EnsureAmrexInitialized();
-  ScopedHdf5ErrorSilencer silencer{};
+  using namespace WeakLibReader;
+  AmrexGuard amrex{};
+  detail::ScopedH5ErrorSuppressor silencer{};
 
   WeakLibEosTable table;
   const Hdf5LoadStatus status = LoadWeakLibEosTableFullParallel("/nonexistent/path.h5", table);
@@ -579,7 +546,8 @@ TEST_CASE("LoadWeakLibEosTableFullParallel fails for nonexistent file", "[weakli
 
 TEST_CASE("LoadWeakLibEosTableFull rejects C-ordered dependent variables", "[weaklib][eos][validation]")
 {
-  EnsureAmrexInitialized();
+  using namespace WeakLibReader;
+  AmrexGuard amrex{};
 
   const std::filesystem::path eosPath =
       std::filesystem::temp_directory_path() / "weaklibreader_eos_c_order.h5";

--- a/test/test_weaklib_opacity_loader.cpp
+++ b/test/test_weaklib_opacity_loader.cpp
@@ -3,31 +3,28 @@
 
 #include "hdf5/WeakLibReader_Hdf5Loader.hpp"
 #include "hdf5/WeakLibReader_Hdf5Types.hpp"
+#include "test_amrex_guard.hpp"
 
-#include <AMReX.H>
 #include <AMReX_GpuContainers.H>
 #include <hdf5.h>
 
 #include <algorithm>
 #include <array>
 #include <cmath>
-#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <string>
 #include <vector>
 
-using namespace WeakLibReader;
-
 namespace {
 
-constexpr int kTestNE = 4;
-constexpr int kTestNRho = 2;
-constexpr int kTestNT = 3;
-constexpr int kTestNYe = 2;
-constexpr int kTestNOpacities = 2;
-constexpr int kTestNMoments = 2;
-constexpr int kTestNEta = 3;
+constexpr int TestNE = 4;
+constexpr int TestNRho = 2;
+constexpr int TestNT = 3;
+constexpr int TestNYe = 2;
+constexpr int TestNOpacities = 2;
+constexpr int TestNMoments = 2;
+constexpr int TestNEta = 3;
 
 double Encode5dIndexValue(int i0, int i1, int i2, int i3, int i4,
                           double base = 0.0)
@@ -67,21 +64,6 @@ std::vector<double> BuildFortranOrdered5dData(const std::array<int, 5>& cOrderDi
   }
 
   return data;
-}
-
-/// Initialize AMReX if not already initialized.
-void EnsureAmrexInitialized()
-{
-  if (!amrex::Initialized()) {
-    int argc = 0;
-    char** argv = nullptr;
-    amrex::Initialize(argc, argv);
-    std::atexit([]() {
-      if (amrex::Initialized()) {
-        amrex::Finalize();
-      }
-    });
-  }
 }
 
 void WriteIntArrayDataset(hid_t parent,
@@ -208,7 +190,7 @@ void WriteThermoStateGroup(hid_t file)
   hid_t thermoGroup = H5Gcreate(file, "ThermoState", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   REQUIRE(thermoGroup >= 0);
   WriteIntArrayDataset(thermoGroup, "LogInterp", {1, 1, 0});
-  WriteIntArrayDataset(thermoGroup, "Dimensions", {kTestNRho, kTestNT, kTestNYe});
+  WriteIntArrayDataset(thermoGroup, "Dimensions", {TestNRho, TestNT, TestNYe});
   WriteStringArrayDataset(thermoGroup, "Names",
                           {"Density", "Temperature", "Electron Fraction"});
   WriteStringArrayDataset(thermoGroup, "Units",
@@ -232,11 +214,11 @@ void WriteOpacityBaseGroups(hid_t file, bool includeEtaGrid)
 
 void CreateWeakLibEmAbTestFile(const std::filesystem::path& filePath)
 {
-  constexpr int nE = kTestNE;
-  constexpr int nRho = kTestNRho;
-  constexpr int nT = kTestNT;
-  constexpr int nYe = kTestNYe;
-  constexpr int nOpacities = kTestNOpacities;
+  constexpr int nE = TestNE;
+  constexpr int nRho = TestNRho;
+  constexpr int nT = TestNT;
+  constexpr int nYe = TestNYe;
+  constexpr int nOpacities = TestNOpacities;
 
   hid_t file = H5Fcreate(filePath.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
   REQUIRE(file >= 0);
@@ -286,10 +268,10 @@ void CreateWeakLibEmAbTestFile(const std::filesystem::path& filePath)
 
 void CreateWeakLibIsoTestFile(const std::filesystem::path& filePath)
 {
-  constexpr int nMoments = kTestNMoments;
-  constexpr int nOpacities = kTestNOpacities;
-  constexpr double kIsoNuBase = 100000.0;
-  constexpr double kIsoNuBarBase = 200000.0;
+  constexpr int nMoments = TestNMoments;
+  constexpr int nOpacities = TestNOpacities;
+  constexpr double IsoNuBase = 100000.0;
+  constexpr double IsoNuBarBase = 200000.0;
 
   hid_t file = H5Fcreate(filePath.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
   REQUIRE(file >= 0);
@@ -309,7 +291,7 @@ void CreateWeakLibIsoTestFile(const std::filesystem::path& filePath)
   WriteDoubleArray2dDataset(group, "Offsets", offsetDims, offsets);
 
   const std::array<int, 5> kernelDimsC = {
-      kTestNE, nMoments, kTestNRho, kTestNT, kTestNYe};
+      TestNE, nMoments, TestNRho, TestNT, TestNYe};
   const std::array<hsize_t, 5> kernelDims = {
       static_cast<hsize_t>(kernelDimsC[4]),
       static_cast<hsize_t>(kernelDimsC[3]),
@@ -317,9 +299,9 @@ void CreateWeakLibIsoTestFile(const std::filesystem::path& filePath)
       static_cast<hsize_t>(kernelDimsC[1]),
       static_cast<hsize_t>(kernelDimsC[0])};
   const std::vector<double> nuData =
-      BuildFortranOrdered5dData(kernelDimsC, kIsoNuBase);
+      BuildFortranOrdered5dData(kernelDimsC, IsoNuBase);
   const std::vector<double> nuBarData =
-      BuildFortranOrdered5dData(kernelDimsC, kIsoNuBarBase);
+      BuildFortranOrdered5dData(kernelDimsC, IsoNuBarBase);
   WriteDoubleArray5dDataset(group, "Electron Neutrino", kernelDims, nuData);
   WriteDoubleArray5dDataset(group, "Electron Antineutrino", kernelDims, nuBarData);
 
@@ -331,7 +313,7 @@ void CreateWeakLibNESTestFile(const std::filesystem::path& filePath)
 {
   constexpr int nMoments = 2;
   constexpr int nOpacities = 1;
-  constexpr double kNesBase = 300000.0;
+  constexpr double NesBase = 300000.0;
 
   hid_t file = H5Fcreate(filePath.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
   REQUIRE(file >= 0);
@@ -351,7 +333,7 @@ void CreateWeakLibNESTestFile(const std::filesystem::path& filePath)
   WriteDoubleArray2dDataset(group, "Offsets", offsetDims, offsets);
 
   const std::array<int, 5> kernelDimsC = {
-      kTestNE, kTestNE, nMoments, kTestNT, kTestNEta};
+      TestNE, TestNE, nMoments, TestNT, TestNEta};
   const std::array<hsize_t, 5> kernelDims = {
       static_cast<hsize_t>(kernelDimsC[4]),
       static_cast<hsize_t>(kernelDimsC[3]),
@@ -359,7 +341,7 @@ void CreateWeakLibNESTestFile(const std::filesystem::path& filePath)
       static_cast<hsize_t>(kernelDimsC[1]),
       static_cast<hsize_t>(kernelDimsC[0])};
   const std::vector<double> data =
-      BuildFortranOrdered5dData(kernelDimsC, kNesBase);
+      BuildFortranOrdered5dData(kernelDimsC, NesBase);
   WriteDoubleArray5dDataset(group, "Kernels", kernelDims, data);
 
   H5Gclose(group);
@@ -370,7 +352,7 @@ void CreateWeakLibPairTestFile(const std::filesystem::path& filePath)
 {
   constexpr int nMoments = 2;
   constexpr int nOpacities = 1;
-  constexpr double kPairBase = 400000.0;
+  constexpr double PairBase = 400000.0;
 
   hid_t file = H5Fcreate(filePath.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
   REQUIRE(file >= 0);
@@ -390,7 +372,7 @@ void CreateWeakLibPairTestFile(const std::filesystem::path& filePath)
   WriteDoubleArray2dDataset(group, "Offsets", offsetDims, offsets);
 
   const std::array<int, 5> kernelDimsC = {
-      kTestNE, kTestNE, nMoments, kTestNT, kTestNEta};
+      TestNE, TestNE, nMoments, TestNT, TestNEta};
   const std::array<hsize_t, 5> kernelDims = {
       static_cast<hsize_t>(kernelDimsC[4]),
       static_cast<hsize_t>(kernelDimsC[3]),
@@ -398,7 +380,7 @@ void CreateWeakLibPairTestFile(const std::filesystem::path& filePath)
       static_cast<hsize_t>(kernelDimsC[1]),
       static_cast<hsize_t>(kernelDimsC[0])};
   const std::vector<double> data =
-      BuildFortranOrdered5dData(kernelDimsC, kPairBase);
+      BuildFortranOrdered5dData(kernelDimsC, PairBase);
   WriteDoubleArray5dDataset(group, "Kernels", kernelDims, data);
 
   H5Gclose(group);
@@ -409,7 +391,7 @@ void CreateWeakLibBremTestFile(const std::filesystem::path& filePath)
 {
   constexpr int nMoments = 1;
   constexpr int nOpacities = 1;
-  constexpr double kBremBase = 500000.0;
+  constexpr double BremBase = 500000.0;
 
   hid_t file = H5Fcreate(filePath.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
   REQUIRE(file >= 0);
@@ -429,7 +411,7 @@ void CreateWeakLibBremTestFile(const std::filesystem::path& filePath)
   WriteDoubleArray2dDataset(group, "Offsets", offsetDims, offsets);
 
   const std::array<int, 5> kernelDimsC = {
-      kTestNE, kTestNE, nMoments, kTestNRho, kTestNT};
+      TestNE, TestNE, nMoments, TestNRho, TestNT};
   const std::array<hsize_t, 5> kernelDims = {
       static_cast<hsize_t>(kernelDimsC[4]),
       static_cast<hsize_t>(kernelDimsC[3]),
@@ -437,35 +419,19 @@ void CreateWeakLibBremTestFile(const std::filesystem::path& filePath)
       static_cast<hsize_t>(kernelDimsC[1]),
       static_cast<hsize_t>(kernelDimsC[0])};
   const std::vector<double> data =
-      BuildFortranOrdered5dData(kernelDimsC, kBremBase);
+      BuildFortranOrdered5dData(kernelDimsC, BremBase);
   WriteDoubleArray5dDataset(group, "S_sigma", kernelDims, data);
 
   H5Gclose(group);
   H5Fclose(file);
 }
 
-/// RAII helper that temporarily silences HDF5 automatic error printing.
-struct ScopedHdf5ErrorSilencer {
-  H5E_auto2_t oldFunc = nullptr;
-  void* oldClientData = nullptr;
-
-  ScopedHdf5ErrorSilencer()
-  {
-    H5Eget_auto2(H5E_DEFAULT, &oldFunc, &oldClientData);
-    H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
-  }
-
-  ~ScopedHdf5ErrorSilencer()
-  {
-    H5Eset_auto2(H5E_DEFAULT, oldFunc, oldClientData);
-  }
-};
-
 } // namespace
 
 TEST_CASE("LoadWeakLibEmAbTable loads legacy EmAb opacity table", "[weaklib][opacity][emab]")
 {
-  EnsureAmrexInitialized();
+  using namespace WeakLibReader;
+  AmrexGuard amrex{};
 
   const std::filesystem::path filePath =
       std::filesystem::temp_directory_path() / "weaklibreader_emab_legacy.h5";
@@ -531,7 +497,8 @@ TEST_CASE("LoadWeakLibEmAbTable loads legacy EmAb opacity table", "[weaklib][opa
 
 TEST_CASE("LoadWeakLibOpacityTableFull loads EmAb table", "[hdf5][weaklib][opacity]")
 {
-  EnsureAmrexInitialized();
+  using namespace WeakLibReader;
+  AmrexGuard amrex{};
 
   const std::filesystem::path filePath =
       std::filesystem::temp_directory_path() / "weaklibreader_opacity_emab_full.h5";
@@ -546,20 +513,20 @@ TEST_CASE("LoadWeakLibOpacityTableFull loads EmAb table", "[hdf5][weaklib][opaci
   REQUIRE(table.HasEmAb());
 
   // Check EnergyGrid
-  CHECK(table.energyGrid.nPoints == kTestNE);
+  CHECK(table.energyGrid.nPoints == TestNE);
   CHECK(table.energyGrid.scale == AxisScale::Linear);
 
   // Check ThermoState
-  CHECK(table.thermoState.dimensions[0] == kTestNRho);  // nRho
-  CHECK(table.thermoState.dimensions[1] == kTestNT);    // nT
-  CHECK(table.thermoState.dimensions[2] == kTestNYe);   // nYe
+  CHECK(table.thermoState.dimensions[0] == TestNRho);  // nRho
+  CHECK(table.thermoState.dimensions[1] == TestNT);    // nT
+  CHECK(table.thermoState.dimensions[2] == TestNYe);   // nYe
 
   // Check EmAb
-  CHECK(table.emAb.nOpacities == kTestNOpacities);
-  CHECK(table.emAb.dimensions[0] == kTestNE);    // nE
-  CHECK(table.emAb.dimensions[1] == kTestNRho);  // nRho
-  CHECK(table.emAb.dimensions[2] == kTestNT);    // nT
-  CHECK(table.emAb.dimensions[3] == kTestNYe);   // nYe
+  CHECK(table.emAb.nOpacities == TestNOpacities);
+  CHECK(table.emAb.dimensions[0] == TestNE);    // nE
+  CHECK(table.emAb.dimensions[1] == TestNRho);  // nRho
+  CHECK(table.emAb.dimensions[2] == TestNT);    // nT
+  CHECK(table.emAb.dimensions[3] == TestNYe);   // nYe
 
   CHECK(table.emAb.names[0] == "Electron Neutrino");
   CHECK(table.emAb.names[1] == "Electron Antineutrino");
@@ -567,10 +534,11 @@ TEST_CASE("LoadWeakLibOpacityTableFull loads EmAb table", "[hdf5][weaklib][opaci
 
 TEST_CASE("LoadWeakLibOpacityTableFull loads Iso table", "[hdf5][weaklib][opacity]")
 {
-  constexpr double kIsoNuBase = 100000.0;
-  constexpr double kIsoNuBarBase = 200000.0;
+  using namespace WeakLibReader;
+  constexpr double IsoNuBase = 100000.0;
+  constexpr double IsoNuBarBase = 200000.0;
 
-  EnsureAmrexInitialized();
+  AmrexGuard amrex{};
   const std::filesystem::path filePath =
       std::filesystem::temp_directory_path() / "weaklibreader_opacity_iso_full.h5";
   CreateWeakLibIsoTestFile(filePath);
@@ -583,13 +551,13 @@ TEST_CASE("LoadWeakLibOpacityTableFull loads Iso table", "[hdf5][weaklib][opacit
   REQUIRE(status == Hdf5LoadStatus::Success);
   REQUIRE(table.HasScatIso());
 
-  CHECK(table.scatIso.nOpacities == kTestNOpacities);
-  CHECK(table.scatIso.nMoments == kTestNMoments);
-  CHECK(table.scatIso.dimensions[0] == kTestNE);    // nE
-  CHECK(table.scatIso.dimensions[1] == kTestNMoments);  // nMom
-  CHECK(table.scatIso.dimensions[2] == kTestNRho);  // nRho
-  CHECK(table.scatIso.dimensions[3] == kTestNT);    // nT
-  CHECK(table.scatIso.dimensions[4] == kTestNYe);   // nYe
+  CHECK(table.scatIso.nOpacities == TestNOpacities);
+  CHECK(table.scatIso.nMoments == TestNMoments);
+  CHECK(table.scatIso.dimensions[0] == TestNE);    // nE
+  CHECK(table.scatIso.dimensions[1] == TestNMoments);  // nMom
+  CHECK(table.scatIso.dimensions[2] == TestNRho);  // nRho
+  CHECK(table.scatIso.dimensions[3] == TestNT);    // nT
+  CHECK(table.scatIso.dimensions[4] == TestNYe);   // nYe
 
   const double* nuData = table.scatIso.KernelData(0);
   const double* nuBarData = table.scatIso.KernelData(1);
@@ -598,18 +566,19 @@ TEST_CASE("LoadWeakLibOpacityTableFull loads Iso table", "[hdf5][weaklib][opacit
 
   const auto& layout = table.scatIso.layout;
   CHECK(nuData[layout.Offset(0, 0, 0, 0, 0)] ==
-        Catch::Approx(Encode5dIndexValue(0, 0, 0, 0, 0, kIsoNuBase)));
+        Catch::Approx(Encode5dIndexValue(0, 0, 0, 0, 0, IsoNuBase)));
   CHECK(nuData[layout.Offset(3, 1, 1, 2, 1)] ==
-        Catch::Approx(Encode5dIndexValue(3, 1, 1, 2, 1, kIsoNuBase)));
+        Catch::Approx(Encode5dIndexValue(3, 1, 1, 2, 1, IsoNuBase)));
   CHECK(nuBarData[layout.Offset(2, 0, 1, 1, 1)] ==
-        Catch::Approx(Encode5dIndexValue(2, 0, 1, 1, 1, kIsoNuBarBase)));
+        Catch::Approx(Encode5dIndexValue(2, 0, 1, 1, 1, IsoNuBarBase)));
 }
 
 TEST_CASE("LoadWeakLibOpacityTableFull loads NES table", "[hdf5][weaklib][opacity]")
 {
-  constexpr double kNesBase = 300000.0;
+  using namespace WeakLibReader;
+  constexpr double NesBase = 300000.0;
 
-  EnsureAmrexInitialized();
+  AmrexGuard amrex{};
   const std::filesystem::path filePath =
       std::filesystem::temp_directory_path() / "weaklibreader_opacity_nes_full.h5";
   CreateWeakLibNESTestFile(filePath);
@@ -623,31 +592,32 @@ TEST_CASE("LoadWeakLibOpacityTableFull loads NES table", "[hdf5][weaklib][opacit
   REQUIRE(table.HasScatNES());
 
   // Check EtaGrid was loaded
-  CHECK(table.etaGrid.nPoints == kTestNEta);
+  CHECK(table.etaGrid.nPoints == TestNEta);
 
   CHECK(table.scatNES.nOpacities == 1);
   CHECK(table.scatNES.nMoments == 2);
-  CHECK(table.scatNES.dimensions[0] == kTestNE);    // nE_in
-  CHECK(table.scatNES.dimensions[1] == kTestNE);    // nE_out
+  CHECK(table.scatNES.dimensions[0] == TestNE);    // nE_in
+  CHECK(table.scatNES.dimensions[1] == TestNE);    // nE_out
   CHECK(table.scatNES.dimensions[2] == 2);          // nMom
-  CHECK(table.scatNES.dimensions[3] == kTestNT);    // nT
-  CHECK(table.scatNES.dimensions[4] == kTestNEta);  // nEta
+  CHECK(table.scatNES.dimensions[3] == TestNT);    // nT
+  CHECK(table.scatNES.dimensions[4] == TestNEta);  // nEta
 
   const double* kernel = table.scatNES.KernelData();
   REQUIRE(kernel != nullptr);
 
   const auto& layout = table.scatNES.layout;
   CHECK(kernel[layout.Offset(0, 0, 0, 0, 0)] ==
-        Catch::Approx(Encode5dIndexValue(0, 0, 0, 0, 0, kNesBase)));
+        Catch::Approx(Encode5dIndexValue(0, 0, 0, 0, 0, NesBase)));
   CHECK(kernel[layout.Offset(3, 2, 1, 2, 2)] ==
-        Catch::Approx(Encode5dIndexValue(3, 2, 1, 2, 2, kNesBase)));
+        Catch::Approx(Encode5dIndexValue(3, 2, 1, 2, 2, NesBase)));
 }
 
 TEST_CASE("LoadWeakLibOpacityTableFull loads Pair table", "[hdf5][weaklib][opacity]")
 {
-  constexpr double kPairBase = 400000.0;
+  using namespace WeakLibReader;
+  constexpr double PairBase = 400000.0;
 
-  EnsureAmrexInitialized();
+  AmrexGuard amrex{};
   const std::filesystem::path filePath =
       std::filesystem::temp_directory_path() / "weaklibreader_opacity_pair_full.h5";
   CreateWeakLibPairTestFile(filePath);
@@ -668,16 +638,17 @@ TEST_CASE("LoadWeakLibOpacityTableFull loads Pair table", "[hdf5][weaklib][opaci
 
   const auto& layout = table.scatPair.layout;
   CHECK(kernel[layout.Offset(1, 0, 0, 0, 0)] ==
-        Catch::Approx(Encode5dIndexValue(1, 0, 0, 0, 0, kPairBase)));
+        Catch::Approx(Encode5dIndexValue(1, 0, 0, 0, 0, PairBase)));
   CHECK(kernel[layout.Offset(3, 3, 1, 2, 2)] ==
-        Catch::Approx(Encode5dIndexValue(3, 3, 1, 2, 2, kPairBase)));
+        Catch::Approx(Encode5dIndexValue(3, 3, 1, 2, 2, PairBase)));
 }
 
 TEST_CASE("LoadWeakLibOpacityTableFull loads Brem table", "[hdf5][weaklib][opacity]")
 {
-  constexpr double kBremBase = 500000.0;
+  using namespace WeakLibReader;
+  constexpr double BremBase = 500000.0;
 
-  EnsureAmrexInitialized();
+  AmrexGuard amrex{};
   const std::filesystem::path filePath =
       std::filesystem::temp_directory_path() / "weaklibreader_opacity_brem_full.h5";
   CreateWeakLibBremTestFile(filePath);
@@ -699,14 +670,15 @@ TEST_CASE("LoadWeakLibOpacityTableFull loads Brem table", "[hdf5][weaklib][opaci
 
   const auto& layout = table.scatBrem.layout;
   CHECK(kernel[layout.Offset(0, 0, 0, 0, 0)] ==
-        Catch::Approx(Encode5dIndexValue(0, 0, 0, 0, 0, kBremBase)));
+        Catch::Approx(Encode5dIndexValue(0, 0, 0, 0, 0, BremBase)));
   CHECK(kernel[layout.Offset(3, 1, 0, 1, 2)] ==
-        Catch::Approx(Encode5dIndexValue(3, 1, 0, 1, 2, kBremBase)));
+        Catch::Approx(Encode5dIndexValue(3, 1, 0, 1, 2, BremBase)));
 }
 
 TEST_CASE("LoadWeakLibOpacityTableFull loads multiple types", "[hdf5][weaklib][opacity]")
 {
-  EnsureAmrexInitialized();
+  using namespace WeakLibReader;
+  AmrexGuard amrex{};
   const std::filesystem::path emabPath =
       std::filesystem::temp_directory_path() / "weaklibreader_opacity_emab_multi.h5";
   const std::filesystem::path isoPath =
@@ -730,8 +702,9 @@ TEST_CASE("LoadWeakLibOpacityTableFull loads multiple types", "[hdf5][weaklib][o
 
 TEST_CASE("LoadWeakLibOpacityTableFull returns error for missing files", "[hdf5][weaklib][opacity]")
 {
-  EnsureAmrexInitialized();
-  ScopedHdf5ErrorSilencer silencer{};
+  using namespace WeakLibReader;
+  AmrexGuard amrex{};
+  detail::ScopedH5ErrorSuppressor silencer{};
 
   WeakLibOpacityTable table;
   auto status = LoadWeakLibOpacityTableFull(table, "nonexistent.h5");
@@ -741,8 +714,9 @@ TEST_CASE("LoadWeakLibOpacityTableFull returns error for missing files", "[hdf5]
 
 TEST_CASE("LoadWeakLibOpacityTableFull returns error for no files", "[hdf5][weaklib][opacity]")
 {
-  EnsureAmrexInitialized();
-  ScopedHdf5ErrorSilencer silencer{};
+  using namespace WeakLibReader;
+  AmrexGuard amrex{};
+  detail::ScopedH5ErrorSuppressor silencer{};
 
   WeakLibOpacityTable table;
   auto status = LoadWeakLibOpacityTableFull(table);
@@ -752,7 +726,8 @@ TEST_CASE("LoadWeakLibOpacityTableFull returns error for no files", "[hdf5][weak
 
 TEST_CASE("MakeDeviceCopy creates device copy of opacity table", "[hdf5][weaklib][opacity][gpu]")
 {
-  EnsureAmrexInitialized();
+  using namespace WeakLibReader;
+  AmrexGuard amrex{};
   const std::filesystem::path filePath =
       std::filesystem::temp_directory_path() / "weaklibreader_opacity_emab_device.h5";
   CreateWeakLibEmAbTestFile(filePath);
@@ -774,7 +749,8 @@ TEST_CASE("MakeDeviceCopy creates device copy of opacity table", "[hdf5][weaklib
 TEST_CASE("LoadWeakLibOpacityTableFullParallel loads EmAb and Iso",
           "[weaklib][opacity][parallel]")
 {
-  EnsureAmrexInitialized();
+  using namespace WeakLibReader;
+  AmrexGuard amrex{};
 
   const auto emabPath =
       std::filesystem::temp_directory_path() / "weaklibreader_opacity_emab_parallel.h5";
@@ -881,8 +857,9 @@ TEST_CASE("LoadWeakLibOpacityTableFullParallel loads EmAb and Iso",
 TEST_CASE("LoadWeakLibOpacityTableFullParallel fails for nonexistent file",
           "[weaklib][opacity][parallel]")
 {
-  EnsureAmrexInitialized();
-  ScopedHdf5ErrorSilencer silencer{};
+  using namespace WeakLibReader;
+  AmrexGuard amrex{};
+  detail::ScopedH5ErrorSuppressor silencer{};
 
   WeakLibOpacityTable table;
   auto status = LoadWeakLibOpacityTableFullParallel(table, "nonexistent.h5");


### PR DESCRIPTION
## Summary
- **Test infrastructure**: Unify AMReX initialization to shared `GlobalAmrexGuard`/`AmrexGuard` pattern, replace duplicate `ScopedHdf5ErrorSilencer` with production `ScopedH5ErrorSuppressor`, add shared `test_main.cpp` and `test_amrex_guard.hpp`
- **Namespace hygiene**: Move `using namespace WeakLibReader` from file-scope to per-test-case in all test files
- **Constant naming**: Rename all `k`-prefixed constants to PascalCase (`kTol`→`Tol`, `kNumSpecies`→`NumSpecies`, etc.) across production and test code
- **GPU annotation**: Add `AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE` to `detail::StoreSymmetric`
- **Missing macro**: Add `SIMPLE_CATCH_NO_MAIN` to `test_log_interpolate_2d.cpp`

## Test plan
- [x] `scripts/check.sh` passes (full build + all 11 test files)
- [x] No `EnsureAmrexInitialized` remains in codebase
- [x] No `ScopedHdf5ErrorSilencer` remains in test files
- [x] All test files define `SIMPLE_CATCH_NO_MAIN`
- [x] No `k`-prefixed constant definitions remain
- [x] `StoreSymmetric` has GPU annotation