### PR TITLE
Refactor interpolation scaffolding and opacity loader file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ double result = LogInterpolateSingleVariable3DCustomPoint(
 #### Simple Format (Generic Tables)
 
 ```
-/values              # N-D array (row-major layout)
+/values              # N-D array (column-major layout; stride[0]=1)
 /axis0               # 1D array with "scale" attribute ("linear" or "log10")
 /axis1               # ...
 ```

--- a/src/hdf5/WeakLibReader_Hdf5LoaderOpacityMain.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5LoaderOpacityMain.hpp
@@ -67,6 +67,18 @@ inline Hdf5LoadStatus LoadWeakLibOpacityThermoState(hid_t file,
   return Hdf5LoadStatus::Success;
 }
 
+
+template<typename Loader>
+inline Hdf5LoadStatus WithOpenedOpacityFile(const std::string& path,
+                                            Loader&& loader)
+{
+  ScopedHandle file(H5Fopen(path.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT), H5Fclose);
+  if (!file.Valid()) {
+    return Hdf5LoadStatus::FileOpenFailed;
+  }
+  return loader(file.Get());
+}
+
 } // namespace detail
 
 inline Hdf5LoadStatus LoadWeakLibOpacityTableFull(
@@ -99,34 +111,24 @@ inline Hdf5LoadStatus LoadWeakLibOpacityTableFull(
   else if (hasPair) firstFile = filePair;
   else firstFile = fileBrem;
 
-  // Load EnergyGrid from first file
-  {
-    detail::ScopedHandle file(H5Fopen(firstFile.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT), H5Fclose);
-    if (!file.Valid()) {
-      return Hdf5LoadStatus::FileOpenFailed;
+  // Load EnergyGrid and ThermoState from first file
+  status = detail::WithOpenedOpacityFile(firstFile, [&](hid_t file) {
+    Hdf5LoadStatus rc = detail::LoadWeakLibOpacityGrid(file, "EnergyGrid", result.energyGrid);
+    if (rc != Hdf5LoadStatus::Success) {
+      return rc;
     }
-
-    status = detail::LoadWeakLibOpacityGrid(file.Get(), "EnergyGrid", result.energyGrid);
-    if (status != Hdf5LoadStatus::Success) {
-      return status;
-    }
-
-    // Load ThermoState from first file
-    status = detail::LoadWeakLibOpacityThermoState(file.Get(), result.thermoState);
-    if (status != Hdf5LoadStatus::Success) {
-      return status;
-    }
+    return detail::LoadWeakLibOpacityThermoState(file, result.thermoState);
+  });
+  if (status != Hdf5LoadStatus::Success) {
+    return status;
   }
 
   // Load EtaGrid if NES or Pair files are provided
   if (hasNES || hasPair) {
-    std::string etaFile = hasNES ? fileNES : filePair;
-    detail::ScopedHandle file(H5Fopen(etaFile.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT), H5Fclose);
-    if (!file.Valid()) {
-      return Hdf5LoadStatus::FileOpenFailed;
-    }
-
-    status = detail::LoadWeakLibOpacityGrid(file.Get(), "EtaGrid", result.etaGrid);
+    const std::string etaFile = hasNES ? fileNES : filePair;
+    status = detail::WithOpenedOpacityFile(etaFile, [&](hid_t file) {
+      return detail::LoadWeakLibOpacityGrid(file, "EtaGrid", result.etaGrid);
+    });
     if (status != Hdf5LoadStatus::Success) {
       return status;
     }
@@ -134,12 +136,9 @@ inline Hdf5LoadStatus LoadWeakLibOpacityTableFull(
 
   // Load EmAb
   if (hasEmAb) {
-    detail::ScopedHandle file(H5Fopen(fileEmAb.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT), H5Fclose);
-    if (!file.Valid()) {
-      return Hdf5LoadStatus::FileOpenFailed;
-    }
-
-    status = LoadWeakLibEmAbTable(file.Get(), result.emAb, result.energyGrid, result.thermoState);
+    status = detail::WithOpenedOpacityFile(fileEmAb, [&](hid_t file) {
+      return LoadWeakLibEmAbTable(file, result.emAb, result.energyGrid, result.thermoState);
+    });
     if (status != Hdf5LoadStatus::Success) {
       return status;
     }
@@ -147,12 +146,9 @@ inline Hdf5LoadStatus LoadWeakLibOpacityTableFull(
 
   // Load Iso
   if (hasIso) {
-    detail::ScopedHandle file(H5Fopen(fileIso.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT), H5Fclose);
-    if (!file.Valid()) {
-      return Hdf5LoadStatus::FileOpenFailed;
-    }
-
-    status = LoadWeakLibScatIsoTable(file.Get(), result.scatIso, result.energyGrid, result.thermoState);
+    status = detail::WithOpenedOpacityFile(fileIso, [&](hid_t file) {
+      return LoadWeakLibScatIsoTable(file, result.scatIso, result.energyGrid, result.thermoState);
+    });
     if (status != Hdf5LoadStatus::Success) {
       return status;
     }
@@ -160,12 +156,9 @@ inline Hdf5LoadStatus LoadWeakLibOpacityTableFull(
 
   // Load NES
   if (hasNES) {
-    detail::ScopedHandle file(H5Fopen(fileNES.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT), H5Fclose);
-    if (!file.Valid()) {
-      return Hdf5LoadStatus::FileOpenFailed;
-    }
-
-    status = LoadWeakLibScatNESTable(file.Get(), result.scatNES, result.energyGrid, result.etaGrid, result.thermoState);
+    status = detail::WithOpenedOpacityFile(fileNES, [&](hid_t file) {
+      return LoadWeakLibScatNESTable(file, result.scatNES, result.energyGrid, result.etaGrid, result.thermoState);
+    });
     if (status != Hdf5LoadStatus::Success) {
       return status;
     }
@@ -173,12 +166,9 @@ inline Hdf5LoadStatus LoadWeakLibOpacityTableFull(
 
   // Load Pair
   if (hasPair) {
-    detail::ScopedHandle file(H5Fopen(filePair.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT), H5Fclose);
-    if (!file.Valid()) {
-      return Hdf5LoadStatus::FileOpenFailed;
-    }
-
-    status = LoadWeakLibScatPairTable(file.Get(), result.scatPair, result.energyGrid, result.etaGrid, result.thermoState);
+    status = detail::WithOpenedOpacityFile(filePair, [&](hid_t file) {
+      return LoadWeakLibScatPairTable(file, result.scatPair, result.energyGrid, result.etaGrid, result.thermoState);
+    });
     if (status != Hdf5LoadStatus::Success) {
       return status;
     }
@@ -186,12 +176,9 @@ inline Hdf5LoadStatus LoadWeakLibOpacityTableFull(
 
   // Load Brem
   if (hasBrem) {
-    detail::ScopedHandle file(H5Fopen(fileBrem.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT), H5Fclose);
-    if (!file.Valid()) {
-      return Hdf5LoadStatus::FileOpenFailed;
-    }
-
-    status = LoadWeakLibScatBremTable(file.Get(), result.scatBrem, result.energyGrid, result.thermoState);
+    status = detail::WithOpenedOpacityFile(fileBrem, [&](hid_t file) {
+      return LoadWeakLibScatBremTable(file, result.scatBrem, result.energyGrid, result.thermoState);
+    });
     if (status != Hdf5LoadStatus::Success) {
       return status;
     }

--- a/src/interp/WeakLibReader_LogInterpolateCore.hpp
+++ b/src/interp/WeakLibReader_LogInterpolateCore.hpp
@@ -12,6 +12,32 @@
 namespace WeakLibReader {
 namespace detail {
 
+template<int ND>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+bool AxesAndDataValid(const Axis axes[ND], const double* data) noexcept
+{
+  if (data == nullptr) {
+    return false;
+  }
+  for (int d = 0; d < ND; ++d) {
+    if (axes[d].grid == nullptr) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template<int ND>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+Layout MakeAxisLayout(const Axis axes[ND]) noexcept
+{
+  int extents[ND];
+  for (int d = 0; d < ND; ++d) {
+    extents[d] = axes[d].n;
+  }
+  return MakeLayout(extents, ND);
+}
+
 /// GPU-optimized log-interpolation using compile-time dimension dispatch
 /// @tparam ND Number of dimensions (1-5), known at compile time
 /// @param data Raw data array in column-major order (log10-stored values)
@@ -38,6 +64,17 @@ double LogInterpolatedValueDirect(const double* data,
   return LinearInterpPointDirect<ND>(indices, fractions, offset, data, layout);
 }
 
+template<int ND>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+double LogInterpolatedValueFromAxes(const double* data,
+                                    const Axis axes[ND],
+                                    const double coords[ND],
+                                    double offset) noexcept
+{
+  const Layout layout = MakeAxisLayout<ND>(axes);
+  return LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
+}
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void StoreSymmetric(double* plane, std::size_t size,
                     std::size_t i, std::size_t j,
@@ -47,6 +84,17 @@ void StoreSymmetric(double* plane, std::size_t size,
   plane[idxLower] = value;
   if (i != j) {
     plane[i * size + j] = value;
+  }
+}
+
+template<typename Func>
+AMREX_FORCE_INLINE
+void ForEachSymmetricUpper(std::size_t size, Func&& func) noexcept
+{
+  for (std::size_t j = 0; j < size; ++j) {
+    for (std::size_t i = 0; i <= j; ++i) {
+      func(i, j);
+    }
   }
 }
 

--- a/src/interp/WeakLibReader_LogInterpolateDeriv.hpp
+++ b/src/interp/WeakLibReader_LogInterpolateDeriv.hpp
@@ -16,13 +16,12 @@ inline int LogInterpolateDifferentiateSingleVariable3DCustomPoint(
     double& interpolant,
     double derivatives[3]) noexcept
 {
-  if (data == nullptr ||
-      axes[0].grid == nullptr || axes[1].grid == nullptr || axes[2].grid == nullptr) {
+  constexpr int ND = 3;
+  if (!detail::AxesAndDataValid<ND>(axes, data)) {
     return 1;
   }
 
-  int extents[3] = {axes[0].n, axes[1].n, axes[2].n};
-  const Layout layout = MakeLayout(extents, 3);
+  const Layout layout = detail::MakeAxisLayout<ND>(axes);
 
   detail::LogInterpolateDifferentiateSingleVariable3DCustomPointImpl(
       d, t, y, data, layout, axes, offset, interpolant, derivatives);
@@ -38,14 +37,14 @@ inline int LogInterpolateDifferentiateSingleVariable3DCustom(
     double* interpolants,
     double* derivatives) noexcept
 {
+  constexpr int ND = 3;
   if (d == nullptr || t == nullptr || y == nullptr ||
-      data == nullptr || interpolants == nullptr || derivatives == nullptr ||
-      axes[0].grid == nullptr || axes[1].grid == nullptr || axes[2].grid == nullptr) {
+      interpolants == nullptr || derivatives == nullptr ||
+      !detail::AxesAndDataValid<ND>(axes, data)) {
     return 1;
   }
 
-  int extents[3] = {axes[0].n, axes[1].n, axes[2].n};
-  const Layout layout = MakeLayout(extents, 3);
+  const Layout layout = detail::MakeAxisLayout<ND>(axes);
 
   for (std::size_t i = 0; i < count; ++i) {
     double deriv[3] = {0.0, 0.0, 0.0};
@@ -72,18 +71,17 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustomPoint(
     double* derivativeTPlane,
     double* derivativeXPlane) noexcept
 {
-  if (logE == nullptr || data == nullptr ||
-      interpolantPlane == nullptr || derivativeTPlane == nullptr || derivativeXPlane == nullptr ||
-      axes[0].grid == nullptr || axes[1].grid == nullptr ||
-      axes[2].grid == nullptr || axes[3].grid == nullptr) {
+  constexpr int ND = 4;
+  if (logE == nullptr || interpolantPlane == nullptr ||
+      derivativeTPlane == nullptr || derivativeXPlane == nullptr ||
+      !detail::AxesAndDataValid<ND>(axes, data)) {
     return 1;
   }
   if (sizeE == 0) {
     return 0;
   }
 
-  int extents[4] = {axes[0].n, axes[1].n, axes[2].n, axes[3].n};
-  const Layout layout = MakeLayout(extents, 4);
+  const Layout layout = detail::MakeAxisLayout<ND>(axes);
 
   int idxT = 0;
   int idxX = 0;
@@ -98,34 +96,31 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustomPoint(
   const double aT = 1.0 / (spanT * math::Pow10(logT));
   const double aX = 1.0 / (spanX * math::Pow10(logX));
 
-  for (std::size_t j = 0; j < sizeE; ++j) {
+  detail::ForEachSymmetricUpper(sizeE, [&](std::size_t i, std::size_t j) noexcept {
+    int idxE1 = 0;
     int idxE2 = 0;
+    double fracE1 = 0.0;
     double fracE2 = 0.0;
+    detail::IndexAndDelta(axes[0], logE[i], idxE1, fracE1);
     detail::IndexAndDelta(axes[1], logE[j], idxE2, fracE2);
 
-    for (std::size_t i = 0; i <= j; ++i) {
-      int idxE1 = 0;
-      double fracE1 = 0.0;
-      detail::IndexAndDelta(axes[0], logE[i], idxE1, fracE1);
+    double interpValue = 0.0;
+    double derivE1 = 0.0;
+    double derivE2 = 0.0;
+    double derivTVal = 0.0;
+    double derivXVal = 0.0;
 
-      double interpValue = 0.0;
-      double derivE1 = 0.0;
-      double derivE2 = 0.0;
-      double derivTVal = 0.0;
-      double derivXVal = 0.0;
+    LinearInterpDeriv4DPoint(
+        idxE1, idxE2, idxT, idxX,
+        fracE1, fracE2, fracT, fracX,
+        1.0, 1.0, aT, aX,
+        offset, data, layout,
+        interpValue, derivE1, derivE2, derivTVal, derivXVal);
 
-      LinearInterpDeriv4DPoint(
-          idxE1, idxE2, idxT, idxX,
-          fracE1, fracE2, fracT, fracX,
-          1.0, 1.0, aT, aX,
-          offset, data, layout,
-          interpValue, derivE1, derivE2, derivTVal, derivXVal);
-
-      detail::StoreSymmetric(interpolantPlane, sizeE, i, j, interpValue);
-      detail::StoreSymmetric(derivativeTPlane, sizeE, i, j, derivTVal);
-      detail::StoreSymmetric(derivativeXPlane, sizeE, i, j, derivXVal);
-    }
-  }
+    detail::StoreSymmetric(interpolantPlane, sizeE, i, j, interpValue);
+    detail::StoreSymmetric(derivativeTPlane, sizeE, i, j, derivTVal);
+    detail::StoreSymmetric(derivativeXPlane, sizeE, i, j, derivXVal);
+  });
 
   return 0;
 }
@@ -140,11 +135,10 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustom(
     double* derivativeT,
     double* derivativeX) noexcept
 {
+  constexpr int ND = 4;
   if (logE == nullptr || logT == nullptr || logX == nullptr ||
-      data == nullptr || interpolant == nullptr ||
-      derivativeT == nullptr || derivativeX == nullptr ||
-      axes[0].grid == nullptr || axes[1].grid == nullptr ||
-      axes[2].grid == nullptr || axes[3].grid == nullptr) {
+      interpolant == nullptr || derivativeT == nullptr || derivativeX == nullptr ||
+      !detail::AxesAndDataValid<ND>(axes, data)) {
     return 1;
   }
   if (sizeE == 0 || count == 0) {
@@ -209,26 +203,24 @@ inline int LogInterpolateDifferentiateSingleVariable2D2DCustomAlignedPoint(
   const double aT = 1.0 / (spanT * math::Pow10(logT));
   const double aX = 1.0 / (spanX * math::Pow10(logX));
 
-  for (std::size_t j = 0; j < sizeE; ++j) {
-    for (std::size_t i = 0; i <= j; ++i) {
-      double interpValue = 0.0;
-      double derivTVal = 0.0;
-      double derivXVal = 0.0;
+  detail::ForEachSymmetricUpper(sizeE, [&](std::size_t i, std::size_t j) noexcept {
+    double interpValue = 0.0;
+    double derivTVal = 0.0;
+    double derivXVal = 0.0;
 
-      LinearInterpDeriv2D4DArray2DAlignedPoint(
-          static_cast<int>(i), static_cast<int>(j),
-          idxT, idxX,
-          fracT, fracX,
-          aT, aX,
-          offset,
-          data, layout,
-          interpValue, derivTVal, derivXVal);
+    LinearInterpDeriv2D4DArray2DAlignedPoint(
+        static_cast<int>(i), static_cast<int>(j),
+        idxT, idxX,
+        fracT, fracX,
+        aT, aX,
+        offset,
+        data, layout,
+        interpValue, derivTVal, derivXVal);
 
-      detail::StoreSymmetric(interpolantPlane, sizeE, i, j, interpValue);
-      detail::StoreSymmetric(derivativeTPlane, sizeE, i, j, derivTVal);
-      detail::StoreSymmetric(derivativeXPlane, sizeE, i, j, derivXVal);
-    }
-  }
+    detail::StoreSymmetric(interpolantPlane, sizeE, i, j, interpValue);
+    detail::StoreSymmetric(derivativeTPlane, sizeE, i, j, derivTVal);
+    detail::StoreSymmetric(derivativeXPlane, sizeE, i, j, derivXVal);
+  });
 
   return 0;
 }

--- a/src/interp/WeakLibReader_LogInterpolatePoint.hpp
+++ b/src/interp/WeakLibReader_LogInterpolatePoint.hpp
@@ -17,16 +17,12 @@ double LogInterpolateSingleVariable2DCustomPoint(
     const double* data,
     double offset) noexcept
 {
-  if (data == nullptr || axes[0].grid == nullptr || axes[1].grid == nullptr) {
+  constexpr int ND = 2;
+  if (!detail::AxesAndDataValid<ND>(axes, data)) {
     return std::numeric_limits<double>::quiet_NaN();
   }
-  // Compile-time known dimensionality (eliminates runtime branching!)
-  constexpr int ND = 2;
-  int extents[ND] = {axes[0].n, axes[1].n};
-  const Layout layout = MakeLayout(extents, ND);
-  double coords[ND] = {x0, x1};
-  // Template parameter known at compile time - zero branching!
-  return detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
+  const double coords[ND] = {x0, x1};
+  return detail::LogInterpolatedValueFromAxes<ND>(data, axes, coords, offset);
 }
 
 /// GPU-optimized 2D log-interpolation (batch)
@@ -38,13 +34,12 @@ inline int LogInterpolateSingleVariable2DCustom(
     double offset,
     double* out) noexcept
 {
+  constexpr int ND = 2;
   if (x0 == nullptr || x1 == nullptr || out == nullptr ||
-      data == nullptr || axes[0].grid == nullptr || axes[1].grid == nullptr) {
+      !detail::AxesAndDataValid<ND>(axes, data)) {
     return 1;
   }
-  constexpr int ND = 2;
-  int extents[ND] = {axes[0].n, axes[1].n};
-  const Layout layout = MakeLayout(extents, ND);
+  const Layout layout = detail::MakeAxisLayout<ND>(axes);
   for (std::size_t i = 0; i < count; ++i) {
     double coords[ND] = {x0[i], x1[i]};
     out[i] = detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
@@ -61,15 +56,12 @@ double LogInterpolateSingleVariable3DCustomPoint(
     const double* data,
     double offset) noexcept
 {
-  if (data == nullptr || axes[0].grid == nullptr ||
-      axes[1].grid == nullptr || axes[2].grid == nullptr) {
+  constexpr int ND = 3;
+  if (!detail::AxesAndDataValid<ND>(axes, data)) {
     return std::numeric_limits<double>::quiet_NaN();
   }
-  constexpr int ND = 3;
-  int extents[ND] = {axes[0].n, axes[1].n, axes[2].n};
-  const Layout layout = MakeLayout(extents, ND);
-  double coords[ND] = {x0, x1, x2};
-  return detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
+  const double coords[ND] = {x0, x1, x2};
+  return detail::LogInterpolatedValueFromAxes<ND>(data, axes, coords, offset);
 }
 
 /// GPU-optimized 3D log-interpolation (batch)
@@ -81,14 +73,12 @@ inline int LogInterpolateSingleVariable3DCustom(
     double offset,
     double* out) noexcept
 {
+  constexpr int ND = 3;
   if (x0 == nullptr || x1 == nullptr || x2 == nullptr ||
-      out == nullptr || data == nullptr ||
-      axes[0].grid == nullptr || axes[1].grid == nullptr || axes[2].grid == nullptr) {
+      out == nullptr || !detail::AxesAndDataValid<ND>(axes, data)) {
     return 1;
   }
-  constexpr int ND = 3;
-  int extents[ND] = {axes[0].n, axes[1].n, axes[2].n};
-  const Layout layout = MakeLayout(extents, ND);
+  const Layout layout = detail::MakeAxisLayout<ND>(axes);
   for (std::size_t i = 0; i < count; ++i) {
     double coords[ND] = {x0[i], x1[i], x2[i]};
     out[i] = detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
@@ -105,15 +95,12 @@ double LogInterpolateSingleVariable4DCustomPoint(
     const double* data,
     double offset) noexcept
 {
-  if (data == nullptr || axes[0].grid == nullptr || axes[1].grid == nullptr ||
-      axes[2].grid == nullptr || axes[3].grid == nullptr) {
+  constexpr int ND = 4;
+  if (!detail::AxesAndDataValid<ND>(axes, data)) {
     return std::numeric_limits<double>::quiet_NaN();
   }
-  constexpr int ND = 4;
-  int extents[ND] = {axes[0].n, axes[1].n, axes[2].n, axes[3].n};
-  const Layout layout = MakeLayout(extents, ND);
-  double coords[ND] = {x0, x1, x2, x3};
-  return detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
+  const double coords[ND] = {x0, x1, x2, x3};
+  return detail::LogInterpolatedValueFromAxes<ND>(data, axes, coords, offset);
 }
 
 /// GPU-optimized 4D log-interpolation (batch)
@@ -126,15 +113,12 @@ inline int LogInterpolateSingleVariable4DCustom(
     double offset,
     double* out) noexcept
 {
+  constexpr int ND = 4;
   if (x0 == nullptr || x1 == nullptr || x2 == nullptr || x3 == nullptr ||
-      out == nullptr || data == nullptr ||
-      axes[0].grid == nullptr || axes[1].grid == nullptr ||
-      axes[2].grid == nullptr || axes[3].grid == nullptr) {
+      out == nullptr || !detail::AxesAndDataValid<ND>(axes, data)) {
     return 1;
   }
-  constexpr int ND = 4;
-  int extents[ND] = {axes[0].n, axes[1].n, axes[2].n, axes[3].n};
-  const Layout layout = MakeLayout(extents, ND);
+  const Layout layout = detail::MakeAxisLayout<ND>(axes);
   for (std::size_t i = 0; i < count; ++i) {
     double coords[ND] = {x0[i], x1[i], x2[i], x3[i]};
     out[i] = detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);

--- a/src/interp/WeakLibReader_LogInterpolateSweep.hpp
+++ b/src/interp/WeakLibReader_LogInterpolateSweep.hpp
@@ -16,18 +16,15 @@ inline int LogInterpolateSingleVariable1D3DCustomPoint(
     double offset,
     double* out) noexcept
 {
-  if (logE == nullptr || out == nullptr || data == nullptr ||
-      axes[0].grid == nullptr || axes[1].grid == nullptr ||
-      axes[2].grid == nullptr || axes[3].grid == nullptr) {
+  constexpr int ND = 4;
+  if (logE == nullptr || out == nullptr || !detail::AxesAndDataValid<ND>(axes, data)) {
     return 1;
   }
   if (sizeE == 0) {
     return 0;
   }
 
-  constexpr int ND = 4;
-  int extents[ND] = {axes[0].n, axes[1].n, axes[2].n, axes[3].n};
-  const Layout layout = MakeLayout(extents, ND);
+  const Layout layout = detail::MakeAxisLayout<ND>(axes);
 
   for (std::size_t i = 0; i < sizeE; ++i) {
     double coords[ND] = {logE[i], logD, logT, y};
@@ -46,19 +43,16 @@ inline int LogInterpolateSingleVariable1D3DCustom(
     double offset,
     double* out) noexcept
 {
+  constexpr int ND = 4;
   if (logE == nullptr || logD == nullptr || logT == nullptr || y == nullptr ||
-      out == nullptr || data == nullptr ||
-      axes[0].grid == nullptr || axes[1].grid == nullptr ||
-      axes[2].grid == nullptr || axes[3].grid == nullptr) {
+      out == nullptr || !detail::AxesAndDataValid<ND>(axes, data)) {
     return 1;
   }
   if (sizeE == 0 || count == 0) {
     return 0;
   }
 
-  constexpr int ND = 4;
-  int extents[ND] = {axes[0].n, axes[1].n, axes[2].n, axes[3].n};
-  const Layout layout = MakeLayout(extents, ND);
+  const Layout layout = detail::MakeAxisLayout<ND>(axes);
 
   for (std::size_t j = 0; j < count; ++j) {
     double* row = out + j * sizeE;
@@ -80,26 +74,21 @@ inline int LogInterpolateSingleVariable2D2DCustomPoint(
     double offset,
     double* out) noexcept
 {
-  if (logE == nullptr || data == nullptr || out == nullptr ||
-      axes[0].grid == nullptr || axes[1].grid == nullptr ||
-      axes[2].grid == nullptr || axes[3].grid == nullptr) {
+  constexpr int ND = 4;
+  if (logE == nullptr || out == nullptr || !detail::AxesAndDataValid<ND>(axes, data)) {
     return 1;
   }
   if (sizeE == 0) {
     return 0;
   }
 
-  constexpr int ND = 4;
-  int extents[ND] = {axes[0].n, axes[1].n, axes[2].n, axes[3].n};
-  const Layout layout = MakeLayout(extents, ND);
+  const Layout layout = detail::MakeAxisLayout<ND>(axes);
 
-  for (std::size_t j = 0; j < sizeE; ++j) {
-    for (std::size_t i = 0; i <= j; ++i) {
-      double coords[ND] = {logE[i], logE[j], logT, logX};
-      const double value = detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
-      detail::StoreSymmetric(out, sizeE, i, j, value);
-    }
-  }
+  detail::ForEachSymmetricUpper(sizeE, [&](std::size_t i, std::size_t j) noexcept {
+    const double coords[ND] = {logE[i], logE[j], logT, logX};
+    const double value = detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
+    detail::StoreSymmetric(out, sizeE, i, j, value);
+  });
 
   return 0;
 }
@@ -113,30 +102,25 @@ inline int LogInterpolateSingleVariable2D2DCustom(
     double offset,
     double* out) noexcept
 {
+  constexpr int ND = 4;
   if (logE == nullptr || logT == nullptr || logX == nullptr ||
-      out == nullptr || data == nullptr ||
-      axes[0].grid == nullptr || axes[1].grid == nullptr ||
-      axes[2].grid == nullptr || axes[3].grid == nullptr) {
+      out == nullptr || !detail::AxesAndDataValid<ND>(axes, data)) {
     return 1;
   }
   if (sizeE == 0 || count == 0) {
     return 0;
   }
 
-  constexpr int ND = 4;
-  int extents[ND] = {axes[0].n, axes[1].n, axes[2].n, axes[3].n};
-  const Layout layout = MakeLayout(extents, ND);
+  const Layout layout = detail::MakeAxisLayout<ND>(axes);
 
   const std::size_t planeSize = sizeE * sizeE;
   for (std::size_t l = 0; l < count; ++l) {
     double* plane = out + l * planeSize;
-    for (std::size_t j = 0; j < sizeE; ++j) {
-      for (std::size_t i = 0; i <= j; ++i) {
-        double coords[ND] = {logE[i], logE[j], logT[l], logX[l]};
-        const double value = detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
-        detail::StoreSymmetric(plane, sizeE, i, j, value);
-      }
-    }
+    detail::ForEachSymmetricUpper(sizeE, [&](std::size_t i, std::size_t j) noexcept {
+      const double coords[ND] = {logE[i], logE[j], logT[l], logX[l]};
+      const double value = detail::LogInterpolatedValueDirect<ND>(data, layout, axes, coords, offset);
+      detail::StoreSymmetric(plane, sizeE, i, j, value);
+    });
   }
 
   return 0;
@@ -172,15 +156,13 @@ inline int LogInterpolateSingleVariable2D2DCustomAlignedPoint(
   detail::IndexAndDelta(axes[0], logT, idxT, fracT);
   detail::IndexAndDelta(axes[1], logX, idxX, fracX);
 
-  for (std::size_t j = 0; j < sizeE; ++j) {
-    for (std::size_t i = 0; i <= j; ++i) {
-      const double value = LinearInterp2D4DArray2DAlignedPoint(
-          static_cast<int>(i), static_cast<int>(j),
-          idxT, idxX, fracT, fracX, offset,
-          data, layout);
-      detail::StoreSymmetric(out, sizeE, i, j, value);
-    }
-  }
+  detail::ForEachSymmetricUpper(sizeE, [&](std::size_t i, std::size_t j) noexcept {
+    const double value = LinearInterp2D4DArray2DAlignedPoint(
+        static_cast<int>(i), static_cast<int>(j),
+        idxT, idxX, fracT, fracX, offset,
+        data, layout);
+    detail::StoreSymmetric(out, sizeE, i, j, value);
+  });
 
   return 0;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TEST_SOURCES
   test_log_interpolate_deriv.cpp
   test_log_interpolate_basis.cpp
   test_log_interpolate_kernel.cpp
+  test_refactor_helpers.cpp
   test_hdf5_loader.cpp
   test_weaklib_eos_loader.cpp
   test_weaklib_opacity_loader.cpp

--- a/test/test_refactor_helpers.cpp
+++ b/test/test_refactor_helpers.cpp
@@ -1,0 +1,140 @@
+#define SIMPLE_CATCH_NO_MAIN
+#include <catch2/catch_test_macros.hpp>
+
+#include "interp/WeakLibReader_LogInterpolate.hpp"
+#include "base/WeakLibReader_Layout.hpp"
+#include "base/WeakLibReader_AxisTypes.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+
+namespace {
+constexpr double Tol = 1.0e-12;
+}
+
+TEST_CASE("Point wrappers reject null axis/data pointers", "[loginterp][guards]")
+{
+  using namespace WeakLibReader;
+
+  const std::array<double, 2> grid{1.0, 2.0};
+  const std::array<double, 4> table{0.0, 0.0, 0.0, 0.0};
+
+  Axis axes2[2] = {
+      MakeAxis(grid.data(), 2, AxisScale::Linear),
+      MakeAxis(grid.data(), 2, AxisScale::Linear)};
+
+  const double nanValue = LogInterpolateSingleVariable2DCustomPoint(
+      1.2, 1.4,
+      axes2,
+      nullptr,
+      0.0);
+  CHECK(std::isnan(nanValue));
+
+  axes2[1].grid = nullptr;
+  const double nanAxis = LogInterpolateSingleVariable2DCustomPoint(
+      1.2, 1.4,
+      axes2,
+      table.data(),
+      0.0);
+  CHECK(std::isnan(nanAxis));
+}
+
+TEST_CASE("Batch wrappers reject null pointers", "[loginterp][guards][batch]")
+{
+  using namespace WeakLibReader;
+
+  const std::array<double, 2> grid{1.0, 2.0};
+  const std::array<double, 16> table{};
+  const std::array<double, 2> coord{1.1, 1.8};
+  std::array<double, 2> out{};
+
+  Axis axes4[4] = {
+      MakeAxis(grid.data(), 2, AxisScale::Linear),
+      MakeAxis(grid.data(), 2, AxisScale::Linear),
+      MakeAxis(grid.data(), 2, AxisScale::Linear),
+      MakeAxis(grid.data(), 2, AxisScale::Linear)};
+
+  CHECK(LogInterpolateSingleVariable1D3DCustom(
+            coord.data(), coord.size(),
+            coord.data(), coord.data(), coord.data(), coord.size(),
+            axes4,
+            nullptr,
+            0.0,
+            out.data()) == 1);
+
+  axes4[2].grid = nullptr;
+  CHECK(LogInterpolateSingleVariable2D2DCustom(
+            coord.data(), coord.size(),
+            coord.data(), coord.data(), coord.size(),
+            axes4,
+            table.data(),
+            0.0,
+            out.data()) == 1);
+}
+
+TEST_CASE("Derivative 2D2D point output remains symmetric", "[loginterp][derivative][symmetry]")
+{
+  using namespace WeakLibReader;
+
+  constexpr std::size_t sizeE = 3;
+  const std::array<double, sizeE> gridE{1.0, 2.0, 4.0};
+  const std::array<double, 2> gridT{1.0, 2.0};
+  const std::array<double, 2> gridX{1.0, 3.0};
+
+  const int extents[4] = {static_cast<int>(sizeE), static_cast<int>(sizeE), 2, 2};
+  const Layout layout = MakeLayout(extents, 4);
+
+  std::array<double, sizeE * sizeE * 2 * 2> table{};
+  for (std::size_t e0 = 0; e0 < sizeE; ++e0) {
+    for (std::size_t e1 = 0; e1 < sizeE; ++e1) {
+      for (int t = 0; t < 2; ++t) {
+        for (int x = 0; x < 2; ++x) {
+          const double actual = 1.0 + 0.1 * gridE[e0] + 0.2 * gridE[e1] +
+                                0.3 * gridT[t] + 0.4 * gridX[x];
+          table[layout.Offset(static_cast<int>(e0), static_cast<int>(e1), t, x)] =
+              std::log10(actual);
+        }
+      }
+    }
+  }
+
+  Axis axes4[4] = {
+      MakeAxis(gridE.data(), static_cast<int>(sizeE), AxisScale::Linear),
+      MakeAxis(gridE.data(), static_cast<int>(sizeE), AxisScale::Linear),
+      MakeAxis(gridT.data(), 2, AxisScale::Linear),
+      MakeAxis(gridX.data(), 2, AxisScale::Linear)};
+
+  std::array<double, sizeE * sizeE> interp{};
+  std::array<double, sizeE * sizeE> dT{};
+  std::array<double, sizeE * sizeE> dX{};
+
+  REQUIRE(LogInterpolateDifferentiateSingleVariable2D2DCustomPoint(
+              gridE.data(), sizeE,
+              1.3, 2.1,
+              axes4,
+              table.data(),
+              0.0,
+              interp.data(), dT.data(), dX.data()) == 0);
+
+  for (std::size_t j = 0; j < sizeE; ++j) {
+    for (std::size_t i = 0; i < sizeE; ++i) {
+      CHECK(interp[j * sizeE + i] == Catch::Approx(interp[i * sizeE + j]).margin(Tol));
+      CHECK(dT[j * sizeE + i] == Catch::Approx(dT[i * sizeE + j]).margin(Tol));
+      CHECK(dX[j * sizeE + i] == Catch::Approx(dX[i * sizeE + j]).margin(Tol));
+    }
+  }
+}
+
+TEST_CASE("Layout strides are column-major from extents", "[layout][column-major]")
+{
+  using namespace WeakLibReader;
+
+  const int extents[4] = {3, 4, 5, 6};
+  const Layout layout = MakeLayout(extents, 4);
+
+  CHECK(layout.stride[0] == 1);
+  CHECK(layout.stride[1] == 3);
+  CHECK(layout.stride[2] == 12);
+  CHECK(layout.stride[3] == 60);
+}

--- a/test/test_weaklib_eos_loader.cpp
+++ b/test/test_weaklib_eos_loader.cpp
@@ -307,7 +307,7 @@ TEST_CASE("LoadWeakLibEosTableFull reads complete EOS table", "[hdf5][weaklib]")
   // Repaired mask is loaded
   CHECK(table.repaired.data() != nullptr);
 
-  // Layout is computed correctly (row-major)
+  // Layout is computed correctly (column-major)
   // stride[0] = 1, stride[1] = n[0], stride[2] = n[0]*n[1]
   CHECK(table.layout.stride[0] == 1);
   CHECK(table.layout.stride[1] == static_cast<std::size_t>(table.dimensions[0]));


### PR DESCRIPTION
### Motivation

- Reduce repeated ND-specific boilerplate in interpolation wrappers and centralize common checks/layout construction to lower maintenance risk and keep numerical behavior unchanged.
- Single-source the symmetric upper-triangle traversal used by 2D×2D sweep and derivative paths to avoid duplicated indexing/storage logic.
- Centralize HDF5 file-open/error handling in the opacity loader and add small helper-focused tests to de-risk the structural refactor.

### Description

- Added shared helpers in `interp/WeakLibReader_LogInterpolateCore.hpp`: `AxesAndDataValid`, `MakeAxisLayout`, `LogInterpolatedValueFromAxes`, and `ForEachSymmetricUpper` to consolidate pointer validation, layout assembly, direct evaluation, and symmetric traversal.
- Rewrote public wrappers in `interp/WeakLibReader_LogInterpolatePoint.hpp`, `interp/WeakLibReader_LogInterpolateSweep.hpp`, and `interp/WeakLibReader_LogInterpolateDeriv.hpp` to use the new helpers, eliminating repeated `MakeLayout` + null-check boilerplate and unifying symmetric-sweep loops while preserving `StoreSymmetric` semantics.
- Introduced `WithOpenedOpacityFile` in `src/hdf5/WeakLibReader_Hdf5LoaderOpacityMain.hpp` and refactored `LoadWeakLibOpacityTableFull` to use it for EnergyGrid/ThermoState, EtaGrid, and all table-family loads to reduce `H5Fopen` repetition and centralize error handling.
- Synced documentation/comments to consistently describe the N-D table layout as column-major, added `test/test_refactor_helpers.cpp` with focused Catch2 tests for guard behavior, symmetry invariants, and layout stride expectations, and registered the test in `test/CMakeLists.txt`.

### Testing

- Added unit test `test_refactor_helpers.cpp` (Catch2) and wired it into the test target, but the new test was not executed in this environment.
- Attempted to configure the project with `cmake -S . -B build` and the configure step failed with missing HDF5 (error: `Could NOT find HDF5`), preventing full build or test execution.
- Ran `scripts/build.sh` and `scripts/check.sh` in this environment but they failed due to the absence of a configured `build/` directory, so no test binaries were produced or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69933cd691c88325be38d714476b6247)