### PR TITLE
test: close six highest-value test coverage gaps

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,9 @@ set(TEST_SOURCES
   test_hdf5_loader.cpp
   test_weaklib_eos_loader.cpp
   test_weaklib_opacity_loader.cpp
-  test_eos_inversion.cpp)
+  test_eos_inversion.cpp
+  test_extract_iso_slice.cpp
+  test_index_delta.cpp)
 
 add_executable(WeakLibReaderTests ${TEST_SOURCES})
 

--- a/test/test_eos_inversion.cpp
+++ b/test/test_eos_inversion.cpp
@@ -21,6 +21,18 @@ double EnergyFunc(double rho, double T, double Ye)
   return std::pow(rho, 0.3) * std::pow(T, 1.5) * (1.0 + 0.2 * Ye);
 }
 
+// Synthetic pressure: monotonically increasing in T
+double PressureFunc(double rho, double T, double Ye)
+{
+  return std::pow(rho, 0.4) * std::pow(T, 1.8) * (1.0 + 0.15 * Ye);
+}
+
+// Synthetic entropy: monotonically increasing in T
+double EntropyFunc(double rho, double T, double Ye)
+{
+  return std::pow(rho, -0.1) * std::pow(T, 1.2) * (1.0 + 0.3 * Ye);
+}
+
 // Grid definitions
 constexpr int nD = 5;
 constexpr int nT = 5;
@@ -59,6 +71,52 @@ std::vector<double> BuildSyntheticTable(
     }
   }
   return data;
+}
+
+// Extended synthetic data for pressure/entropy inversion tests.
+struct SyntheticEosData {
+  std::vector<double> energy;
+  std::vector<double> pressure;
+  std::vector<double> entropy;
+  WeakLibReader::Axis axes[3];
+  WeakLibReader::Layout layout;
+  WeakLibReader::EosInversionBounds bounds;
+};
+
+SyntheticEosData BuildFullSyntheticEos()
+{
+  using namespace WeakLibReader;
+
+  SyntheticEosData d;
+  d.axes[0] = MakeAxis(gridD, nD, AxisScale::Log10);
+  d.axes[1] = MakeAxis(gridT, nT, AxisScale::Log10);
+  d.axes[2] = MakeAxis(gridY, nY, AxisScale::Linear);
+
+  const int extents[3] = {nD, nT, nY};
+  d.layout = MakeLayout(extents, 3);
+
+  d.energy.resize(totalSize);
+  d.pressure.resize(totalSize);
+  d.entropy.resize(totalSize);
+
+  for (int iRho = 0; iRho < nD; ++iRho) {
+    for (int iTemp = 0; iTemp < nT; ++iTemp) {
+      for (int iYe = 0; iYe < nY; ++iYe) {
+        const auto off = d.layout.Offset(iRho, iTemp, iYe);
+        d.energy[off]   = std::log10(EnergyFunc(gridD[iRho], gridT[iTemp], gridY[iYe]) + Offset);
+        d.pressure[off] = std::log10(PressureFunc(gridD[iRho], gridT[iTemp], gridY[iYe]) + Offset);
+        d.entropy[off]  = std::log10(EntropyFunc(gridD[iRho], gridT[iTemp], gridY[iYe]) + Offset);
+      }
+    }
+  }
+
+  d.bounds = InitializeEosInversionBounds(
+      d.axes, totalSize,
+      d.energy.data(), Offset,
+      d.pressure.data(), Offset,
+      d.entropy.data(), Offset);
+
+  return d;
 }
 
 constexpr double Tol = 1.0e-10;
@@ -424,4 +482,208 @@ TEST_CASE("InitializeEosInversionBounds computes correct bounds", "[eosinversion
   CHECK(bounds.maxP == 0.0);
   CHECK(bounds.minS == 0.0);
   CHECK(bounds.maxS == 0.0);
+}
+
+TEST_CASE("InitializeEosInversionBounds populates pressure and entropy bounds",
+          "[eosinversion]")
+{
+  using namespace WeakLibReader;
+
+  const auto d = BuildFullSyntheticEos();
+
+  // Pressure bounds: compute expected min/max from the synthetic function
+  double expectedMinP = std::numeric_limits<double>::max();
+  double expectedMaxP = std::numeric_limits<double>::lowest();
+  for (int iRho = 0; iRho < nD; ++iRho) {
+    for (int iTemp = 0; iTemp < nT; ++iTemp) {
+      for (int iYe = 0; iYe < nY; ++iYe) {
+        const double P = PressureFunc(gridD[iRho], gridT[iTemp], gridY[iYe]);
+        if (P < expectedMinP) expectedMinP = P;
+        if (P > expectedMaxP) expectedMaxP = P;
+      }
+    }
+  }
+
+  CHECK(std::abs(d.bounds.minP - expectedMinP)
+        / (std::abs(expectedMinP) + 1e-30) < 1e-12);
+  CHECK(std::abs(d.bounds.maxP - expectedMaxP)
+        / (std::abs(expectedMaxP) + 1e-30) < 1e-12);
+
+  // Entropy bounds: compute expected min/max from the synthetic function
+  double expectedMinS = std::numeric_limits<double>::max();
+  double expectedMaxS = std::numeric_limits<double>::lowest();
+  for (int iRho = 0; iRho < nD; ++iRho) {
+    for (int iTemp = 0; iTemp < nT; ++iTemp) {
+      for (int iYe = 0; iYe < nY; ++iYe) {
+        const double S = EntropyFunc(gridD[iRho], gridT[iTemp], gridY[iYe]);
+        if (S < expectedMinS) expectedMinS = S;
+        if (S > expectedMaxS) expectedMaxS = S;
+      }
+    }
+  }
+
+  CHECK(std::abs(d.bounds.minS - expectedMinS)
+        / (std::abs(expectedMinS) + 1e-30) < 1e-12);
+  CHECK(std::abs(d.bounds.maxS - expectedMaxS)
+        / (std::abs(expectedMaxS) + 1e-30) < 1e-12);
+}
+
+TEST_CASE("Round-trip pressure inversion without guess",
+          "[eosinversion][pressure]")
+{
+  using namespace WeakLibReader;
+
+  const auto d = BuildFullSyntheticEos();
+
+  const double testD[] = {3e6, 5e7, 2e8, 7e9};
+  const double testT[] = {2e9, 5e9, 2e10, 5e10};
+  const double testY[] = {0.15, 0.25, 0.35, 0.45};
+
+  for (double D : testD) {
+    for (double T_known : testT) {
+      for (double Y : testY) {
+        const double P = LogInterpolateSingleVariable3DCustomPoint(
+            D, T_known, Y, d.axes, d.pressure.data(), Offset);
+
+        double T_recovered = 0.0;
+        const int error = ComputeTemperatureFromPressure(
+            D, P, Y, d.axes, d.pressure.data(), d.layout, Offset,
+            d.bounds, T_recovered);
+
+        CHECK(error == 0);
+        const double relErr = std::abs(T_recovered - T_known) / T_known;
+        CHECK(relErr < Tol);
+      }
+    }
+  }
+}
+
+TEST_CASE("Round-trip pressure inversion with good guess",
+          "[eosinversion][pressure]")
+{
+  using namespace WeakLibReader;
+
+  const auto d = BuildFullSyntheticEos();
+
+  const double D = 5e8;
+  const double T_known = 1.5e10;
+  const double Y = 0.3;
+
+  const double P = LogInterpolateSingleVariable3DCustomPoint(
+      D, T_known, Y, d.axes, d.pressure.data(), Offset);
+
+  const double tGuess = 1.2e10; // close to T_known
+  double T_recovered = 0.0;
+  const int error = ComputeTemperatureFromPressure(
+      D, P, Y, d.axes, d.pressure.data(), d.layout, Offset,
+      d.bounds, tGuess, T_recovered);
+
+  CHECK(error == 0);
+  const double relErr = std::abs(T_recovered - T_known) / T_known;
+  CHECK(relErr < Tol);
+}
+
+TEST_CASE("Round-trip pressure inversion with bad guess",
+          "[eosinversion][pressure]")
+{
+  using namespace WeakLibReader;
+
+  const auto d = BuildFullSyntheticEos();
+
+  const double D = 5e8;
+  const double T_known = 1.5e10;
+  const double Y = 0.3;
+
+  const double P = LogInterpolateSingleVariable3DCustomPoint(
+      D, T_known, Y, d.axes, d.pressure.data(), Offset);
+
+  const double tGuess = 1e9; // far from T_known=1.5e10
+  double T_recovered = 0.0;
+  const int error = ComputeTemperatureFromPressure(
+      D, P, Y, d.axes, d.pressure.data(), d.layout, Offset,
+      d.bounds, tGuess, T_recovered);
+
+  CHECK(error == 0);
+  const double relErr = std::abs(T_recovered - T_known) / T_known;
+  CHECK(relErr < Tol);
+}
+
+TEST_CASE("Round-trip entropy inversion without guess",
+          "[eosinversion][entropy]")
+{
+  using namespace WeakLibReader;
+
+  const auto d = BuildFullSyntheticEos();
+
+  const double testD[] = {3e6, 5e7, 2e8, 7e9};
+  const double testT[] = {2e9, 5e9, 2e10, 5e10};
+  const double testY[] = {0.15, 0.25, 0.35, 0.45};
+
+  for (double D : testD) {
+    for (double T_known : testT) {
+      for (double Y : testY) {
+        const double S = LogInterpolateSingleVariable3DCustomPoint(
+            D, T_known, Y, d.axes, d.entropy.data(), Offset);
+
+        double T_recovered = 0.0;
+        const int error = ComputeTemperatureFromEntropy(
+            D, S, Y, d.axes, d.entropy.data(), d.layout, Offset,
+            d.bounds, T_recovered);
+
+        CHECK(error == 0);
+        const double relErr = std::abs(T_recovered - T_known) / T_known;
+        CHECK(relErr < Tol);
+      }
+    }
+  }
+}
+
+TEST_CASE("Round-trip entropy inversion with good guess",
+          "[eosinversion][entropy]")
+{
+  using namespace WeakLibReader;
+
+  const auto d = BuildFullSyntheticEos();
+
+  const double D = 5e8;
+  const double T_known = 1.5e10;
+  const double Y = 0.3;
+
+  const double S = LogInterpolateSingleVariable3DCustomPoint(
+      D, T_known, Y, d.axes, d.entropy.data(), Offset);
+
+  const double tGuess = 1.2e10; // close to T_known
+  double T_recovered = 0.0;
+  const int error = ComputeTemperatureFromEntropy(
+      D, S, Y, d.axes, d.entropy.data(), d.layout, Offset,
+      d.bounds, tGuess, T_recovered);
+
+  CHECK(error == 0);
+  const double relErr = std::abs(T_recovered - T_known) / T_known;
+  CHECK(relErr < Tol);
+}
+
+TEST_CASE("Round-trip entropy inversion with bad guess",
+          "[eosinversion][entropy]")
+{
+  using namespace WeakLibReader;
+
+  const auto d = BuildFullSyntheticEos();
+
+  const double D = 5e8;
+  const double T_known = 1.5e10;
+  const double Y = 0.3;
+
+  const double S = LogInterpolateSingleVariable3DCustomPoint(
+      D, T_known, Y, d.axes, d.entropy.data(), Offset);
+
+  const double tGuess = 1e9; // far from T_known=1.5e10
+  double T_recovered = 0.0;
+  const int error = ComputeTemperatureFromEntropy(
+      D, S, Y, d.axes, d.entropy.data(), d.layout, Offset,
+      d.bounds, tGuess, T_recovered);
+
+  CHECK(error == 0);
+  const double relErr = std::abs(T_recovered - T_known) / T_known;
+  CHECK(relErr < Tol);
 }

--- a/test/test_extract_iso_slice.cpp
+++ b/test/test_extract_iso_slice.cpp
@@ -1,0 +1,120 @@
+#define SIMPLE_CATCH_NO_MAIN
+#include <catch2/catch_test_macros.hpp>
+
+#include "hdf5/WeakLibReader_Hdf5LoaderOpacityScat.hpp"
+#include "base/WeakLibReader_Layout.hpp"
+
+#include <vector>
+
+TEST_CASE("ExtractIsoMomentSlice4D extracts correct 4D slice", "[isoslice]")
+{
+  using namespace WeakLibReader;
+
+  // 5D dimensions: [nE=3, nMom=2, nRho=4, nT=3, nYe=2]
+  const std::array<int, 5> dims{{3, 2, 4, 3, 2}};
+  const int nE   = dims[0];
+  const int nMom = dims[1];
+  const int nRho = dims[2];
+  const int nT   = dims[3];
+  const int nYe  = dims[4];
+
+  const Layout layout5d = MakeLayout(dims.data(), 5);
+  const std::size_t totalSize =
+      static_cast<std::size_t>(nE) * nMom * nRho * nT * nYe;
+
+  // Fill 5D array with index-encoding:
+  // data[offset] = iE + 10*iMom + 100*iRho + 1000*iT + 10000*iYe
+  std::vector<double> data(totalSize);
+  for (int iYe = 0; iYe < nYe; ++iYe) {
+    for (int iT = 0; iT < nT; ++iT) {
+      for (int iRho = 0; iRho < nRho; ++iRho) {
+        for (int iMom = 0; iMom < nMom; ++iMom) {
+          for (int iE = 0; iE < nE; ++iE) {
+            const double val = iE + 10 * iMom + 100 * iRho
+                             + 1000 * iT + 10000 * iYe;
+            data[layout5d.Offset(iE, iMom, iRho, iT, iYe)] = val;
+          }
+        }
+      }
+    }
+  }
+
+  // 4D layout for verification: [nE, nRho, nT, nYe]
+  const std::array<int, 4> dims4d{{nE, nRho, nT, nYe}};
+  const Layout layout4d = MakeLayout(dims4d.data(), 4);
+
+  for (int mom = 0; mom < nMom; ++mom) {
+    const auto result = ExtractIsoMomentSlice4D(data.data(), dims, mom);
+
+    REQUIRE(result.size() ==
+            static_cast<std::size_t>(nE) * nRho * nT * nYe);
+
+    for (int iYe = 0; iYe < nYe; ++iYe) {
+      for (int iT = 0; iT < nT; ++iT) {
+        for (int iRho = 0; iRho < nRho; ++iRho) {
+          for (int iE = 0; iE < nE; ++iE) {
+            const double expected = iE + 10 * mom + 100 * iRho
+                                  + 1000 * iT + 10000 * iYe;
+            CHECK(result[layout4d.Offset(iE, iRho, iT, iYe)]
+                  == expected);
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST_CASE("ExtractIsoMomentSlice4D single-moment degenerate case",
+          "[isoslice]")
+{
+  using namespace WeakLibReader;
+
+  // 5D dimensions: [nE=2, nMom=1, nRho=2, nT=2, nYe=2]
+  const std::array<int, 5> dims{{2, 1, 2, 2, 2}};
+  const int nE   = dims[0];
+  const int nMom = dims[1];
+  const int nRho = dims[2];
+  const int nT   = dims[3];
+  const int nYe  = dims[4];
+
+  const Layout layout5d = MakeLayout(dims.data(), 5);
+  const std::size_t totalSize =
+      static_cast<std::size_t>(nE) * nMom * nRho * nT * nYe;
+
+  // Fill with index-encoding (nMom=1, so iMom always 0)
+  std::vector<double> data(totalSize);
+  for (int iYe = 0; iYe < nYe; ++iYe) {
+    for (int iT = 0; iT < nT; ++iT) {
+      for (int iRho = 0; iRho < nRho; ++iRho) {
+        for (int iE = 0; iE < nE; ++iE) {
+          const double val = iE + 100 * iRho + 1000 * iT + 10000 * iYe;
+          data[layout5d.Offset(iE, 0, iRho, iT, iYe)] = val;
+        }
+      }
+    }
+  }
+
+  const auto result = ExtractIsoMomentSlice4D(data.data(), dims, 0);
+
+  // With nMom=1 and iMom=0, the 5D data collapses to 4D.
+  // Since stride[0]=1 and the moment dimension has size 1,
+  // 5D strides [1, nE, nE*1, ...] become effectively [1, nE, nE*nRho, ...]
+  // which matches 4D strides [1, nE, nE*nRho, ...].
+  // So output should match input element-for-element.
+  REQUIRE(result.size() ==
+          static_cast<std::size_t>(nE) * nRho * nT * nYe);
+
+  const std::array<int, 4> dims4d{{nE, nRho, nT, nYe}};
+  const Layout layout4d = MakeLayout(dims4d.data(), 4);
+
+  for (int iYe = 0; iYe < nYe; ++iYe) {
+    for (int iT = 0; iT < nT; ++iT) {
+      for (int iRho = 0; iRho < nRho; ++iRho) {
+        for (int iE = 0; iE < nE; ++iE) {
+          const double expected = iE + 100 * iRho + 1000 * iT + 10000 * iYe;
+          CHECK(result[layout4d.Offset(iE, iRho, iT, iYe)] == expected);
+        }
+      }
+    }
+  }
+}

--- a/test/test_index_delta.cpp
+++ b/test/test_index_delta.cpp
@@ -1,0 +1,271 @@
+#define SIMPLE_CATCH_NO_MAIN
+#include <catch2/catch_test_macros.hpp>
+
+#include "base/WeakLibReader_IndexDelta.hpp"
+
+#include <cmath>
+
+namespace {
+
+constexpr double Tol = 1.0e-12;
+
+} // namespace
+
+// =============================================================================
+// ClampIndex Tests
+// =============================================================================
+
+TEST_CASE("ClampIndex clamps below and above", "[indexdelta]")
+{
+  using WeakLibReader::detail::ClampIndex;
+
+  // Below range
+  CHECK(ClampIndex(-1, 5) == 0);
+  CHECK(ClampIndex(-100, 5) == 0);
+
+  // Above range
+  CHECK(ClampIndex(6, 5) == 5);
+  CHECK(ClampIndex(100, 5) == 5);
+
+  // In range (no-op)
+  CHECK(ClampIndex(3, 5) == 3);
+
+  // Boundaries
+  CHECK(ClampIndex(0, 5) == 0);
+  CHECK(ClampIndex(5, 5) == 5);
+}
+
+// =============================================================================
+// IndexAndDeltaLin Tests
+// =============================================================================
+
+TEST_CASE("IndexAndDeltaLin at exact grid points", "[indexdelta][linear]")
+{
+  using WeakLibReader::IndexAndDeltaLin;
+
+  const double grid[] = {1.0, 2.0, 3.0, 4.0, 5.0};
+  const int n = 5;
+  int i;
+  double t;
+
+  // At grid[0]: i=0, delta=0
+  IndexAndDeltaLin(1.0, grid, n, i, t);
+  CHECK(i == 0);
+  CHECK(t == Catch::Approx(0.0).margin(Tol));
+
+  // At grid[1]: i=1, delta=0
+  IndexAndDeltaLin(2.0, grid, n, i, t);
+  CHECK(i == 1);
+  CHECK(t == Catch::Approx(0.0).margin(Tol));
+
+  // At grid[2]: i=2, delta=0
+  IndexAndDeltaLin(3.0, grid, n, i, t);
+  CHECK(i == 2);
+  CHECK(t == Catch::Approx(0.0).margin(Tol));
+
+  // At grid[3]: i=3, delta=0
+  IndexAndDeltaLin(4.0, grid, n, i, t);
+  CHECK(i == 3);
+  CHECK(t == Catch::Approx(0.0).margin(Tol));
+
+  // At grid[4] (last point): i = n-2 = 3, delta = 1.0
+  IndexAndDeltaLin(5.0, grid, n, i, t);
+  CHECK(i == 3);
+  CHECK(t == Catch::Approx(1.0).margin(Tol));
+}
+
+TEST_CASE("IndexAndDeltaLin at midpoints", "[indexdelta][linear]")
+{
+  using WeakLibReader::IndexAndDeltaLin;
+
+  const double grid[] = {1.0, 2.0, 3.0, 4.0, 5.0};
+  const int n = 5;
+  int i;
+  double t;
+
+  // At x=1.5: midpoint of [1, 2]
+  IndexAndDeltaLin(1.5, grid, n, i, t);
+  CHECK(i == 0);
+  CHECK(t == Catch::Approx(0.5).margin(Tol));
+
+  // At x=3.5: midpoint of [3, 4]
+  IndexAndDeltaLin(3.5, grid, n, i, t);
+  CHECK(i == 2);
+  CHECK(t == Catch::Approx(0.5).margin(Tol));
+}
+
+TEST_CASE("IndexAndDeltaLin below range (extrapolation)", "[indexdelta][linear]")
+{
+  using WeakLibReader::IndexAndDeltaLin;
+
+  const double grid[] = {1.0, 2.0, 3.0, 4.0, 5.0};
+  const int n = 5;
+  int i;
+  double t;
+
+  // At x=0.5 (below grid[0]=1.0)
+  IndexAndDeltaLin(0.5, grid, n, i, t);
+  CHECK(i == 0);
+  CHECK(t < 0.0);
+  // delta = (0.5 - 1.0) / (2.0 - 1.0) = -0.5
+  CHECK(t == Catch::Approx(-0.5).margin(Tol));
+}
+
+TEST_CASE("IndexAndDeltaLin above range (extrapolation)", "[indexdelta][linear]")
+{
+  using WeakLibReader::IndexAndDeltaLin;
+
+  const double grid[] = {1.0, 2.0, 3.0, 4.0, 5.0};
+  const int n = 5;
+  int i;
+  double t;
+
+  // At x=5.5 (above grid[4]=5.0): i clamped to n-2=3
+  IndexAndDeltaLin(5.5, grid, n, i, t);
+  CHECK(i == 3);
+  CHECK(t > 1.0);
+  // delta = (5.5 - 4.0) / (5.0 - 4.0) = 1.5
+  CHECK(t == Catch::Approx(1.5).margin(Tol));
+}
+
+// =============================================================================
+// IndexAndDeltaLog10 Tests
+// =============================================================================
+
+TEST_CASE("IndexAndDeltaLog10 at exact grid points", "[indexdelta][log10]")
+{
+  using WeakLibReader::IndexAndDeltaLog10;
+
+  const double grid[] = {1.0, 10.0, 100.0, 1000.0};
+  const int n = 4;
+  int i;
+  double t;
+
+  // At grid[0]=1.0: i=0, delta=0
+  IndexAndDeltaLog10(1.0, grid, n, i, t);
+  CHECK(i == 0);
+  CHECK(t == Catch::Approx(0.0).margin(Tol));
+
+  // At grid[1]=10.0: i=1, delta=0
+  IndexAndDeltaLog10(10.0, grid, n, i, t);
+  CHECK(i == 1);
+  CHECK(t == Catch::Approx(0.0).margin(Tol));
+
+  // At grid[2]=100.0: i=2, delta=0
+  IndexAndDeltaLog10(100.0, grid, n, i, t);
+  CHECK(i == 2);
+  CHECK(t == Catch::Approx(0.0).margin(Tol));
+
+  // At grid[3]=1000.0 (last): i = n-2 = 2, delta = 1.0
+  IndexAndDeltaLog10(1000.0, grid, n, i, t);
+  CHECK(i == 2);
+  CHECK(t == Catch::Approx(1.0).margin(Tol));
+}
+
+TEST_CASE("IndexAndDeltaLog10 at geometric midpoints", "[indexdelta][log10]")
+{
+  using WeakLibReader::IndexAndDeltaLog10;
+
+  const double grid[] = {1.0, 10.0, 100.0, 1000.0};
+  const int n = 4;
+  int i;
+  double t;
+
+  // sqrt(1*10) = sqrt(10) ~ 3.162: geometric midpoint of [1, 10]
+  IndexAndDeltaLog10(std::sqrt(10.0), grid, n, i, t);
+  CHECK(i == 0);
+  CHECK(t == Catch::Approx(0.5).margin(Tol));
+
+  // sqrt(100*1000) = sqrt(100000) ~ 316.2: geometric midpoint of [100, 1000]
+  IndexAndDeltaLog10(std::sqrt(100.0 * 1000.0), grid, n, i, t);
+  CHECK(i == 2);
+  CHECK(t == Catch::Approx(0.5).margin(Tol));
+}
+
+TEST_CASE("IndexAndDeltaLog10 below range (extrapolation)", "[indexdelta][log10]")
+{
+  using WeakLibReader::IndexAndDeltaLog10;
+
+  const double grid[] = {1.0, 10.0, 100.0, 1000.0};
+  const int n = 4;
+  int i;
+  double t;
+
+  // At x=0.5 (below grid[0]=1.0): i=0, delta < 0
+  IndexAndDeltaLog10(0.5, grid, n, i, t);
+  CHECK(i == 0);
+  CHECK(t < 0.0);
+  // delta = log10(0.5 / 1.0) / log10(10.0 / 1.0) = log10(0.5) / 1.0
+  CHECK(t == Catch::Approx(std::log10(0.5)).margin(Tol));
+}
+
+TEST_CASE("IndexAndDeltaLog10 above range (extrapolation)", "[indexdelta][log10]")
+{
+  using WeakLibReader::IndexAndDeltaLog10;
+
+  const double grid[] = {1.0, 10.0, 100.0, 1000.0};
+  const int n = 4;
+  int i;
+  double t;
+
+  // At x=2000 (above grid[3]=1000): i = n-2 = 2
+  IndexAndDeltaLog10(2000.0, grid, n, i, t);
+  CHECK(i == 2);
+  CHECK(t > 1.0);
+  // delta = log10(2000 / 100) / log10(1000 / 100) = log10(20) / log10(10) = log10(20)
+  CHECK(t == Catch::Approx(std::log10(20.0)).margin(Tol));
+}
+
+// =============================================================================
+// Non-uniform Grid Test
+// =============================================================================
+
+TEST_CASE("IndexAndDeltaLin with non-uniform grid", "[indexdelta][linear]")
+{
+  using WeakLibReader::IndexAndDeltaLin;
+
+  // Non-uniform grid: the initial index estimate assumes uniform spacing,
+  // so for non-uniform grids the index may differ from the "geometrically
+  // correct" cell.  The delta compensates so that overall interpolation
+  // still converges.  We verify the actual (index, delta) pairs produced.
+  const double grid[] = {0.0, 1.0, 4.0, 9.0};
+  const int n = 4;
+  int i;
+  double t;
+
+  // At x=0.5: scaled=0.5/9=0.0556, scaledIndex=0.167 -> rawIndex=0
+  //   i=0, t=(0.5-0.0)/(1.0-0.0)=0.5
+  IndexAndDeltaLin(0.5, grid, n, i, t);
+  CHECK(i == 0);
+  CHECK(t == Catch::Approx(0.5).margin(Tol));
+
+  // At x=2.5: scaled=2.5/9, scaledIndex=0.833 -> rawIndex=0
+  //   i=0, t=(2.5-0.0)/(1.0-0.0)=2.5
+  IndexAndDeltaLin(2.5, grid, n, i, t);
+  CHECK(i == 0);
+  CHECK(t == Catch::Approx(2.5).margin(Tol));
+
+  // At x=6.5: scaled=6.5/9, scaledIndex=2.167 -> rawIndex=2
+  //   i=2, t=(6.5-4.0)/(9.0-4.0)=0.5
+  IndexAndDeltaLin(6.5, grid, n, i, t);
+  CHECK(i == 2);
+  CHECK(t == Catch::Approx(0.5).margin(Tol));
+
+  // At x=1.0: scaled=1/9, scaledIndex=0.333 -> rawIndex=0
+  //   i=0, t=(1.0-0.0)/(1.0-0.0)=1.0
+  IndexAndDeltaLin(1.0, grid, n, i, t);
+  CHECK(i == 0);
+  CHECK(t == Catch::Approx(1.0).margin(Tol));
+
+  // At x=4.0: scaled=4/9, scaledIndex=1.333 -> rawIndex=1
+  //   i=1, t=(4.0-1.0)/(4.0-1.0)=1.0
+  IndexAndDeltaLin(4.0, grid, n, i, t);
+  CHECK(i == 1);
+  CHECK(t == Catch::Approx(1.0).margin(Tol));
+
+  // At x=9.0: scaled=1.0, scaledIndex=3.0 -> rawIndex=3, clamped to 2
+  //   i=2, t=(9.0-4.0)/(9.0-4.0)=1.0
+  IndexAndDeltaLin(9.0, grid, n, i, t);
+  CHECK(i == 2);
+  CHECK(t == Catch::Approx(1.0).margin(Tol));
+}

--- a/test/test_log_interpolate_basis.cpp
+++ b/test/test_log_interpolate_basis.cpp
@@ -12,6 +12,139 @@ constexpr double Tol = 1.0e-12;
 } // namespace
 
 // =============================================================================
+// Value Basis Function Tests (InterpBasis.hpp)
+// =============================================================================
+
+TEST_CASE("Linear interpolates between two values", "[basis][value][1d]")
+{
+  using namespace WeakLibReader;
+
+  const double p0 = 2.0, p1 = 8.0;
+
+  // At endpoints
+  CHECK(Linear(p0, p1, 0.0) == Catch::Approx(p0).margin(Tol));
+  CHECK(Linear(p0, p1, 1.0) == Catch::Approx(p1).margin(Tol));
+
+  // At midpoint
+  CHECK(Linear(p0, p1, 0.5) == Catch::Approx((p0 + p1) / 2.0).margin(Tol));
+
+  // At known point: Linear(2.0, 8.0, 0.25) = 0.75*2 + 0.25*8 = 3.5
+  CHECK(Linear(2.0, 8.0, 0.25) == Catch::Approx(3.5).margin(Tol));
+}
+
+TEST_CASE("BiLinear interpolates on 2D cell", "[basis][value][2d]")
+{
+  using namespace WeakLibReader;
+
+  const double p00 = 1.0, p10 = 3.0, p01 = 5.0, p11 = 7.0;
+
+  // At all 4 corners
+  CHECK(BiLinear(p00, p10, p01, p11, 0.0, 0.0) == Catch::Approx(p00).margin(Tol));
+  CHECK(BiLinear(p00, p10, p01, p11, 1.0, 0.0) == Catch::Approx(p10).margin(Tol));
+  CHECK(BiLinear(p00, p10, p01, p11, 0.0, 1.0) == Catch::Approx(p01).margin(Tol));
+  CHECK(BiLinear(p00, p10, p01, p11, 1.0, 1.0) == Catch::Approx(p11).margin(Tol));
+
+  // At center (0.5, 0.5): average of 4 corners
+  const double avg = (p00 + p10 + p01 + p11) / 4.0;
+  CHECK(BiLinear(p00, p10, p01, p11, 0.5, 0.5) == Catch::Approx(avg).margin(Tol));
+
+  // Hand-computed: (1-dX1)(1-dX2)*p00 + dX1*(1-dX2)*p10 + (1-dX1)*dX2*p01 + dX1*dX2*p11
+  const double dX1 = 0.3, dX2 = 0.7;
+  const double expected = (1.0 - dX1) * (1.0 - dX2) * p00 +
+                          dX1 * (1.0 - dX2) * p10 +
+                          (1.0 - dX1) * dX2 * p01 +
+                          dX1 * dX2 * p11;
+  CHECK(BiLinear(p00, p10, p01, p11, dX1, dX2) == Catch::Approx(expected).margin(Tol));
+}
+
+TEST_CASE("TriLinear interpolates on 3D cell", "[basis][value][3d]")
+{
+  using namespace WeakLibReader;
+
+  const double p000 = 1.0, p100 = 2.0, p010 = 1.5, p110 = 3.0;
+  const double p001 = 2.5, p101 = 3.5, p011 = 2.0, p111 = 4.0;
+
+  // At all 8 corners
+  CHECK(TriLinear(p000, p100, p010, p110, p001, p101, p011, p111,
+                  0.0, 0.0, 0.0) == Catch::Approx(p000).margin(Tol));
+  CHECK(TriLinear(p000, p100, p010, p110, p001, p101, p011, p111,
+                  1.0, 0.0, 0.0) == Catch::Approx(p100).margin(Tol));
+  CHECK(TriLinear(p000, p100, p010, p110, p001, p101, p011, p111,
+                  0.0, 1.0, 0.0) == Catch::Approx(p010).margin(Tol));
+  CHECK(TriLinear(p000, p100, p010, p110, p001, p101, p011, p111,
+                  1.0, 1.0, 0.0) == Catch::Approx(p110).margin(Tol));
+  CHECK(TriLinear(p000, p100, p010, p110, p001, p101, p011, p111,
+                  0.0, 0.0, 1.0) == Catch::Approx(p001).margin(Tol));
+  CHECK(TriLinear(p000, p100, p010, p110, p001, p101, p011, p111,
+                  1.0, 0.0, 1.0) == Catch::Approx(p101).margin(Tol));
+  CHECK(TriLinear(p000, p100, p010, p110, p001, p101, p011, p111,
+                  0.0, 1.0, 1.0) == Catch::Approx(p011).margin(Tol));
+  CHECK(TriLinear(p000, p100, p010, p110, p001, p101, p011, p111,
+                  1.0, 1.0, 1.0) == Catch::Approx(p111).margin(Tol));
+
+  // At center (0.5, 0.5, 0.5): average of all 8 corners
+  const double avg = (p000 + p100 + p010 + p110 + p001 + p101 + p011 + p111) / 8.0;
+  CHECK(TriLinear(p000, p100, p010, p110, p001, p101, p011, p111,
+                  0.5, 0.5, 0.5) == Catch::Approx(avg).margin(Tol));
+
+  // Dimensional reduction: TriLinear(..., dX1, dX2, 0.0) == BiLinear(p000, p100, p010, p110, dX1, dX2)
+  for (double dX1 : {0.2, 0.5, 0.8}) {
+    for (double dX2 : {0.2, 0.5, 0.8}) {
+      const double tri = TriLinear(p000, p100, p010, p110, p001, p101, p011, p111,
+                                   dX1, dX2, 0.0);
+      const double bi = BiLinear(p000, p100, p010, p110, dX1, dX2);
+      CHECK(tri == Catch::Approx(bi).margin(Tol));
+    }
+  }
+}
+
+TEST_CASE("TetraLinear interpolates on 4D cell", "[basis][value][4d]")
+{
+  using namespace WeakLibReader;
+
+  // 16 corner values for 4D hypercube
+  const double p0000 = 1.0, p1000 = 2.0, p0100 = 1.5, p1100 = 3.0;
+  const double p0010 = 2.5, p1010 = 3.5, p0110 = 2.0, p1110 = 4.0;
+  const double p0001 = 1.2, p1001 = 2.2, p0101 = 1.7, p1101 = 3.2;
+  const double p0011 = 2.7, p1011 = 3.7, p0111 = 2.2, p1111 = 4.2;
+
+  // Store corners in array indexed by binary encoding: bit0=X1, bit1=X2, bit2=X3, bit3=X4
+  const double corners[16] = {
+      p0000, p1000, p0100, p1100, p0010, p1010, p0110, p1110,
+      p0001, p1001, p0101, p1101, p0011, p1011, p0111, p1111};
+
+  // At all 16 corners: dX values are 0 or 1 from binary encoding
+  for (int c = 0; c < 16; ++c) {
+    const double dX1 = (c & 1) ? 1.0 : 0.0;
+    const double dX2 = (c & 2) ? 1.0 : 0.0;
+    const double dX3 = (c & 4) ? 1.0 : 0.0;
+    const double dX4 = (c & 8) ? 1.0 : 0.0;
+    CHECK(TetraLinear(p0000, p1000, p0100, p1100,
+                      p0010, p1010, p0110, p1110,
+                      p0001, p1001, p0101, p1101,
+                      p0011, p1011, p0111, p1111,
+                      dX1, dX2, dX3, dX4) == Catch::Approx(corners[c]).margin(Tol));
+  }
+
+  // Dimensional reduction: TetraLinear(..., dX1, dX2, dX3, 0.0) == TriLinear(lo-face, dX1, dX2, dX3)
+  for (double dX1 : {0.2, 0.5, 0.8}) {
+    for (double dX2 : {0.3, 0.7}) {
+      for (double dX3 : {0.4, 0.6}) {
+        const double tetra = TetraLinear(p0000, p1000, p0100, p1100,
+                                         p0010, p1010, p0110, p1110,
+                                         p0001, p1001, p0101, p1101,
+                                         p0011, p1011, p0111, p1111,
+                                         dX1, dX2, dX3, 0.0);
+        const double tri = TriLinear(p0000, p1000, p0100, p1100,
+                                     p0010, p1010, p0110, p1110,
+                                     dX1, dX2, dX3);
+        CHECK(tetra == Catch::Approx(tri).margin(Tol));
+      }
+    }
+  }
+}
+
+// =============================================================================
 // Derivative Basis Function Tests (InterpBasis.hpp)
 // =============================================================================
 

--- a/test/test_log_interpolate_sweep.cpp
+++ b/test/test_log_interpolate_sweep.cpp
@@ -5,6 +5,7 @@
 #include "interp/WeakLibReader_InterpLogTable.hpp"
 #include "base/WeakLibReader_Layout.hpp"
 #include "base/WeakLibReader_AxisTypes.hpp"
+#include "base/WeakLibReader_Math.hpp"
 
 #include <array>
 #include <cmath>
@@ -330,6 +331,93 @@ TEST_CASE("Batch aligned 2D2D matches point version", "[loginterp][2d2d][aligned
 
     for (std::size_t i = 0; i < planeSize; ++i) {
       CHECK(outBatch[k * planeSize + i] == Catch::Approx(outPoint[i]).margin(Tol));
+    }
+  }
+}
+
+TEST_CASE("PreAlignScatteringKernelMoment interpolates correctly", "[loginterp][prealign]")
+{
+  using namespace WeakLibReader;
+
+  // --- Setup: small 5D kernel [nE, nE, nMom, nDim3, nDim4] ---
+  constexpr int nE_raw = 3;
+  constexpr int nMom = 2;
+  constexpr int nDim3 = 2;
+  constexpr int nDim4 = 2;
+  constexpr double offset = 1.0;
+  constexpr std::size_t rawTotal = nE_raw * nE_raw * nMom * nDim3 * nDim4; // 72
+
+  // Raw energy grid (Log10 scale)
+  const std::array<double, nE_raw> gridE{1.0, 10.0, 100.0};
+
+  // 5D kernel layout
+  const int rawExtents[5] = {nE_raw, nE_raw, nMom, nDim3, nDim4};
+  const Layout rawLayout = MakeLayout(rawExtents, 5);
+
+  // Fill with known analytic function:
+  //   value(E_in, E_out, iMom, iD3, iD4) =
+  //       1.0 + 0.1*E_in + 0.2*E_out + 0.5*(iMom+1) + 0.3*(iD3+1) + 0.4*(iD4+1)
+  // Store as log10(value + offset)
+  std::array<double, rawTotal> rawKernel{};
+  for (int iD4 = 0; iD4 < nDim4; ++iD4) {
+    for (int iD3 = 0; iD3 < nDim3; ++iD3) {
+      for (int iMom = 0; iMom < nMom; ++iMom) {
+        for (int iE2 = 0; iE2 < nE_raw; ++iE2) {
+          for (int iE1 = 0; iE1 < nE_raw; ++iE1) {
+            const double value = 1.0 + 0.1 * gridE[iE1] + 0.2 * gridE[iE2] +
+                                 0.5 * static_cast<double>(iMom + 1) +
+                                 0.3 * static_cast<double>(iD3 + 1) +
+                                 0.4 * static_cast<double>(iD4 + 1);
+            rawKernel[rawLayout.Offset(iE1, iE2, iMom, iD3, iD4)] =
+                std::log10(value + offset);
+          }
+        }
+      }
+    }
+  }
+
+  // Aligned energy grid (within raw range [1, 100])
+  constexpr int nAligned = 4;
+  const std::array<double, nAligned> alignedE{2.0, 5.0, 20.0, 50.0};
+
+  // Energy axis
+  const Axis energyAxis = MakeAxis(gridE.data(), nE_raw, AxisScale::Log10);
+  const Axis energyAxes[2] = {energyAxis, energyAxis};
+
+  // Output layout: [nAligned, nAligned, nDim3, nDim4]
+  const int outExtents[4] = {nAligned, nAligned, nDim3, nDim4};
+  const Layout outLayout = MakeLayout(outExtents, 4);
+  constexpr std::size_t outSize = nAligned * nAligned * nDim3 * nDim4; // 64
+
+  // --- Test each moment ---
+  for (int iMom = 0; iMom < nMom; ++iMom) {
+    std::array<double, outSize> output{};
+
+    PreAlignScatteringKernelMoment(
+        rawKernel.data(), rawLayout, energyAxis,
+        iMom, nDim3, nDim4,
+        alignedE.data(), nAligned,
+        offset, output.data());
+
+    // Verify against manual 2D interpolation calls
+    for (int iD4 = 0; iD4 < nDim4; ++iD4) {
+      for (int iD3 = 0; iD3 < nDim3; ++iD3) {
+        // Get pointer to contiguous 2D energy slice [nE, nE] at (iMom, iD3, iD4)
+        const int sliceIdx[5] = {0, 0, iMom, iD3, iD4};
+        const double* slice2d = rawKernel.data() + rawLayout.Offset(sliceIdx);
+
+        for (int iA2 = 0; iA2 < nAligned; ++iA2) {
+          for (int iA1 = 0; iA1 < nAligned; ++iA1) {
+            const double manual = LogInterpolateSingleVariable2DCustomPoint(
+                alignedE[iA1], alignedE[iA2],
+                energyAxes, slice2d, offset);
+            const double expected = math::Log10(manual + offset);
+
+            CHECK(output[outLayout.Offset(iA1, iA2, iD3, iD4)] ==
+                  Catch::Approx(expected).margin(Tol));
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add ~30 new test cases closing the six highest-value coverage gaps identified in the test coverage analysis
- Cover EOS pressure/entropy inversion (round-trip with no-guess, good-guess, bad-guess), `ExtractIsoMomentSlice4D`, `PreAlignScatteringKernelMoment`, `IndexAndDeltaLin`/`IndexAndDeltaLog10`/`ClampIndex`, and `Linear`/`BiLinear`/`TriLinear`/`TetraLinear` value basis functions
- Total test count rises from ~92 to 104, all passing

## Test plan

- [x] `scripts/check.sh` passes (build + all 104 tests)
- [x] `VERBOSE=1` run confirms all new tests appear and pass
- [x] Manual review of test correctness for each phase