### PR TITLE
Refactor HDF5 axis-reading logic into shared helper ReadAxisDataset1D

### DIFF
--- a/src/hdf5/WeakLibReader_Hdf5LoaderDetail.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5LoaderDetail.hpp
@@ -471,6 +471,46 @@ inline std::size_t ComputeTotalSize(int nd, const std::array<int, 5>& extents)
   return size;
 }
 
+inline Hdf5LoadStatus ReadAxisDataset1D(hid_t datasetId,
+                                        int expectedExtent,
+                                        AxisScale scale,
+                                        amrex::Vector<double>& storage,
+                                        Axis& outAxis)
+{
+  ScopedHandle space(H5Dget_space(datasetId), H5Sclose);
+  if (!space.Valid()) {
+    return Hdf5LoadStatus::AxisReadFailed;
+  }
+
+  const int rank = H5Sget_simple_extent_ndims(space.Get());
+  if (rank != 1) {
+    return Hdf5LoadStatus::AxisReadFailed;
+  }
+
+  hsize_t length = 0;
+  if (H5Sget_simple_extent_dims(space.Get(), &length, nullptr) < 0) {
+    return Hdf5LoadStatus::AxisReadFailed;
+  }
+  if (length != static_cast<hsize_t>(expectedExtent)) {
+    return Hdf5LoadStatus::AxisExtentMismatch;
+  }
+
+  storage.resize(static_cast<std::size_t>(length));
+  if (H5Dread(datasetId, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+              storage.data()) < 0) {
+    return Hdf5LoadStatus::AxisReadFailed;
+  }
+
+  if (!ValidateAxis(storage, scale)) {
+    return Hdf5LoadStatus::AxisNotMonotone;
+  }
+
+  outAxis.grid = storage.data();
+  outAxis.n = static_cast<int>(storage.size());
+  outAxis.scale = scale;
+  return Hdf5LoadStatus::Success;
+}
+
 inline Hdf5LoadStatus LoadAxes(hid_t file,
                                int nd,
                                const Hdf5LoadConfig& cfg,
@@ -483,32 +523,6 @@ inline Hdf5LoadStatus LoadAxes(hid_t file,
       return Hdf5LoadStatus::AxisDatasetOpenFailed;
     }
 
-    ScopedHandle axisSpace(H5Dget_space(axisDataset.Get()), H5Sclose);
-    if (!axisSpace.Valid()) {
-      return Hdf5LoadStatus::AxisReadFailed;
-    }
-
-    const int rank = H5Sget_simple_extent_ndims(axisSpace.Get());
-    if (rank != 1) {
-      return Hdf5LoadStatus::AxisReadFailed;
-    }
-
-    hsize_t length = 0;
-    if (H5Sget_simple_extent_dims(axisSpace.Get(), &length, nullptr) < 0) {
-      return Hdf5LoadStatus::AxisReadFailed;
-    }
-
-    if (length != static_cast<hsize_t>(table.extents[dim])) {
-      return Hdf5LoadStatus::AxisExtentMismatch;
-    }
-
-    amrex::Vector<double>& storage = table.axisStorage[dim];
-    storage.resize(static_cast<std::size_t>(length));
-    if (H5Dread(axisDataset.Get(), H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT,
-                storage.data()) < 0) {
-      return Hdf5LoadStatus::AxisReadFailed;
-    }
-
     std::string scaleAttr;
     AxisScale scale = AxisScale::Linear;
     if (ReadStringAttribute(axisDataset.Get(), cfg.axisScaleAttribute, scaleAttr)) {
@@ -517,15 +531,12 @@ inline Hdf5LoadStatus LoadAxes(hid_t file,
       }
     }
 
-    if (!ValidateAxis(storage, scale)) {
-      return Hdf5LoadStatus::AxisNotMonotone;
+    const Hdf5LoadStatus axisStatus = ReadAxisDataset1D(
+        axisDataset.Get(), table.extents[dim], scale,
+        table.axisStorage[dim], table.axes[dim]);
+    if (axisStatus != Hdf5LoadStatus::Success) {
+      return axisStatus;
     }
-
-    Axis axis{};
-    axis.grid = storage.data();
-    axis.n = static_cast<int>(storage.size());
-    axis.scale = scale;
-    table.axes[dim] = axis;
   }
 
   for (int dim = nd; dim < 5; ++dim) {
@@ -548,40 +559,7 @@ inline Hdf5LoadStatus LoadWeakLibAxis(hid_t thermoGroup,
     return Hdf5LoadStatus::AxisDatasetOpenFailed;
   }
 
-  ScopedHandle space(H5Dget_space(dataset.Get()), H5Sclose);
-  if (!space.Valid()) {
-    return Hdf5LoadStatus::AxisReadFailed;
-  }
-
-  const int rank = H5Sget_simple_extent_ndims(space.Get());
-  if (rank != 1) {
-    return Hdf5LoadStatus::AxisReadFailed;
-  }
-
-  hsize_t length = 0;
-  if (H5Sget_simple_extent_dims(space.Get(), &length, nullptr) < 0) {
-    return Hdf5LoadStatus::AxisReadFailed;
-  }
-
-  if (static_cast<int>(length) != expectedExtent) {
-    return Hdf5LoadStatus::AxisExtentMismatch;
-  }
-
-  storage.resize(static_cast<std::size_t>(length));
-  if (H5Dread(dataset.Get(), H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT,
-              storage.data()) < 0) {
-    return Hdf5LoadStatus::AxisReadFailed;
-  }
-
-  if (!ValidateAxis(storage, scale)) {
-    return Hdf5LoadStatus::AxisNotMonotone;
-  }
-
-  outAxis.grid = storage.data();
-  outAxis.n = static_cast<int>(storage.size());
-  outAxis.scale = scale;
-
-  return Hdf5LoadStatus::Success;
+  return ReadAxisDataset1D(dataset.Get(), expectedExtent, scale, storage, outAxis);
 }
 
 /// Broadcast a vector of strings from root to all ranks.


### PR DESCRIPTION
### Motivation
- Remove duplicated HDF5 1D axis read/validate/populate logic to improve maintainability and reduce copy/paste.
- Centralize dataspace/rank/extent/read/validation semantics so future changes (error handling, logging) apply in one place.
- Make `LoadAxes` and `LoadWeakLibAxis` share the same, well-tested path for creating `Axis` objects.

### Description
- Added a new helper `ReadAxisDataset1D(...)` in `src/hdf5/WeakLibReader_Hdf5LoaderDetail.hpp` that encapsulates dataspace open, rank check, extent validation, `H5Dread` into an `amrex::Vector<double>`, axis monotonicity validation, and `Axis` population.
- Rewrote `LoadAxes(...)` to call `ReadAxisDataset1D(...)` for each axis and to preserve reading the axis scale attribute via `ReadStringAttribute` + `ParseAxisScale` before reading axis values.
- Rewrote `LoadWeakLibAxis(...)` to open the dataset and forward to `ReadAxisDataset1D(...)`, removing its duplicated interior logic.
- Preserved original `Hdf5LoadStatus` semantics and return codes (no intended behavioral changes), and reduced ~70 lines of duplicated code.

### Testing
- Attempted to configure the project with `cmake -S . -B build`, but configuration failed because the system HDF5 C package was not found, so no build artifacts were produced.
- `scripts/build.sh` and `scripts/test.sh` were attempted but failed because the build directory was not configured due to the missing HDF5 dependency.
- No unit tests were executed in this environment; changes were committed locally with message `refactor hdf5 axis dataset read path`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991eccf5968832595b0c5482bb94a4a)