### PR TITLE
cleanup: remove redundant extents field from Hdf5Table

### DIFF
--- a/src/hdf5/WeakLibReader_Hdf5LoaderDetail.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5LoaderDetail.hpp
@@ -532,7 +532,7 @@ inline Hdf5LoadStatus LoadAxes(hid_t file,
     }
 
     const Hdf5LoadStatus axisStatus = ReadAxisDataset1D(
-        axisDataset.Get(), table.extents[dim], scale,
+        axisDataset.Get(), table.layout.n[dim], scale,
         table.axisStorage[dim], table.axes[dim]);
     if (axisStatus != Hdf5LoadStatus::Success) {
       return axisStatus;

--- a/src/hdf5/WeakLibReader_Hdf5LoaderParallel.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5LoaderParallel.hpp
@@ -40,7 +40,7 @@ inline Hdf5LoadStatus LoadHdf5TableParallel(const std::string& filePath,
   if (myRank == root) {
     header[0] = localTable.nd;
     for (int dim = 0; dim < 5; ++dim) {
-      header[1 + dim] = localTable.extents[dim];
+      header[1 + dim] = localTable.layout.n[dim];
     }
   }
   amrex::ParallelDescriptor::Bcast(header, 6, root);
@@ -76,12 +76,11 @@ inline Hdf5LoadStatus LoadHdf5TableParallel(const std::string& filePath,
   if (myRank != root) {
     output = Hdf5Table{};
     output.nd = nd;
-    output.extents = extents;
     if (totalSize == 0) {
       return Hdf5LoadStatus::IncompatibleDatasetExtent;
     }
     output.values.resize(totalSize);
-    output.layout = MakeLayout(output.extents.data(), output.nd);
+    output.layout = MakeLayout(extents.data(), output.nd);
     for (int dim = 0; dim < 5; ++dim) {
       amrex::Vector<double>& storage = output.axisStorage[dim];
       storage.resize(static_cast<std::size_t>(axisCounts[dim]));

--- a/src/hdf5/WeakLibReader_Hdf5LoaderTable.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5LoaderTable.hpp
@@ -44,7 +44,7 @@ inline Hdf5LoadStatus LoadHdf5Table(const std::string& filePath,
     }
     extents[dim] = static_cast<int>(source);
   }
-  result.extents = extents;
+  result.layout = MakeLayout(extents.data(), result.nd);
 
   const std::size_t totalSize = detail::ComputeTotalSize(rank, extents);
   if (totalSize == 0) {
@@ -62,8 +62,6 @@ inline Hdf5LoadStatus LoadHdf5Table(const std::string& filePath,
   if (axisStatus != Hdf5LoadStatus::Success) {
     return axisStatus;
   }
-
-  result.layout = MakeLayout(result.extents.data(), result.nd);
   output = std::move(result);
   return Hdf5LoadStatus::Success;
 }

--- a/src/hdf5/WeakLibReader_Hdf5Types.hpp
+++ b/src/hdf5/WeakLibReader_Hdf5Types.hpp
@@ -63,7 +63,6 @@ struct TableDevice {
 
 struct Hdf5Table {
   int nd = 0;
-  std::array<int, 5> extents{{1, 1, 1, 1, 1}};
   Layout layout{};
   Axis axes[5]{};
   amrex::Gpu::PinnedVector<double> values;

--- a/test/test_hdf5_loader.cpp
+++ b/test/test_hdf5_loader.cpp
@@ -66,10 +66,6 @@ TEST_CASE("HDF5 loader reads table and axes", "[hdf5][loader]")
   REQUIRE(status == Hdf5LoadStatus::Success);
   REQUIRE(table.nd == 3);
 
-  CHECK(table.extents[0] == 2);
-  CHECK(table.extents[1] == 3);
-  CHECK(table.extents[2] == 4);
-
   const Layout& layout = table.layout;
   CHECK(layout.nd == 3);
   CHECK(layout.n[0] == 2);
@@ -104,7 +100,7 @@ TEST_CASE("HDF5 loader reads table and axes", "[hdf5][loader]")
   const double* roundtripPtr = roundtrip.data();
   std::size_t total = 1;
   for (int dim = 0; dim < table.nd; ++dim) {
-    total *= static_cast<std::size_t>(table.extents[dim]);
+    total *= static_cast<std::size_t>(table.layout.n[dim]);
   }
   for (std::size_t i = 0; i < total; ++i) {
     CHECK(roundtripPtr[i] == Catch::Approx(originalPtr[i]).margin(Tol));
@@ -509,13 +505,6 @@ TEST_CASE("HDF5 loader handles 5D tables correctly", "[hdf5][loader][5d]")
 
   REQUIRE(status == Hdf5LoadStatus::Success);
   REQUIRE(table.nd == 5);
-
-  // Verify extents (C-order)
-  CHECK(table.extents[0] == 2);
-  CHECK(table.extents[1] == 3);
-  CHECK(table.extents[2] == 4);
-  CHECK(table.extents[3] == 5);
-  CHECK(table.extents[4] == 6);
 
   // Verify layout
   CHECK(table.layout.nd == 5);


### PR DESCRIPTION
## Summary
- Remove `std::array<int, 5> extents` from `Hdf5Table`, which duplicated `Layout::n[]`
- Move `MakeLayout()` earlier in `LoadHdf5Table()` so `layout.n[]` is available for axis loading
- Replace all `table.extents[dim]` references with `table.layout.n[dim]` in loaders, parallel loader, and tests

## Test plan
- [x] `scripts/check.sh` passes (build + all tests)