### PR TITLE
test: deduplicate HDF5 helper functions and test file builders

### DIFF
--- a/test/include/catch2/catch_test_macros.hpp
+++ b/test/include/catch2/catch_test_macros.hpp
@@ -181,7 +181,7 @@ inline int run_all()
     std::cout << "All tests passed" << std::endl;
   }
 
-  return failures == 0 ? 0 : failures;
+  return failures;
 }
 
 } // namespace simple_catch

--- a/test/include/test_hdf5_helpers.hpp
+++ b/test/include/test_hdf5_helpers.hpp
@@ -86,12 +86,14 @@ inline void WriteStringArrayDataset(hid_t parent,
   H5Tclose(type);
 }
 
-inline void WriteDoubleArray2dDataset(hid_t parent,
-                                       const std::string& name,
-                                       const std::array<hsize_t, 2>& dims,
-                                       const std::vector<double>& values)
+// Write an N-dimensional double dataset. Replaces WriteDoubleArray{2,3,4,5}dDataset.
+template <std::size_t N>
+void WriteDoubleNdDataset(hid_t parent,
+                          const std::string& name,
+                          const std::array<hsize_t, N>& dims,
+                          const std::vector<double>& values)
 {
-  hid_t space = H5Screate_simple(2, dims.data(), nullptr);
+  hid_t space = H5Screate_simple(static_cast<int>(N), dims.data(), nullptr);
   hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_IEEE_F64LE, space,
                             H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   REQUIRE(dataset >= 0);
@@ -100,26 +102,14 @@ inline void WriteDoubleArray2dDataset(hid_t parent,
   H5Sclose(space);
 }
 
-inline void WriteDoubleArray3dDataset(hid_t parent,
-                                       const std::string& name,
-                                       const std::array<hsize_t, 3>& dims,
-                                       const std::vector<double>& values)
+// Write an N-dimensional int dataset. Replaces WriteIntArray3dDataset.
+template <std::size_t N>
+void WriteIntNdDataset(hid_t parent,
+                       const std::string& name,
+                       const std::array<hsize_t, N>& dims,
+                       const std::vector<int>& values)
 {
-  hid_t space = H5Screate_simple(3, dims.data(), nullptr);
-  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_IEEE_F64LE, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
-  H5Dclose(dataset);
-  H5Sclose(space);
-}
-
-inline void WriteIntArray3dDataset(hid_t parent,
-                                    const std::string& name,
-                                    const std::array<hsize_t, 3>& dims,
-                                    const std::vector<int>& values)
-{
-  hid_t space = H5Screate_simple(3, dims.data(), nullptr);
+  hid_t space = H5Screate_simple(static_cast<int>(N), dims.data(), nullptr);
   hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_NATIVE_INT, space,
                             H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   REQUIRE(dataset >= 0);
@@ -128,34 +118,33 @@ inline void WriteIntArray3dDataset(hid_t parent,
   H5Sclose(space);
 }
 
-inline void WriteDoubleArray4dDataset(hid_t parent,
-                                       const std::string& name,
+// Backward-compatible aliases for existing callers
+inline void WriteDoubleArray2dDataset(hid_t parent, const std::string& name,
+                                       const std::array<hsize_t, 2>& dims,
+                                       const std::vector<double>& values)
+{ WriteDoubleNdDataset<2>(parent, name, dims, values); }
+
+inline void WriteDoubleArray3dDataset(hid_t parent, const std::string& name,
+                                       const std::array<hsize_t, 3>& dims,
+                                       const std::vector<double>& values)
+{ WriteDoubleNdDataset<3>(parent, name, dims, values); }
+
+inline void WriteIntArray3dDataset(hid_t parent, const std::string& name,
+                                    const std::array<hsize_t, 3>& dims,
+                                    const std::vector<int>& values)
+{ WriteIntNdDataset<3>(parent, name, dims, values); }
+
+inline void WriteDoubleArray4dDataset(hid_t parent, const std::string& name,
                                        const std::array<hsize_t, 4>& dims,
                                        const std::vector<double>& values)
-{
-  hid_t space = H5Screate_simple(4, dims.data(), nullptr);
-  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_IEEE_F64LE, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
-  H5Dclose(dataset);
-  H5Sclose(space);
-}
+{ WriteDoubleNdDataset<4>(parent, name, dims, values); }
 
-inline void WriteDoubleArray5dDataset(hid_t parent,
-                                       const std::string& name,
+inline void WriteDoubleArray5dDataset(hid_t parent, const std::string& name,
                                        const std::array<hsize_t, 5>& dims,
                                        const std::vector<double>& values)
-{
-  hid_t space = H5Screate_simple(5, dims.data(), nullptr);
-  hid_t dataset = H5Dcreate(parent, name.c_str(), H5T_IEEE_F64LE, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-  H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values.data());
-  H5Dclose(dataset);
-  H5Sclose(space);
-}
+{ WriteDoubleNdDataset<5>(parent, name, dims, values); }
 
+// Create an axis dataset with a scale attribute (used by test_hdf5_loader.cpp)
 inline void CreateAxisDataset(hid_t file,
                                const std::string& name,
                                const std::vector<double>& values,
@@ -171,6 +160,7 @@ inline void CreateAxisDataset(hid_t file,
   H5Sclose(space);
 }
 
+// Create a raw axis dataset without a scale attribute (used by test_weaklib_eos_loader.cpp)
 inline void CreateAxisDataset(hid_t parent, const char* name, const double* values, std::size_t count)
 {
   const hsize_t dims = static_cast<hsize_t>(count);

--- a/test/test_log_interpolate_2d.cpp
+++ b/test/test_log_interpolate_2d.cpp
@@ -8,7 +8,6 @@
 
 #include <array>
 #include <cmath>
-#include <limits>
 
 namespace {
 
@@ -27,9 +26,6 @@ TEST_CASE("2D log interpolation matches bilinear expectation", "[loginterp][2d]"
       std::log10(3.0),
       std::log10(4.0),
       std::log10(5.0)};
-
-  const int extents[2] = {2, 2};
-  const Layout layout = MakeLayout(extents, 2);
 
   Axis axes[2] = {
       MakeAxis(gridX.data(), 2, AxisScale::Linear),

--- a/test/test_log_interpolate_3d.cpp
+++ b/test/test_log_interpolate_3d.cpp
@@ -7,7 +7,6 @@
 
 #include <array>
 #include <cmath>
-#include <limits>
 
 namespace {
 

--- a/test/test_log_interpolate_4d5d.cpp
+++ b/test/test_log_interpolate_4d5d.cpp
@@ -9,7 +9,6 @@
 
 #include <array>
 #include <cmath>
-#include <limits>
 
 namespace {
 

--- a/test/test_log_interpolate_deriv.cpp
+++ b/test/test_log_interpolate_deriv.cpp
@@ -8,7 +8,6 @@
 
 #include <array>
 #include <cmath>
-#include <limits>
 
 namespace {
 

--- a/test/test_log_interpolate_sweep.cpp
+++ b/test/test_log_interpolate_sweep.cpp
@@ -9,7 +9,6 @@
 
 #include <array>
 #include <cmath>
-#include <limits>
 
 namespace {
 

--- a/test/test_weaklib_eos_loader.cpp
+++ b/test/test_weaklib_eos_loader.cpp
@@ -8,9 +8,7 @@
 #include <AMReX_GpuContainers.H>
 #include <hdf5.h>
 
-#include <algorithm>
 #include <array>
-#include <cstring>
 #include <filesystem>
 #include <string>
 #include <vector>
@@ -19,19 +17,36 @@ namespace {
 
 using namespace TestHelpers;
 
-constexpr std::size_t RhoCount = 3;
-constexpr std::size_t TempCount = 2;
-constexpr std::size_t YeCount = 2;
-
-const double DensityAxis[RhoCount] = {1.0e3, 1.0e6, 1.0e9};
-const double TemperatureAxis[TempCount] = {0.1, 1.0};
-const double YeAxis[YeCount] = {0.1, 0.3};
-
-void CreateWeakLibEosTestFileFull(const std::filesystem::path& filePath)
+// Write the EOS variable index datasets shared by all test EOS files.
+void WriteEosVariableIndices(hid_t dvGroup)
 {
-  constexpr int nRho = 2;
-  constexpr int nT = 3;
-  constexpr int nYe = 2;
+  WriteIntArrayDataset(dvGroup, "iPressure", {1});
+  WriteIntArrayDataset(dvGroup, "iEntropyPerBaryon", {2});
+  WriteIntArrayDataset(dvGroup, "iInternalEnergyDensity", {1});
+  WriteIntArrayDataset(dvGroup, "iElectronChemicalPotential", {1});
+  WriteIntArrayDataset(dvGroup, "iProtonChemicalPotential", {1});
+  WriteIntArrayDataset(dvGroup, "iNeutronChemicalPotential", {1});
+  WriteIntArrayDataset(dvGroup, "iProtonMassFraction", {1});
+  WriteIntArrayDataset(dvGroup, "iNeutronMassFraction", {1});
+  WriteIntArrayDataset(dvGroup, "iAlphaMassFraction", {1});
+  WriteIntArrayDataset(dvGroup, "iHeavyMassFraction", {1});
+  WriteIntArrayDataset(dvGroup, "iHeavyChargeNumber", {1});
+  WriteIntArrayDataset(dvGroup, "iHeavyMassNumber", {1});
+  WriteIntArrayDataset(dvGroup, "iHeavyBindingEnergy", {1});
+  WriteIntArrayDataset(dvGroup, "iThermalEnergy", {1});
+  WriteIntArrayDataset(dvGroup, "iGamma1", {3});
+}
+
+// Write a complete EOS test file. The fileDimOrder controls whether the
+// dependent variable datasets are written in Fortran order {nYe,nT,nRho}
+// (the correct WeakLib layout) or C order {nRho,nT,nYe} (for rejection tests).
+enum class DimOrder { Fortran, COrder };
+
+void CreateWeakLibEosTestFileImpl(const std::filesystem::path& filePath,
+                                  int nRho, int nT, int nYe,
+                                  const std::vector<double>& yeValues,
+                                  DimOrder order)
+{
   constexpr int nVariables = 3;
 
   hid_t file = H5Fcreate(filePath.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
@@ -49,7 +64,7 @@ void CreateWeakLibEosTestFileFull(const std::filesystem::path& filePath)
 
   WriteDoubleArrayDataset(thermoGroup, "Density", {1.0, 2.0});
   WriteDoubleArrayDataset(thermoGroup, "Temperature", {0.5, 1.0, 2.0});
-  WriteDoubleArrayDataset(thermoGroup, "Electron Fraction", {0.1, 0.2});
+  WriteDoubleArrayDataset(thermoGroup, "Electron Fraction", yeValues);
 
   H5Gclose(thermoGroup);
 
@@ -65,10 +80,16 @@ void CreateWeakLibEosTestFileFull(const std::filesystem::path& filePath)
                           {"dyn/cm^2", "kb/baryon", "dimensionless"});
   WriteDoubleArrayDataset(dvGroup, "Offsets", {0.0, 0.1, 0.2});
 
-  const std::array<hsize_t, 3> fileDims = {
-      static_cast<hsize_t>(nYe),
-      static_cast<hsize_t>(nT),
-      static_cast<hsize_t>(nRho)};
+  std::array<hsize_t, 3> fileDims{};
+  if (order == DimOrder::Fortran) {
+    fileDims = {static_cast<hsize_t>(nYe),
+                static_cast<hsize_t>(nT),
+                static_cast<hsize_t>(nRho)};
+  } else {
+    fileDims = {static_cast<hsize_t>(nRho),
+                static_cast<hsize_t>(nT),
+                static_cast<hsize_t>(nYe)};
+  }
   const std::size_t totalSize = static_cast<std::size_t>(nRho * nT * nYe);
 
   for (int iVar = 0; iVar < nVariables; ++iVar) {
@@ -82,177 +103,21 @@ void CreateWeakLibEosTestFileFull(const std::filesystem::path& filePath)
   std::vector<int> repaired(totalSize, 0);
   WriteIntArray3dDataset(dvGroup, "Repaired", fileDims, repaired);
 
-  WriteIntArrayDataset(dvGroup, "iPressure", {1});
-  WriteIntArrayDataset(dvGroup, "iEntropyPerBaryon", {2});
-  WriteIntArrayDataset(dvGroup, "iInternalEnergyDensity", {1});
-  WriteIntArrayDataset(dvGroup, "iElectronChemicalPotential", {1});
-  WriteIntArrayDataset(dvGroup, "iProtonChemicalPotential", {1});
-  WriteIntArrayDataset(dvGroup, "iNeutronChemicalPotential", {1});
-  WriteIntArrayDataset(dvGroup, "iProtonMassFraction", {1});
-  WriteIntArrayDataset(dvGroup, "iNeutronMassFraction", {1});
-  WriteIntArrayDataset(dvGroup, "iAlphaMassFraction", {1});
-  WriteIntArrayDataset(dvGroup, "iHeavyMassFraction", {1});
-  WriteIntArrayDataset(dvGroup, "iHeavyChargeNumber", {1});
-  WriteIntArrayDataset(dvGroup, "iHeavyMassNumber", {1});
-  WriteIntArrayDataset(dvGroup, "iHeavyBindingEnergy", {1});
-  WriteIntArrayDataset(dvGroup, "iThermalEnergy", {1});
-  WriteIntArrayDataset(dvGroup, "iGamma1", {3});
+  WriteEosVariableIndices(dvGroup);
 
   H5Gclose(dvGroup);
   H5Fclose(file);
+}
+
+void CreateWeakLibEosTestFileFull(const std::filesystem::path& filePath)
+{
+  CreateWeakLibEosTestFileImpl(filePath, 2, 3, 2, {0.1, 0.2}, DimOrder::Fortran);
 }
 
 void CreateWeakLibEosTestFileFullCOrder(const std::filesystem::path& filePath)
 {
-  constexpr int nRho = 2;
-  constexpr int nT = 3;
-  constexpr int nYe = 4;
-  constexpr int nVariables = 3;
-
-  hid_t file = H5Fcreate(filePath.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(file >= 0);
-
-  hid_t thermoGroup = H5Gcreate(file, "ThermoState", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(thermoGroup >= 0);
-
-  WriteIntArrayDataset(thermoGroup, "LogInterp", {1, 1, 0});
-  WriteIntArrayDataset(thermoGroup, "Dimensions", {nRho, nT, nYe});
-  WriteStringArrayDataset(thermoGroup, "Names",
-                          {"Density", "Temperature", "Electron Fraction"});
-  WriteStringArrayDataset(thermoGroup, "Units",
-                          {"g/cm^3", "MeV", "dimensionless"});
-
-  WriteDoubleArrayDataset(thermoGroup, "Density", {1.0, 2.0});
-  WriteDoubleArrayDataset(thermoGroup, "Temperature", {0.5, 1.0, 2.0});
-  WriteDoubleArrayDataset(thermoGroup, "Electron Fraction", {0.1, 0.2, 0.3, 0.4});
-
-  H5Gclose(thermoGroup);
-
-  hid_t dvGroup = H5Gcreate(file, "DependentVariables", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dvGroup >= 0);
-
-  WriteIntArrayDataset(dvGroup, "nVariables", {nVariables});
-
-  const std::vector<std::string> varNames = {
-      "Pressure", "Entropy Per Baryon", "Gamma1"};
-  WriteStringArrayDataset(dvGroup, "Names", varNames);
-  WriteStringArrayDataset(dvGroup, "Units",
-                          {"dyn/cm^2", "kb/baryon", "dimensionless"});
-  WriteDoubleArrayDataset(dvGroup, "Offsets", {0.0, 0.1, 0.2});
-
-  const std::array<hsize_t, 3> fileDims = {
-      static_cast<hsize_t>(nRho),
-      static_cast<hsize_t>(nT),
-      static_cast<hsize_t>(nYe)};
-  const std::size_t totalSize = static_cast<std::size_t>(nRho * nT * nYe);
-
-  for (int iVar = 0; iVar < nVariables; ++iVar) {
-    std::vector<double> data(totalSize);
-    for (std::size_t i = 0; i < totalSize; ++i) {
-      data[i] = static_cast<double>(iVar) + 0.01 * static_cast<double>(i);
-    }
-    WriteDoubleArray3dDataset(dvGroup, varNames[iVar], fileDims, data);
-  }
-
-  std::vector<int> repaired(totalSize, 0);
-  WriteIntArray3dDataset(dvGroup, "Repaired", fileDims, repaired);
-
-  WriteIntArrayDataset(dvGroup, "iPressure", {1});
-  WriteIntArrayDataset(dvGroup, "iEntropyPerBaryon", {2});
-  WriteIntArrayDataset(dvGroup, "iInternalEnergyDensity", {1});
-  WriteIntArrayDataset(dvGroup, "iElectronChemicalPotential", {1});
-  WriteIntArrayDataset(dvGroup, "iProtonChemicalPotential", {1});
-  WriteIntArrayDataset(dvGroup, "iNeutronChemicalPotential", {1});
-  WriteIntArrayDataset(dvGroup, "iProtonMassFraction", {1});
-  WriteIntArrayDataset(dvGroup, "iNeutronMassFraction", {1});
-  WriteIntArrayDataset(dvGroup, "iAlphaMassFraction", {1});
-  WriteIntArrayDataset(dvGroup, "iHeavyMassFraction", {1});
-  WriteIntArrayDataset(dvGroup, "iHeavyChargeNumber", {1});
-  WriteIntArrayDataset(dvGroup, "iHeavyMassNumber", {1});
-  WriteIntArrayDataset(dvGroup, "iHeavyBindingEnergy", {1});
-  WriteIntArrayDataset(dvGroup, "iThermalEnergy", {1});
-  WriteIntArrayDataset(dvGroup, "iGamma1", {3});
-
-  H5Gclose(dvGroup);
-  H5Fclose(file);
+  CreateWeakLibEosTestFileImpl(filePath, 2, 3, 4, {0.1, 0.2, 0.3, 0.4}, DimOrder::COrder);
 }
-
-std::vector<double> MakeDependentValues(double offset)
-{
-  std::vector<double> values;
-  values.reserve(RhoCount * TempCount * YeCount);
-  for (std::size_t ye = 0; ye < YeCount; ++ye) {
-    for (std::size_t temp = 0; temp < TempCount; ++temp) {
-      for (std::size_t rho = 0; rho < RhoCount; ++rho) {
-        values.push_back(offset +
-                         1.0 +
-                         100.0 * static_cast<double>(ye) +
-                         10.0 * static_cast<double>(temp) +
-                         static_cast<double>(rho));
-      }
-    }
-  }
-  return values;
-}
-
-void CreateDependentVariable(hid_t parent, const char* name, const std::vector<double>& values)
-{
-  const hsize_t dims[3] = {
-      static_cast<hsize_t>(YeCount),
-      static_cast<hsize_t>(TempCount),
-      static_cast<hsize_t>(RhoCount)};
-  hid_t space = H5Screate_simple(3, dims, nullptr);
-  REQUIRE(space >= 0);
-
-  hid_t dataset = H5Dcreate(parent, name, H5T_IEEE_F64LE, space,
-                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dataset >= 0);
-  REQUIRE(H5Dwrite(dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL,
-                   H5P_DEFAULT, values.data()) >= 0);
-
-  H5Dclose(dataset);
-  H5Sclose(space);
-}
-
-void CreateWeakLibEosTestFile(const std::filesystem::path& path)
-{
-  hid_t file = H5Fcreate(path.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(file >= 0);
-
-  hid_t thermoGroup = H5Gcreate(file, "ThermoState", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(thermoGroup >= 0);
-
-  const int logInterp[3] = {1, 1, 0};
-  CreateIntDataset(thermoGroup, "LogInterp", logInterp, 3);
-
-  CreateAxisDataset(thermoGroup, "Density", DensityAxis, RhoCount);
-  CreateAxisDataset(thermoGroup, "Temperature", TemperatureAxis, TempCount);
-  CreateAxisDataset(thermoGroup, "Electron Fraction", YeAxis, YeCount);
-
-  H5Gclose(thermoGroup);
-
-  hid_t dependentGroup =
-      H5Gcreate(file, "DependentVariables", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(dependentGroup >= 0);
-
-  const std::vector<double> pressure = MakeDependentValues(0.0);
-  const std::vector<double> entropy = MakeDependentValues(1000.0);
-  CreateDependentVariable(dependentGroup, "Pressure", pressure);
-  CreateDependentVariable(dependentGroup, "Entropy Per Baryon", entropy);
-
-  H5Gclose(dependentGroup);
-  H5Fclose(file);
-}
-
-struct TempWeakLibEosFile {
-  std::filesystem::path path;
-  TempWeakLibEosFile()
-  {
-    path = std::filesystem::temp_directory_path() / "weaklibreader_eos_test.h5";
-    CreateWeakLibEosTestFile(path);
-  }
-  ~TempWeakLibEosFile() { std::filesystem::remove(path); }
-};
 
 } // namespace
 

--- a/test/test_weaklib_opacity_loader.cpp
+++ b/test/test_weaklib_opacity_loader.cpp
@@ -9,10 +9,7 @@
 #include <AMReX_GpuContainers.H>
 #include <hdf5.h>
 
-#include <algorithm>
 #include <array>
-#include <cmath>
-#include <cstring>
 #include <filesystem>
 #include <string>
 #include <vector>
@@ -210,90 +207,65 @@ void CreateWeakLibIsoTestFile(const std::filesystem::path& filePath)
   H5Fclose(file);
 }
 
-void CreateWeakLibNESTestFile(const std::filesystem::path& filePath)
+// Write scattering kernel metadata (nOpacities, nMoments, Units, Offsets) into an HDF5 group.
+void WriteScatKernelMetadata(hid_t group, int nOpacities, int nMoments,
+                             const std::vector<std::string>& units)
 {
-  constexpr int nMoments = 2;
-  constexpr int nOpacities = 1;
-  constexpr double NesBase = 300000.0;
-
-  hid_t file = H5Fcreate(filePath.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(file >= 0);
-
-  WriteOpacityBaseGroups(file, true);
-
-  hid_t group = H5Gcreate(file, "Scat_NES_Kernels", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(group >= 0);
   WriteIntArrayDataset(group, "nOpacities", {nOpacities});
   WriteIntArrayDataset(group, "nMoments", {nMoments});
-  WriteStringArrayDataset(group, "Units", {"1/cm"});
+  WriteStringArrayDataset(group, "Units", units);
 
   const std::array<hsize_t, 2> offsetDims = {
       static_cast<hsize_t>(nMoments),
       static_cast<hsize_t>(nOpacities)};
   std::vector<double> offsets(static_cast<std::size_t>(nMoments) * nOpacities, 0.0);
   WriteDoubleArray2dDataset(group, "Offsets", offsetDims, offsets);
+}
 
-  const std::array<int, 5> kernelDimsC = {
-      TestNE, TestNE, nMoments, TestNT, TestNEta};
-  const std::array<hsize_t, 5> kernelDims = {
-      static_cast<hsize_t>(kernelDimsC[4]),
-      static_cast<hsize_t>(kernelDimsC[3]),
-      static_cast<hsize_t>(kernelDimsC[2]),
-      static_cast<hsize_t>(kernelDimsC[1]),
-      static_cast<hsize_t>(kernelDimsC[0])};
-  const std::vector<double> data =
-      BuildFortranOrdered5dData(kernelDimsC, NesBase);
-  WriteDoubleArray5dDataset(group, "Kernels", kernelDims, data);
+// Write a 5D kernel dataset from C-order dimensions (stored Fortran-reversed in HDF5).
+void WriteKernel5d(hid_t group, const char* name,
+                   const std::array<int, 5>& cDims, double base)
+{
+  const std::array<hsize_t, 5> hdfDims = {
+      static_cast<hsize_t>(cDims[4]),
+      static_cast<hsize_t>(cDims[3]),
+      static_cast<hsize_t>(cDims[2]),
+      static_cast<hsize_t>(cDims[1]),
+      static_cast<hsize_t>(cDims[0])};
+  const std::vector<double> data = BuildFortranOrdered5dData(cDims, base);
+  WriteDoubleArray5dDataset(group, name, hdfDims, data);
+}
+
+// NES and Pair share the same structure: eta grid, 2 moments, 1 opacity, dataset name "Kernels".
+void CreateWeakLibEtaScatTestFile(const std::filesystem::path& filePath,
+                                  const char* groupName, double base)
+{
+  hid_t file = H5Fcreate(filePath.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  REQUIRE(file >= 0);
+
+  WriteOpacityBaseGroups(file, true);
+
+  hid_t group = H5Gcreate(file, groupName, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  REQUIRE(group >= 0);
+  WriteScatKernelMetadata(group, 1, 2, {"1/cm"});
+  WriteKernel5d(group, "Kernels", {TestNE, TestNE, 2, TestNT, TestNEta}, base);
 
   H5Gclose(group);
   H5Fclose(file);
+}
+
+void CreateWeakLibNESTestFile(const std::filesystem::path& filePath)
+{
+  CreateWeakLibEtaScatTestFile(filePath, "Scat_NES_Kernels", 300000.0);
 }
 
 void CreateWeakLibPairTestFile(const std::filesystem::path& filePath)
 {
-  constexpr int nMoments = 2;
-  constexpr int nOpacities = 1;
-  constexpr double PairBase = 400000.0;
-
-  hid_t file = H5Fcreate(filePath.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(file >= 0);
-
-  WriteOpacityBaseGroups(file, true);
-
-  hid_t group = H5Gcreate(file, "Scat_Pair_Kernels", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  REQUIRE(group >= 0);
-  WriteIntArrayDataset(group, "nOpacities", {nOpacities});
-  WriteIntArrayDataset(group, "nMoments", {nMoments});
-  WriteStringArrayDataset(group, "Units", {"1/cm"});
-
-  const std::array<hsize_t, 2> offsetDims = {
-      static_cast<hsize_t>(nMoments),
-      static_cast<hsize_t>(nOpacities)};
-  std::vector<double> offsets(static_cast<std::size_t>(nMoments) * nOpacities, 0.0);
-  WriteDoubleArray2dDataset(group, "Offsets", offsetDims, offsets);
-
-  const std::array<int, 5> kernelDimsC = {
-      TestNE, TestNE, nMoments, TestNT, TestNEta};
-  const std::array<hsize_t, 5> kernelDims = {
-      static_cast<hsize_t>(kernelDimsC[4]),
-      static_cast<hsize_t>(kernelDimsC[3]),
-      static_cast<hsize_t>(kernelDimsC[2]),
-      static_cast<hsize_t>(kernelDimsC[1]),
-      static_cast<hsize_t>(kernelDimsC[0])};
-  const std::vector<double> data =
-      BuildFortranOrdered5dData(kernelDimsC, PairBase);
-  WriteDoubleArray5dDataset(group, "Kernels", kernelDims, data);
-
-  H5Gclose(group);
-  H5Fclose(file);
+  CreateWeakLibEtaScatTestFile(filePath, "Scat_Pair_Kernels", 400000.0);
 }
 
 void CreateWeakLibBremTestFile(const std::filesystem::path& filePath)
 {
-  constexpr int nMoments = 1;
-  constexpr int nOpacities = 1;
-  constexpr double BremBase = 500000.0;
-
   hid_t file = H5Fcreate(filePath.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
   REQUIRE(file >= 0);
 
@@ -301,27 +273,8 @@ void CreateWeakLibBremTestFile(const std::filesystem::path& filePath)
 
   hid_t group = H5Gcreate(file, "Scat_Brem_Kernels", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   REQUIRE(group >= 0);
-  WriteIntArrayDataset(group, "nOpacities", {nOpacities});
-  WriteIntArrayDataset(group, "nMoments", {nMoments});
-  WriteStringArrayDataset(group, "Units", {"1/cm"});
-
-  const std::array<hsize_t, 2> offsetDims = {
-      static_cast<hsize_t>(nMoments),
-      static_cast<hsize_t>(nOpacities)};
-  std::vector<double> offsets(static_cast<std::size_t>(nMoments) * nOpacities, 0.0);
-  WriteDoubleArray2dDataset(group, "Offsets", offsetDims, offsets);
-
-  const std::array<int, 5> kernelDimsC = {
-      TestNE, TestNE, nMoments, TestNRho, TestNT};
-  const std::array<hsize_t, 5> kernelDims = {
-      static_cast<hsize_t>(kernelDimsC[4]),
-      static_cast<hsize_t>(kernelDimsC[3]),
-      static_cast<hsize_t>(kernelDimsC[2]),
-      static_cast<hsize_t>(kernelDimsC[1]),
-      static_cast<hsize_t>(kernelDimsC[0])};
-  const std::vector<double> data =
-      BuildFortranOrdered5dData(kernelDimsC, BremBase);
-  WriteDoubleArray5dDataset(group, "S_sigma", kernelDims, data);
+  WriteScatKernelMetadata(group, 1, 1, {"1/cm"});
+  WriteKernel5d(group, "S_sigma", {TestNE, TestNE, 1, TestNRho, TestNT}, 500000.0);
 
   H5Gclose(group);
   H5Fclose(file);


### PR DESCRIPTION
## Summary
- Consolidate per-dimension `WriteDoubleArray{2..5}dDataset` and `WriteIntArray3dDataset` into generic templates (`WriteDoubleNdDataset`, `WriteIntNdDataset`) with backward-compatible aliases
- Merge duplicate EOS test file creators into a single `CreateWeakLibEosTestFileImpl` with a `DimOrder` parameter, extracting shared `WriteEosVariableIndices`
- Unify NES/Pair scattering test file builders via `CreateWeakLibEtaScatTestFile`; factor out `WriteScatKernelMetadata` and `WriteKernel5d` helpers
- Remove unused includes (`<limits>`, `<algorithm>`, `<cmath>`, `<cstring>`) and dead variables across test files
- Simplify `catch_test_macros.hpp` return expression

## Test plan
- [ ] Verify all existing tests pass with `scripts/check.sh`
- [ ] Confirm no regressions in EOS loader, opacity loader, and interpolation tests