### PR TITLE
refactor: unify test infrastructure, constant naming, and GPU annotations

### DIFF
--- a/cactus_interface/TestWeakLibReader/src/testweaklibreader_eos.cxx
+++ b/cactus_interface/TestWeakLibReader/src/testweaklibreader_eos.cxx
@@ -9,24 +9,12 @@
 #include <interp/WeakLibReader_EosInversion.hpp>
 #include <interp/WeakLibReader_LogInterpolate.hpp>
 
+#include "testweaklibreader_helpers.hxx"
+
 namespace TestWeakLibReader {
 
 WeakLibReader::WeakLibEosTableDevice eos_table_device;
 WeakLibReader::EosInversionBounds eos_inversion_bounds;
-
-// Map a coordinate t in [0,1) to the physical range of the given axis.
-// For Log10 axes the mapping is uniform in log-space.
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-double RescaleToAxis(double t, const WeakLibReader::Axis& axis) noexcept
-{
-  const double lo = axis.grid[0];
-  const double hi = axis.grid[axis.n - 1];
-  if (axis.scale == WeakLibReader::AxisScale::Log10) {
-    return lo * WeakLibReader::math::Pow10(
-        WeakLibReader::math::Log10(hi / lo) * t);
-  }
-  return lo + (hi - lo) * t;
-}
 
 extern "C" void TestWeakLibReader_LoadTable(CCTK_ARGUMENTS) {
   DECLARE_CCTK_PARAMETERS;

--- a/cactus_interface/TestWeakLibReader/src/testweaklibreader_helpers.hxx
+++ b/cactus_interface/TestWeakLibReader/src/testweaklibreader_helpers.hxx
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <base/WeakLibReader_AxisTypes.hpp>
+#include <base/WeakLibReader_Math.hpp>
+
+namespace TestWeakLibReader {
+
+// Map a coordinate t in [0,1) to the physical range of the given axis.
+// For Log10 axes the mapping is uniform in log-space.
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+double RescaleToAxis(double t, const WeakLibReader::Axis& axis) noexcept
+{
+  const double lo = axis.grid[0];
+  const double hi = axis.grid[axis.n - 1];
+  if (axis.scale == WeakLibReader::AxisScale::Log10) {
+    return lo * WeakLibReader::math::Pow10(
+        WeakLibReader::math::Log10(hi / lo) * t);
+  }
+  return lo + (hi - lo) * t;
+}
+
+} // namespace TestWeakLibReader

--- a/cactus_interface/TestWeakLibReader/src/testweaklibreader_opacity.cxx
+++ b/cactus_interface/TestWeakLibReader/src/testweaklibreader_opacity.cxx
@@ -8,6 +8,8 @@
 #include <hdf5/WeakLibReader_Hdf5Loader.hpp>
 #include <interp/WeakLibReader_LogInterpolate.hpp>
 
+#include "testweaklibreader_helpers.hxx"
+
 namespace TestWeakLibReader {
 
 WeakLibReader::WeakLibOpacityTableDevice opacity_table_device;
@@ -30,20 +32,6 @@ struct AlignedKernel {
 std::vector<AlignedKernel> nes_aligned;
 std::vector<AlignedKernel> pair_aligned;
 std::vector<AlignedKernel> brem_aligned;
-
-// Map a coordinate t in [0,1) to the physical range of the given axis.
-// For Log10 axes the mapping is uniform in log-space.
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-double RescaleToAxis(double t, const WeakLibReader::Axis& axis) noexcept
-{
-  const double lo = axis.grid[0];
-  const double hi = axis.grid[axis.n - 1];
-  if (axis.scale == WeakLibReader::AxisScale::Log10) {
-    return lo * WeakLibReader::math::Pow10(
-        WeakLibReader::math::Log10(hi / lo) * t);
-  }
-  return lo + (hi - lo) * t;
-}
 
 extern "C" void TestWeakLibReader_LoadOpacityTable(CCTK_ARGUMENTS) {
   DECLARE_CCTK_PARAMETERS;

--- a/src/base/WeakLibReader_Math.hpp
+++ b/src/base/WeakLibReader_Math.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <AMReX_GpuQualifiers.H>
+
 #include <cmath>
 
 namespace WeakLibReader {

--- a/src/hdf5/WeakLibReader_Hdf5LoaderDetail.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5LoaderDetail.hpp
@@ -288,10 +288,10 @@ inline bool ReadStringArray(hid_t parent, const char* name, std::vector<std::str
   return true;
 }
 
-template <int Rank>
+template <int ND>
 inline bool OpenWeakLibDataset(hid_t parent, const char* name,
                                ScopedHandle& dataset,
-                               std::array<hsize_t, Rank>& fileDims)
+                               std::array<hsize_t, ND>& fileDims)
 {
   if (parent < 0) {
     return false;
@@ -308,53 +308,53 @@ inline bool OpenWeakLibDataset(hid_t parent, const char* name,
   }
 
   const int rank = H5Sget_simple_extent_ndims(dataspace.Get());
-  if (rank != Rank) {
+  if (rank != ND) {
     return false;
   }
 
-  hsize_t dims[Rank] = {};
+  hsize_t dims[ND] = {};
   if (H5Sget_simple_extent_dims(dataspace.Get(), dims, nullptr) < 0) {
     return false;
   }
 
-  for (int i = 0; i < Rank; ++i) {
+  for (int i = 0; i < ND; ++i) {
     fileDims[i] = dims[i];
   }
   return true;
 }
 
-template <int Rank>
-inline bool ValidateFortranDims(const std::array<hsize_t, Rank>& fileDims,
-                                const std::array<int, Rank>& expectedDims)
+template <int ND>
+inline bool ValidateFortranDims(const std::array<hsize_t, ND>& fileDims,
+                                const std::array<int, ND>& expectedDims)
 {
-  for (int i = 0; i < Rank; ++i) {
+  for (int i = 0; i < ND; ++i) {
     if (expectedDims[i] <= 0) {
       return false;
     }
-    if (static_cast<int>(fileDims[i]) != expectedDims[Rank - 1 - i]) {
+    if (static_cast<int>(fileDims[i]) != expectedDims[ND - 1 - i]) {
       return false;
     }
   }
   return true;
 }
 
-template <typename Container, typename T, int Rank>
+template <typename Container, typename T, int ND>
 bool ReadWeakLibArrayNdImpl(hid_t parent, const char* name,
                              Container& output,
-                             const std::array<int, Rank>& expectedDims)
+                             const std::array<int, ND>& expectedDims)
 {
   ScopedHandle dataset;
-  std::array<hsize_t, Rank> fileDims{};
-  if (!OpenWeakLibDataset<Rank>(parent, name, dataset, fileDims)) {
+  std::array<hsize_t, ND> fileDims{};
+  if (!OpenWeakLibDataset<ND>(parent, name, dataset, fileDims)) {
     return false;
   }
 
-  if (!ValidateFortranDims<Rank>(fileDims, expectedDims)) {
+  if (!ValidateFortranDims<ND>(fileDims, expectedDims)) {
     return false;
   }
 
   std::size_t totalSize = 1;
-  for (int i = 0; i < Rank; ++i) {
+  for (int i = 0; i < ND; ++i) {
     totalSize *= static_cast<std::size_t>(expectedDims[i]);
   }
   output.resize(totalSize);
@@ -368,12 +368,12 @@ bool ReadWeakLibArrayNdImpl(hid_t parent, const char* name,
   return true;
 }
 
-template <typename T, int Rank>
+template <typename T, int ND>
 bool ReadWeakLibArrayNd(hid_t parent, const char* name,
                         amrex::Gpu::PinnedVector<T>& output,
-                        const std::array<int, Rank>& expectedDims)
+                        const std::array<int, ND>& expectedDims)
 {
-  return ReadWeakLibArrayNdImpl<amrex::Gpu::PinnedVector<T>, T, Rank>(
+  return ReadWeakLibArrayNdImpl<amrex::Gpu::PinnedVector<T>, T, ND>(
       parent, name, output, expectedDims);
 }
 

--- a/src/hdf5/WeakLibReader_Hdf5LoaderEos.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5LoaderEos.hpp
@@ -138,49 +138,49 @@ inline Hdf5LoadStatus LoadWeakLibEosTableFull(const std::string& filePath,
   }
 
   // Read index mappings
-  auto readIndex = [&](const char* name, int& idx) -> bool {
+  auto ReadIndex = [&](const char* name, int& idx) -> bool {
     return detail::ReadScalarInt(dvGroup.Get(), name, idx);
   };
 
-  if (!readIndex("iPressure", result.indices.iPressure) ||
-      !readIndex("iEntropyPerBaryon", result.indices.iEntropyPerBaryon) ||
-      !readIndex("iInternalEnergyDensity", result.indices.iInternalEnergyDensity) ||
-      !readIndex("iElectronChemicalPotential", result.indices.iElectronChemicalPotential) ||
-      !readIndex("iProtonChemicalPotential", result.indices.iProtonChemicalPotential) ||
-      !readIndex("iNeutronChemicalPotential", result.indices.iNeutronChemicalPotential) ||
-      !readIndex("iProtonMassFraction", result.indices.iProtonMassFraction) ||
-      !readIndex("iNeutronMassFraction", result.indices.iNeutronMassFraction) ||
-      !readIndex("iAlphaMassFraction", result.indices.iAlphaMassFraction) ||
-      !readIndex("iHeavyMassFraction", result.indices.iHeavyMassFraction) ||
-      !readIndex("iHeavyChargeNumber", result.indices.iHeavyChargeNumber) ||
-      !readIndex("iHeavyMassNumber", result.indices.iHeavyMassNumber) ||
-      !readIndex("iHeavyBindingEnergy", result.indices.iHeavyBindingEnergy) ||
-      !readIndex("iThermalEnergy", result.indices.iThermalEnergy) ||
-      !readIndex("iGamma1", result.indices.iGamma1)) {
+  if (!ReadIndex("iPressure", result.indices.iPressure) ||
+      !ReadIndex("iEntropyPerBaryon", result.indices.iEntropyPerBaryon) ||
+      !ReadIndex("iInternalEnergyDensity", result.indices.iInternalEnergyDensity) ||
+      !ReadIndex("iElectronChemicalPotential", result.indices.iElectronChemicalPotential) ||
+      !ReadIndex("iProtonChemicalPotential", result.indices.iProtonChemicalPotential) ||
+      !ReadIndex("iNeutronChemicalPotential", result.indices.iNeutronChemicalPotential) ||
+      !ReadIndex("iProtonMassFraction", result.indices.iProtonMassFraction) ||
+      !ReadIndex("iNeutronMassFraction", result.indices.iNeutronMassFraction) ||
+      !ReadIndex("iAlphaMassFraction", result.indices.iAlphaMassFraction) ||
+      !ReadIndex("iHeavyMassFraction", result.indices.iHeavyMassFraction) ||
+      !ReadIndex("iHeavyChargeNumber", result.indices.iHeavyChargeNumber) ||
+      !ReadIndex("iHeavyMassNumber", result.indices.iHeavyMassNumber) ||
+      !ReadIndex("iHeavyBindingEnergy", result.indices.iHeavyBindingEnergy) ||
+      !ReadIndex("iThermalEnergy", result.indices.iThermalEnergy) ||
+      !ReadIndex("iGamma1", result.indices.iGamma1)) {
     return Hdf5LoadStatus::DatasetReadFailed;
   }
 
   // Fortran indices are 1-based; normalize to 0-based for C++ access.
-  auto normalizeIndex = [](int& idx) {
+  auto NormalizeIndex = [](int& idx) {
     if (idx > 0) {
       --idx;
     }
   };
-  normalizeIndex(result.indices.iPressure);
-  normalizeIndex(result.indices.iEntropyPerBaryon);
-  normalizeIndex(result.indices.iInternalEnergyDensity);
-  normalizeIndex(result.indices.iElectronChemicalPotential);
-  normalizeIndex(result.indices.iProtonChemicalPotential);
-  normalizeIndex(result.indices.iNeutronChemicalPotential);
-  normalizeIndex(result.indices.iProtonMassFraction);
-  normalizeIndex(result.indices.iNeutronMassFraction);
-  normalizeIndex(result.indices.iAlphaMassFraction);
-  normalizeIndex(result.indices.iHeavyMassFraction);
-  normalizeIndex(result.indices.iHeavyChargeNumber);
-  normalizeIndex(result.indices.iHeavyMassNumber);
-  normalizeIndex(result.indices.iHeavyBindingEnergy);
-  normalizeIndex(result.indices.iThermalEnergy);
-  normalizeIndex(result.indices.iGamma1);
+  NormalizeIndex(result.indices.iPressure);
+  NormalizeIndex(result.indices.iEntropyPerBaryon);
+  NormalizeIndex(result.indices.iInternalEnergyDensity);
+  NormalizeIndex(result.indices.iElectronChemicalPotential);
+  NormalizeIndex(result.indices.iProtonChemicalPotential);
+  NormalizeIndex(result.indices.iNeutronChemicalPotential);
+  NormalizeIndex(result.indices.iProtonMassFraction);
+  NormalizeIndex(result.indices.iNeutronMassFraction);
+  NormalizeIndex(result.indices.iAlphaMassFraction);
+  NormalizeIndex(result.indices.iHeavyMassFraction);
+  NormalizeIndex(result.indices.iHeavyChargeNumber);
+  NormalizeIndex(result.indices.iHeavyMassNumber);
+  NormalizeIndex(result.indices.iHeavyBindingEnergy);
+  NormalizeIndex(result.indices.iThermalEnergy);
+  NormalizeIndex(result.indices.iGamma1);
 
   // Compute layout for interpolation
   std::array<int, 5> extents5{{result.dimensions[0], result.dimensions[1], result.dimensions[2], 1, 1}};

--- a/src/interp/WeakLibReader_EosInversion.hpp
+++ b/src/interp/WeakLibReader_EosInversion.hpp
@@ -44,7 +44,7 @@ inline EosInversionBounds InitializeEosInversionBounds(
   bounds.maxY = axes[2].grid[axes[2].n - 1];
 
   // Scan variable data for min/max in physical space
-  auto scanMinMax = [totalSize](const double* data, double offset,
+  auto ScanMinMax = [totalSize](const double* data, double offset,
                                 double& minVal, double& maxVal) {
     if (data == nullptr) {
       minVal = 0.0;
@@ -62,9 +62,9 @@ inline EosInversionBounds InitializeEosInversionBounds(
     maxVal = hi;
   };
 
-  scanMinMax(energyData,   energyOffset,   bounds.minE, bounds.maxE);
-  scanMinMax(pressureData, pressureOffset, bounds.minP, bounds.maxP);
-  scanMinMax(entropyData,  entropyOffset,  bounds.minS, bounds.maxS);
+  ScanMinMax(energyData,   energyOffset,   bounds.minE, bounds.maxE);
+  ScanMinMax(pressureData, pressureOffset, bounds.minP, bounds.maxP);
+  ScanMinMax(entropyData,  entropyOffset,  bounds.minS, bounds.maxS);
 
   return bounds;
 }

--- a/src/interp/WeakLibReader_LogInterpolateCore.hpp
+++ b/src/interp/WeakLibReader_LogInterpolateCore.hpp
@@ -2,6 +2,7 @@
 
 #include <AMReX_BLassert.H>
 #include <AMReX_GpuQualifiers.H>
+
 #include <cstddef>
 
 #include "interp/WeakLibReader_InterpLogTable.hpp"

--- a/test/include/test_hdf5_helpers.hpp
+++ b/test/include/test_hdf5_helpers.hpp
@@ -1,0 +1,204 @@
+#pragma once
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <hdf5.h>
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace TestHelpers {
+
+inline void WriteStringAttribute(hid_t parent, const std::string& name, const char* value)
+{
+  hid_t type = H5Tcopy(H5T_C_S1);
+  H5Tset_size(type, std::strlen(value));
+  H5Tset_strpad(type, H5T_STR_NULLTERM);
+
+  hid_t space = H5Screate(H5S_SCALAR);
+  hid_t attr = H5Acreate(parent, name.c_str(), type, space, H5P_DEFAULT, H5P_DEFAULT);
+  H5Awrite(attr, type, value);
+  H5Aclose(attr);
+  H5Sclose(space);
+  H5Tclose(type);
+}
+
+inline void WriteIntArrayDataset(hid_t parent,
+                                  const std::string& name,
+                                  const std::vector<int>& values)
+{
+  const hsize_t dims = static_cast<hsize_t>(values.size());
+  hid_t space = H5Screate_simple(1, &dims, nullptr);
+  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_NATIVE_INT, space,
+                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  REQUIRE(dataset >= 0);
+  H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
+  H5Dclose(dataset);
+  H5Sclose(space);
+}
+
+inline void WriteDoubleArrayDataset(hid_t parent,
+                                     const std::string& name,
+                                     const std::vector<double>& values)
+{
+  const hsize_t dims = static_cast<hsize_t>(values.size());
+  hid_t space = H5Screate_simple(1, &dims, nullptr);
+  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_IEEE_F64LE, space,
+                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  REQUIRE(dataset >= 0);
+  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
+  H5Dclose(dataset);
+  H5Sclose(space);
+}
+
+inline void WriteStringArrayDataset(hid_t parent,
+                                     const std::string& name,
+                                     const std::vector<std::string>& values)
+{
+  const hsize_t dims = static_cast<hsize_t>(values.size());
+  hid_t space = H5Screate_simple(1, &dims, nullptr);
+
+  std::size_t maxLen = 1;
+  for (const auto& value : values) {
+    maxLen = std::max(maxLen, value.size());
+  }
+  const std::size_t stride = maxLen + 1;
+
+  hid_t type = H5Tcopy(H5T_C_S1);
+  H5Tset_size(type, stride);
+  H5Tset_strpad(type, H5T_STR_NULLTERM);
+
+  hid_t dataset = H5Dcreate(parent, name.c_str(), type, space,
+                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  REQUIRE(dataset >= 0);
+
+  std::vector<char> buffer(values.size() * stride, '\0');
+  for (std::size_t i = 0; i < values.size(); ++i) {
+    std::memcpy(buffer.data() + i * stride, values[i].c_str(), values[i].size());
+  }
+
+  H5Dwrite(dataset, type, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer.data());
+  H5Dclose(dataset);
+  H5Sclose(space);
+  H5Tclose(type);
+}
+
+inline void WriteDoubleArray2dDataset(hid_t parent,
+                                       const std::string& name,
+                                       const std::array<hsize_t, 2>& dims,
+                                       const std::vector<double>& values)
+{
+  hid_t space = H5Screate_simple(2, dims.data(), nullptr);
+  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_IEEE_F64LE, space,
+                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  REQUIRE(dataset >= 0);
+  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
+  H5Dclose(dataset);
+  H5Sclose(space);
+}
+
+inline void WriteDoubleArray3dDataset(hid_t parent,
+                                       const std::string& name,
+                                       const std::array<hsize_t, 3>& dims,
+                                       const std::vector<double>& values)
+{
+  hid_t space = H5Screate_simple(3, dims.data(), nullptr);
+  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_IEEE_F64LE, space,
+                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  REQUIRE(dataset >= 0);
+  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
+  H5Dclose(dataset);
+  H5Sclose(space);
+}
+
+inline void WriteIntArray3dDataset(hid_t parent,
+                                    const std::string& name,
+                                    const std::array<hsize_t, 3>& dims,
+                                    const std::vector<int>& values)
+{
+  hid_t space = H5Screate_simple(3, dims.data(), nullptr);
+  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_NATIVE_INT, space,
+                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  REQUIRE(dataset >= 0);
+  H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
+  H5Dclose(dataset);
+  H5Sclose(space);
+}
+
+inline void WriteDoubleArray4dDataset(hid_t parent,
+                                       const std::string& name,
+                                       const std::array<hsize_t, 4>& dims,
+                                       const std::vector<double>& values)
+{
+  hid_t space = H5Screate_simple(4, dims.data(), nullptr);
+  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_IEEE_F64LE, space,
+                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  REQUIRE(dataset >= 0);
+  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
+  H5Dclose(dataset);
+  H5Sclose(space);
+}
+
+inline void WriteDoubleArray5dDataset(hid_t parent,
+                                       const std::string& name,
+                                       const std::array<hsize_t, 5>& dims,
+                                       const std::vector<double>& values)
+{
+  hid_t space = H5Screate_simple(5, dims.data(), nullptr);
+  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_IEEE_F64LE, space,
+                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  REQUIRE(dataset >= 0);
+  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
+  H5Dclose(dataset);
+  H5Sclose(space);
+}
+
+inline void CreateAxisDataset(hid_t file,
+                               const std::string& name,
+                               const std::vector<double>& values,
+                               const char* scale)
+{
+  const hsize_t dims = static_cast<hsize_t>(values.size());
+  hid_t space = H5Screate_simple(1, &dims, nullptr);
+  hid_t dataset = H5Dcreate(file, name.c_str(), H5T_IEEE_F64LE, space,
+                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
+  WriteStringAttribute(dataset, "scale", scale);
+  H5Dclose(dataset);
+  H5Sclose(space);
+}
+
+inline void CreateAxisDataset(hid_t parent, const char* name, const double* values, std::size_t count)
+{
+  const hsize_t dims = static_cast<hsize_t>(count);
+  hid_t space = H5Screate_simple(1, &dims, nullptr);
+  REQUIRE(space >= 0);
+
+  hid_t dataset = H5Dcreate(parent, name, H5T_IEEE_F64LE, space,
+                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  REQUIRE(dataset >= 0);
+  REQUIRE(H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values) >= 0);
+
+  H5Dclose(dataset);
+  H5Sclose(space);
+}
+
+inline void CreateIntDataset(hid_t parent, const char* name, const int* values, std::size_t count)
+{
+  const hsize_t dims = static_cast<hsize_t>(count);
+  hid_t space = H5Screate_simple(1, &dims, nullptr);
+  REQUIRE(space >= 0);
+
+  hid_t dataset = H5Dcreate(parent, name, H5T_STD_I32LE, space,
+                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  REQUIRE(dataset >= 0);
+  REQUIRE(H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, values) >= 0);
+
+  H5Dclose(dataset);
+  H5Sclose(space);
+}
+
+} // namespace TestHelpers

--- a/test/test_hdf5_loader.cpp
+++ b/test/test_hdf5_loader.cpp
@@ -3,49 +3,22 @@
 
 #include "hdf5/WeakLibReader_Hdf5Loader.hpp"
 #include "test_amrex_guard.hpp"
+#include "test_hdf5_helpers.hpp"
 
 #include <AMReX_GpuContainers.H>
 #include <AMReX_GpuDevice.H>
 
 #include <hdf5.h>
 
-#include <cstring>
 #include <filesystem>
 #include <string>
 #include <vector>
 
 namespace {
 
+using namespace TestHelpers;
+
 constexpr double Tol = 1.0e-12;
-
-void WriteStringAttribute(hid_t parent, const std::string& name, const char* value)
-{
-  hid_t type = H5Tcopy(H5T_C_S1);
-  H5Tset_size(type, std::strlen(value));
-  H5Tset_strpad(type, H5T_STR_NULLTERM);
-
-  hid_t space = H5Screate(H5S_SCALAR);
-  hid_t attr = H5Acreate(parent, name.c_str(), type, space, H5P_DEFAULT, H5P_DEFAULT);
-  H5Awrite(attr, type, value);
-  H5Aclose(attr);
-  H5Sclose(space);
-  H5Tclose(type);
-}
-
-void CreateAxisDataset(hid_t file,
-                       const std::string& name,
-                       const std::vector<double>& values,
-                       const char* scale)
-{
-  const hsize_t dims = static_cast<hsize_t>(values.size());
-  hid_t space = H5Screate_simple(1, &dims, nullptr);
-  hid_t dataset = H5Dcreate(file, name.c_str(), H5T_IEEE_F64LE, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
-  WriteStringAttribute(dataset, "scale", scale);
-  H5Dclose(dataset);
-  H5Sclose(space);
-}
 
 } // namespace
 

--- a/test/test_weaklib_eos_loader.cpp
+++ b/test/test_weaklib_eos_loader.cpp
@@ -3,6 +3,7 @@
 
 #include "hdf5/WeakLibReader_Hdf5Loader.hpp"
 #include "test_amrex_guard.hpp"
+#include "test_hdf5_helpers.hpp"
 
 #include <AMReX_GpuContainers.H>
 #include <hdf5.h>
@@ -16,6 +17,8 @@
 
 namespace {
 
+using namespace TestHelpers;
+
 constexpr std::size_t RhoCount = 3;
 constexpr std::size_t TempCount = 2;
 constexpr std::size_t YeCount = 2;
@@ -23,138 +26,6 @@ constexpr std::size_t YeCount = 2;
 const double DensityAxis[RhoCount] = {1.0e3, 1.0e6, 1.0e9};
 const double TemperatureAxis[TempCount] = {0.1, 1.0};
 const double YeAxis[YeCount] = {0.1, 0.3};
-
-void CreateAxisDataset(hid_t parent, const char* name, const double* values, std::size_t count)
-{
-  const hsize_t dims = static_cast<hsize_t>(count);
-  hid_t space = H5Screate_simple(1, &dims, nullptr);
-  REQUIRE(space >= 0);
-
-  hid_t dataset = H5Dcreate(parent, name, H5T_IEEE_F64LE, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-  REQUIRE(H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values) >= 0);
-
-  H5Dclose(dataset);
-  H5Sclose(space);
-}
-
-void CreateIntDataset(hid_t parent, const char* name, const int* values, std::size_t count)
-{
-  const hsize_t dims = static_cast<hsize_t>(count);
-  hid_t space = H5Screate_simple(1, &dims, nullptr);
-  REQUIRE(space >= 0);
-
-  hid_t dataset = H5Dcreate(parent, name, H5T_STD_I32LE, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-  REQUIRE(H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, values) >= 0);
-
-  H5Dclose(dataset);
-  H5Sclose(space);
-}
-
-void WriteStringAttribute(hid_t parent, const std::string& name, const char* value)
-{
-  hid_t type = H5Tcopy(H5T_C_S1);
-  H5Tset_size(type, std::strlen(value));
-  H5Tset_strpad(type, H5T_STR_NULLTERM);
-
-  hid_t space = H5Screate(H5S_SCALAR);
-  hid_t attr = H5Acreate(parent, name.c_str(), type, space, H5P_DEFAULT, H5P_DEFAULT);
-  H5Awrite(attr, type, value);
-  H5Aclose(attr);
-  H5Sclose(space);
-  H5Tclose(type);
-}
-
-void WriteIntArrayDataset(hid_t parent,
-                          const std::string& name,
-                          const std::vector<int>& values)
-{
-  const hsize_t dims = static_cast<hsize_t>(values.size());
-  hid_t space = H5Screate_simple(1, &dims, nullptr);
-  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_NATIVE_INT, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-  H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
-  H5Dclose(dataset);
-  H5Sclose(space);
-}
-
-void WriteDoubleArrayDataset(hid_t parent,
-                             const std::string& name,
-                             const std::vector<double>& values)
-{
-  const hsize_t dims = static_cast<hsize_t>(values.size());
-  hid_t space = H5Screate_simple(1, &dims, nullptr);
-  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_IEEE_F64LE, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
-  H5Dclose(dataset);
-  H5Sclose(space);
-}
-
-void WriteStringArrayDataset(hid_t parent,
-                             const std::string& name,
-                             const std::vector<std::string>& values)
-{
-  const hsize_t dims = static_cast<hsize_t>(values.size());
-  hid_t space = H5Screate_simple(1, &dims, nullptr);
-
-  std::size_t maxLen = 1;
-  for (const auto& value : values) {
-    maxLen = std::max(maxLen, value.size());
-  }
-  const std::size_t stride = maxLen + 1;
-
-  hid_t type = H5Tcopy(H5T_C_S1);
-  H5Tset_size(type, stride);
-  H5Tset_strpad(type, H5T_STR_NULLTERM);
-
-  hid_t dataset = H5Dcreate(parent, name.c_str(), type, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-
-  std::vector<char> buffer(values.size() * stride, '\0');
-  for (std::size_t i = 0; i < values.size(); ++i) {
-    std::memcpy(buffer.data() + i * stride, values[i].c_str(), values[i].size());
-  }
-
-  H5Dwrite(dataset, type, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer.data());
-  H5Dclose(dataset);
-  H5Sclose(space);
-  H5Tclose(type);
-}
-
-void WriteDoubleArray3dDataset(hid_t parent,
-                               const std::string& name,
-                               const std::array<hsize_t, 3>& dims,
-                               const std::vector<double>& values)
-{
-  hid_t space = H5Screate_simple(3, dims.data(), nullptr);
-  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_IEEE_F64LE, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
-  H5Dclose(dataset);
-  H5Sclose(space);
-}
-
-void WriteIntArray3dDataset(hid_t parent,
-                            const std::string& name,
-                            const std::array<hsize_t, 3>& dims,
-                            const std::vector<int>& values)
-{
-  hid_t space = H5Screate_simple(3, dims.data(), nullptr);
-  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_NATIVE_INT, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-  H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
-  H5Dclose(dataset);
-  H5Sclose(space);
-}
 
 void CreateWeakLibEosTestFileFull(const std::filesystem::path& filePath)
 {

--- a/test/test_weaklib_opacity_loader.cpp
+++ b/test/test_weaklib_opacity_loader.cpp
@@ -4,6 +4,7 @@
 #include "hdf5/WeakLibReader_Hdf5Loader.hpp"
 #include "hdf5/WeakLibReader_Hdf5Types.hpp"
 #include "test_amrex_guard.hpp"
+#include "test_hdf5_helpers.hpp"
 
 #include <AMReX_GpuContainers.H>
 #include <hdf5.h>
@@ -17,6 +18,8 @@
 #include <vector>
 
 namespace {
+
+using namespace TestHelpers;
 
 constexpr int TestNE = 4;
 constexpr int TestNRho = 2;
@@ -64,108 +67,6 @@ std::vector<double> BuildFortranOrdered5dData(const std::array<int, 5>& cOrderDi
   }
 
   return data;
-}
-
-void WriteIntArrayDataset(hid_t parent,
-                          const std::string& name,
-                          const std::vector<int>& values)
-{
-  const hsize_t dims = static_cast<hsize_t>(values.size());
-  hid_t space = H5Screate_simple(1, &dims, nullptr);
-  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_NATIVE_INT, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-  H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
-  H5Dclose(dataset);
-  H5Sclose(space);
-}
-
-void WriteDoubleArrayDataset(hid_t parent,
-                             const std::string& name,
-                             const std::vector<double>& values)
-{
-  const hsize_t dims = static_cast<hsize_t>(values.size());
-  hid_t space = H5Screate_simple(1, &dims, nullptr);
-  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_IEEE_F64LE, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
-  H5Dclose(dataset);
-  H5Sclose(space);
-}
-
-void WriteStringArrayDataset(hid_t parent,
-                             const std::string& name,
-                             const std::vector<std::string>& values)
-{
-  const hsize_t dims = static_cast<hsize_t>(values.size());
-  hid_t space = H5Screate_simple(1, &dims, nullptr);
-
-  std::size_t maxLen = 1;
-  for (const auto& value : values) {
-    maxLen = std::max(maxLen, value.size());
-  }
-  const std::size_t stride = maxLen + 1;
-
-  hid_t type = H5Tcopy(H5T_C_S1);
-  H5Tset_size(type, stride);
-  H5Tset_strpad(type, H5T_STR_NULLTERM);
-
-  hid_t dataset = H5Dcreate(parent, name.c_str(), type, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-
-  std::vector<char> buffer(values.size() * stride, '\0');
-  for (std::size_t i = 0; i < values.size(); ++i) {
-    std::memcpy(buffer.data() + i * stride, values[i].c_str(), values[i].size());
-  }
-
-  H5Dwrite(dataset, type, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer.data());
-  H5Dclose(dataset);
-  H5Sclose(space);
-  H5Tclose(type);
-}
-
-void WriteDoubleArray4dDataset(hid_t parent,
-                               const std::string& name,
-                               const std::array<hsize_t, 4>& dims,
-                               const std::vector<double>& values)
-{
-  hid_t space = H5Screate_simple(4, dims.data(), nullptr);
-  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_IEEE_F64LE, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
-  H5Dclose(dataset);
-  H5Sclose(space);
-}
-
-void WriteDoubleArray2dDataset(hid_t parent,
-                               const std::string& name,
-                               const std::array<hsize_t, 2>& dims,
-                               const std::vector<double>& values)
-{
-  hid_t space = H5Screate_simple(2, dims.data(), nullptr);
-  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_IEEE_F64LE, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
-  H5Dclose(dataset);
-  H5Sclose(space);
-}
-
-void WriteDoubleArray5dDataset(hid_t parent,
-                               const std::string& name,
-                               const std::array<hsize_t, 5>& dims,
-                               const std::vector<double>& values)
-{
-  hid_t space = H5Screate_simple(5, dims.data(), nullptr);
-  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_IEEE_F64LE, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
-  H5Dclose(dataset);
-  H5Sclose(space);
 }
 
 void WriteOpacityGridGroup(hid_t file,


### PR DESCRIPTION
## Summary
- Extract duplicated HDF5 test helpers (11 functions) into shared `test/include/test_hdf5_helpers.hpp` (`TestHelpers` namespace), removing copies from 3 test files
- Extract duplicated `RescaleToAxis` into `cactus_interface/TestWeakLibReader/src/testweaklibreader_helpers.hxx` (`TestWeakLibReader` namespace), removing copies from 2 Cactus source files
- Rename camelCase lambdas to PascalCase (`scanMinMax` → `ScanMinMax`, `readIndex` → `ReadIndex`, `normalizeIndex` → `NormalizeIndex`)
- Standardize template parameter `Rank` → `ND` in `WeakLibReader_Hdf5LoaderDetail.hpp` to match project convention
- Add blank-line separators between AMReX and std includes in `WeakLibReader_Math.hpp` and `WeakLibReader_LogInterpolateCore.hpp`

## Test plan
- [x] `scripts/check.sh` passes (build + all tests)
- [ ] Verify no behavioral changes (pure refactor, identical logic)